### PR TITLE
[WIP] arctic table used as temporal table join.

### DIFF
--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -58,6 +58,7 @@ import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 
 import java.util.Collections;
@@ -163,7 +164,8 @@ public class ArcticCatalog extends AbstractCatalog {
     ArcticTable table = internalCatalog.loadTable(tableIdentifier);
     Schema arcticSchema = table.schema();
 
-    RowType rowType = FlinkSchemaUtil.convert(arcticSchema);
+//    RowType rowType = FlinkSchemaUtil.convert(arcticSchema);
+    RowType rowType = (RowType) TypeUtil.visit(arcticSchema, new TypeToFlinkType());
     Map<String, String> arcticProperties = Maps.newHashMap(table.properties());
     fillTableProperties(arcticProperties);
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/ArcticScanContext.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/ArcticScanContext.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.USING_CUSTOM_WATERMARK_STRATEGY;
 import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
 
 /**
@@ -40,6 +41,7 @@ public class ArcticScanContext extends ScanContext implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private final String scanStartupMode;
+  private final boolean usingCustomWatermarkStrategy;
 
   protected ArcticScanContext(
       boolean caseSensitive,
@@ -56,7 +58,8 @@ public class ArcticScanContext extends ScanContext implements Serializable {
       Schema schema,
       List<Expression> filters,
       long limit,
-      String scanStartupMode) {
+      String scanStartupMode,
+      boolean usingCustomWatermarkStrategy) {
     super(caseSensitive,
         snapshotId,
         startSnapshotId,
@@ -72,6 +75,7 @@ public class ArcticScanContext extends ScanContext implements Serializable {
         filters,
         limit);
     this.scanStartupMode = scanStartupMode;
+    this.usingCustomWatermarkStrategy = usingCustomWatermarkStrategy;
   }
 
   public boolean caseSensitive() {
@@ -138,6 +142,10 @@ public class ArcticScanContext extends ScanContext implements Serializable {
     return scanStartupMode;
   }
 
+  public boolean usingCustomWatermarkStrategy() {
+    return usingCustomWatermarkStrategy;
+  }
+
   public static class Builder {
     private boolean caseSensitive = CASE_SENSITIVE.defaultValue();
     private Long snapshotId = SNAPSHOT_ID.defaultValue();
@@ -154,6 +162,7 @@ public class ArcticScanContext extends ScanContext implements Serializable {
     private List<Expression> filters;
     private long limit = -1L;
     private String scanStartupMode;
+    private boolean usingCustomWatermarkStrategy = USING_CUSTOM_WATERMARK_STRATEGY.defaultValue();
 
     private Builder() {
     }
@@ -233,6 +242,11 @@ public class ArcticScanContext extends ScanContext implements Serializable {
       return this;
     }
 
+    public Builder usingCustomWatermarkStrategy(boolean usingCustomWatermarkStrategy) {
+      this.usingCustomWatermarkStrategy = usingCustomWatermarkStrategy;
+      return this;
+    }
+
     public Builder fromProperties(Map<String, String> properties) {
       Configuration config = new Configuration();
       properties.forEach(config::setString);
@@ -254,7 +268,7 @@ public class ArcticScanContext extends ScanContext implements Serializable {
       return new ArcticScanContext(caseSensitive, snapshotId, startSnapshotId,
           endSnapshotId, asOfTimestamp, splitSize, splitLookback,
           splitOpenFileCost, isStreaming, monitorInterval, nameMapping, projectedSchema,
-          filters, limit, scanStartupMode);
+          filters, limit, scanStartupMode, usingCustomWatermarkStrategy);
     }
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/watermark/IncrementalWatermarkStrategy.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/watermark/IncrementalWatermarkStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.watermark;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.table.data.RowData;
+
+import java.sql.Date;
+
+public class IncrementalWatermarkStrategy implements WatermarkStrategy<RowData> {
+  private static final long serialVersionUID = 141960275254590513L;
+
+  @Override
+  public WatermarkGenerator<RowData> createWatermarkGenerator(
+      WatermarkGeneratorSupplier.Context context) {
+
+    return new ArcticWatermarkGenerator();
+  }
+
+  static class ArcticWatermarkGenerator implements WatermarkGenerator<RowData> {
+    int count = 0;
+    long lowestTimestamp = new Date(0).getTime();
+
+    @Override
+    public void onEvent(RowData event, long eventTimestamp, WatermarkOutput output) {
+      count++;
+      if (count > 20) {
+        return;
+      }
+      output.emitWatermark(new Watermark(lowestTimestamp));
+    }
+
+    @Override
+    public void onPeriodicEmit(WatermarkOutput output) {
+      if (count > 20) {
+        output.emitWatermark(new Watermark(System.currentTimeMillis()));
+      }
+    }
+  }
+
+}

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -105,6 +105,13 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           " the current snapshot, \"latest\": read all incremental data in the change table starting from the" +
           " current snapshot (the current snapshot will be excluded).");
 
+  public static final ConfigOption<Boolean> USING_CUSTOM_WATERMARK_STRATEGY = ConfigOptions
+      .key("source.using.custom.watermark-strategy").booleanType().defaultValue(false)
+      .withDescription("Indicates whether to apply a custom watermark strategy to the source scan." +
+          " Only primary key tables are supported. Default value is false. If true, Arctic source will fetch all data" +
+          " and emit the same lower watermark (1970-01-01 00:00:00 GMT) during in static source reading, then emit" +
+          " the continuous watermark with process time during incremental reading.");
+
   @Override
   public void validate(DescriptorProperties properties) {
     String emitMode = properties.getString(ARCTIC_EMIT_MODE);

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/BoundedDynamicFactory.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/BoundedDynamicFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.table;
+
+import com.netease.arctic.flink.util.NumberSequenceSource;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DataStreamScanProvider;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BoundedDynamicFactory implements DynamicTableSourceFactory {
+  @Override
+  public DynamicTableSource createDynamicTableSource(Context context) {
+    return new BoundedDynamicSource();
+  }
+
+  @Override
+  public String factoryIdentifier() {
+    return "bounded_source";
+  }
+
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    final Set<ConfigOption<?>> options = new HashSet<>();
+    return options;
+  }
+
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    final Set<ConfigOption<?>> options = new HashSet<>();
+    return options;
+  }
+
+  static class BoundedDynamicSource implements ScanTableSource {
+    @Override
+    public ChangelogMode getChangelogMode() {
+      return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+      return new DataStreamScanProvider() {
+        @Override
+        public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
+          return execEnv.fromSource(new NumberSequenceSource(0, 10000), WatermarkStrategy.forGenerator((WatermarkGeneratorSupplier<RowData>) context -> new WatermarkGenerator<RowData>() {
+            @Override
+            public void onEvent(RowData event, long eventTimestamp, WatermarkOutput output) {
+              output.emitWatermark(new Watermark(System.currentTimeMillis()));
+            }
+
+            @Override
+            public void onPeriodicEmit(WatermarkOutput output) {
+              output.emitWatermark(new Watermark(System.currentTimeMillis()));
+            }
+          }), "left table");
+        }
+
+        @Override
+        public boolean isBounded() {
+          return true;
+        }
+      };
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+      return new BoundedDynamicSource();
+    }
+
+    @Override
+    public String asSummaryString() {
+      return "Bounded Source";
+    }
+  }
+
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/LookupJoinTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/LookupJoinTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.table;
+
+import com.netease.arctic.flink.FlinkTestBase;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LookupJoinTest extends FlinkTestBase {
+
+  private static final String DB = PK_TABLE_ID.getDatabase();
+  private static final String TABLE = "test_keyed";
+
+  @Override
+  public void before() {
+    super.before();
+    super.config();
+  }
+
+  @Test
+  public void testLookupJoinWithInit() throws Exception {
+    StreamTableEnvironment tableEnv = null;
+    String arcticTableName = null;
+    try {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      // enable checkpoint
+      env.enableCheckpointing(3000);
+      env.setParallelism(1);
+
+      tableEnv = StreamTableEnvironment.create(env, EnvironmentSettings
+          .newInstance()
+          .inStreamingMode().build());
+
+      tableEnv.executeSql("create table left_view (id bigint, opt timestamp(3), watermark for opt as opt," +
+          " primary key (id) not enforced) with ('connector'='bounded_source')");
+
+      tableEnv.executeSql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
+      Map<String, String> tableProperties = new HashMap<>();
+      tableProperties.put("arctic.read.mode", "file");
+      arcticTableName = String.format("arcticCatalog.%s.%s", DB, TABLE);
+//    tableEnv.executeSql(String.format("drop table %s", arcticTableName));
+      String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
+          " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", arcticTableName, toWithClause(tableProperties));
+      tableEnv.executeSql(sql);
+
+      TableResult tableResult = tableEnv.executeSql(
+          String.format("select u.*, d.* from left_view as u left join %s for system_time as of u.opt as d on u.id = d.id",
+              arcticTableName));
+
+      CloseableIterator<Row> iterator = tableResult.collect();
+      while (iterator.hasNext()) {
+        System.out.println(iterator.next());
+      }
+
+
+      JobClient jobClient = tableResult.getJobClient().get();
+      if (jobClient.getJobStatus().get() != JobStatus.RUNNING) {
+        Thread.currentThread().sleep(100000);
+        jobClient.cancel();
+      }
+    } finally {
+      tableEnv.executeSql("drop table " + arcticTableName);
+    }
+  }
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/NumberSequenceSource.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/NumberSequenceSource.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.util;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceEnumerator;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceSplit;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.util.NumberSequenceIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.netease.arctic.flink.FlinkTestBase.FLINK_ROW_TYPE;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A data source that produces a sequence of numbers (longs). This source is useful for testing and
+ * for cases that just need a stream of N events of any kind.
+ *
+ * <p>The source splits the sequence into as many parallel sub-sequences as there are parallel
+ * source readers. Each sub-sequence will be produced in order. Consequently, if the parallelism is
+ * limited to one, this will produce one sequence in order.
+ *
+ * <p>This source is always bounded. For very long sequences (for example over the entire domain of
+ * long integer values), user may want to consider executing the application in a streaming manner,
+ * because, despite the fact that the produced stream is bounded, the end bound is pretty far away.
+ */
+public class NumberSequenceSource implements
+    Source<
+        RowData,
+        NumberSequenceSource.NumberSequenceSplit,
+        Collection<NumberSequenceSource.NumberSequenceSplit>>,
+    ResultTypeQueryable<RowData> {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * The starting number in the sequence, inclusive.
+   */
+  private final long from;
+
+  /**
+   * The end number in the sequence, inclusive.
+   */
+  private final long to;
+
+  /**
+   * Creates a new {@code NumberSequenceSource} that produces parallel sequences covering the
+   * range {@code from} to {@code to} (both boundaries are inclusive).
+   */
+  public NumberSequenceSource(long from, long to) {
+    checkArgument(from <= to, "'from' must be <= 'to'");
+    this.from = from;
+    this.to = to;
+  }
+
+  public long getFrom() {
+    return from;
+  }
+
+  public long getTo() {
+    return to;
+  }
+
+  // ------------------------------------------------------------------------
+  //  source methods
+  // ------------------------------------------------------------------------
+
+  @Override
+  public TypeInformation<RowData> getProducedType() {
+    return InternalTypeInfo.of(FLINK_ROW_TYPE);
+  }
+
+  @Override
+  public Boundedness getBoundedness() {
+    return Boundedness.BOUNDED;
+  }
+
+  @Override
+  public SourceReader<RowData, NumberSequenceSplit> createReader(SourceReaderContext readerContext) {
+    return new SourceReader<RowData, NumberSequenceSplit>() {
+      AtomicInteger count = new AtomicInteger();
+
+      @Override
+      public void start() {
+
+      }
+
+      @Override
+      public InputStatus pollNext(ReaderOutput<RowData> output) throws Exception {
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, count.getAndIncrement());
+        output.collect(row);
+
+        return InputStatus.MORE_AVAILABLE;
+      }
+
+      @Override
+      public List<NumberSequenceSplit> snapshotState(long checkpointId) {
+        return null;
+      }
+
+      @Override
+      public CompletableFuture<Void> isAvailable() {
+        return null;
+      }
+
+      @Override
+      public void addSplits(List<NumberSequenceSplit> splits) {
+
+      }
+
+      @Override
+      public void notifyNoMoreSplits() {
+
+      }
+
+      @Override
+      public void close() throws Exception {
+
+      }
+    };
+  }
+
+  @Override
+  public SplitEnumerator<NumberSequenceSplit, Collection<NumberSequenceSplit>> createEnumerator(
+      final SplitEnumeratorContext<NumberSequenceSplit> enumContext) {
+
+    final List<NumberSequenceSplit> splits =
+        splitNumberRange(from, to, enumContext.currentParallelism());
+    return new IteratorSourceEnumerator<>(enumContext, splits);
+  }
+
+  @Override
+  public SplitEnumerator<NumberSequenceSplit, Collection<NumberSequenceSplit>> restoreEnumerator(
+      final SplitEnumeratorContext<NumberSequenceSplit> enumContext,
+      Collection<NumberSequenceSplit> checkpoint) {
+    return new IteratorSourceEnumerator<>(enumContext, checkpoint);
+  }
+
+  @Override
+  public SimpleVersionedSerializer<NumberSequenceSplit> getSplitSerializer() {
+    return new SplitSerializer();
+  }
+
+  @Override
+  public SimpleVersionedSerializer<Collection<NumberSequenceSplit>>
+  getEnumeratorCheckpointSerializer() {
+    return new CheckpointSerializer();
+  }
+
+  protected List<NumberSequenceSplit> splitNumberRange(long from, long to, int numSplits) {
+    final NumberSequenceIterator[] subSequences =
+        new NumberSequenceIterator(from, to).split(numSplits);
+    final ArrayList<NumberSequenceSplit> splits = new ArrayList<>(subSequences.length);
+
+    int splitId = 1;
+    for (NumberSequenceIterator seq : subSequences) {
+      if (seq.hasNext()) {
+        splits.add(
+            new NumberSequenceSplit(
+                String.valueOf(splitId++), seq.getCurrent(), seq.getTo()));
+      }
+    }
+
+    return splits;
+  }
+
+  // ------------------------------------------------------------------------
+  //  splits & checkpoint
+  // ------------------------------------------------------------------------
+
+  /**
+   * A split of the source, representing a number sub-sequence.
+   */
+  public static class NumberSequenceSplit
+      implements IteratorSourceSplit<Long, NumberSequenceIterator> {
+
+    private final String splitId;
+    private final long from;
+    private final long to;
+
+    public NumberSequenceSplit(String splitId, long from, long to) {
+      checkArgument(from <= to, "'from' must be <= 'to'");
+      this.splitId = checkNotNull(splitId);
+      this.from = from;
+      this.to = to;
+    }
+
+    @Override
+    public String splitId() {
+      return splitId;
+    }
+
+    public long from() {
+      return from;
+    }
+
+    public long to() {
+      return to;
+    }
+
+    @Override
+    public NumberSequenceIterator getIterator() {
+      return new NumberSequenceIterator(from, to);
+    }
+
+    @Override
+    public IteratorSourceSplit<Long, NumberSequenceIterator> getUpdatedSplitForIterator(
+        final NumberSequenceIterator iterator) {
+      return new NumberSequenceSplit(splitId, iterator.getCurrent(), iterator.getTo());
+    }
+
+    @Override
+    public String toString() {
+      return String.format("NumberSequenceSplit [%d, %d] (%s)", from, to, splitId);
+    }
+  }
+
+  private static final class SplitSerializer
+      implements SimpleVersionedSerializer<NumberSequenceSplit> {
+
+    private static final int CURRENT_VERSION = 1;
+
+    @Override
+    public int getVersion() {
+      return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(NumberSequenceSplit split) throws IOException {
+      checkArgument(
+          split.getClass() == NumberSequenceSplit.class, "cannot serialize subclasses");
+
+      // We will serialize 2 longs (16 bytes) plus the UFT representation of the string (2 +
+      // length)
+      final DataOutputSerializer out =
+          new DataOutputSerializer(split.splitId().length() + 18);
+      serializeV1(out, split);
+      return out.getCopyOfBuffer();
+    }
+
+    @Override
+    public NumberSequenceSplit deserialize(int version, byte[] serialized) throws IOException {
+      if (version != CURRENT_VERSION) {
+        throw new IOException("Unrecognized version: " + version);
+      }
+      final DataInputDeserializer in = new DataInputDeserializer(serialized);
+      return deserializeV1(in);
+    }
+
+    static void serializeV1(DataOutputView out, NumberSequenceSplit split) throws IOException {
+      out.writeUTF(split.splitId());
+      out.writeLong(split.from());
+      out.writeLong(split.to());
+    }
+
+    static NumberSequenceSplit deserializeV1(DataInputView in) throws IOException {
+      return new NumberSequenceSplit(in.readUTF(), in.readLong(), in.readLong());
+    }
+  }
+
+  private static final class CheckpointSerializer
+      implements SimpleVersionedSerializer<Collection<NumberSequenceSplit>> {
+
+    private static final int CURRENT_VERSION = 1;
+
+    @Override
+    public int getVersion() {
+      return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(Collection<NumberSequenceSplit> checkpoint) throws IOException {
+      // Each split needs 2 longs (16 bytes) plus the UFT representation of the string (2 +
+      // length)
+      // Assuming at most 4 digit split IDs, 22 bytes per split avoids any intermediate array
+      // resizing.
+      // plus four bytes for the length field
+      final DataOutputSerializer out = new DataOutputSerializer(checkpoint.size() * 22 + 4);
+      out.writeInt(checkpoint.size());
+      for (NumberSequenceSplit split : checkpoint) {
+        SplitSerializer.serializeV1(out, split);
+      }
+      return out.getCopyOfBuffer();
+    }
+
+    @Override
+    public Collection<NumberSequenceSplit> deserialize(int version, byte[] serialized)
+        throws IOException {
+      if (version != CURRENT_VERSION) {
+        throw new IOException("Unrecognized version: " + version);
+      }
+      final DataInputDeserializer in = new DataInputDeserializer(serialized);
+      final int num = in.readInt();
+      final ArrayList<NumberSequenceSplit> result = new ArrayList<>(num);
+      for (int remaining = num; remaining > 0; remaining--) {
+        result.add(SplitSerializer.deserializeV1(in));
+      }
+      return result;
+    }
+  }
+}

--- a/flink/v1.14/flink/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink/v1.14/flink/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.netease.arctic.flink.table.BoundedDynamicFactory


### PR DESCRIPTION
It is a demo showing how to lookup join with the arctic table by temporal table join.
`SELECT [column_list]
FROM table1 [AS <alias1>]
[LEFT] JOIN table2 FOR SYSTEM_TIME AS OF table1.{ proctime | rowtime } [AS <alias2>]
ON table1.column-name1 = table2.column-name1`

Two pain spots：
1. Left table joined with the arctic table would be missing join when initializing the arctic table.

2. How to emit immediately to the next operator, when the right table(arctic) can't push forward its' watermark. 