### PR TITLE
[prepare for conference]Optimize pd one to one node

### DIFF
--- a/core/src/main/java/com/netease/arctic/iceberg/optimize/DeleteFilter.java
+++ b/core/src/main/java/com/netease/arctic/iceberg/optimize/DeleteFilter.java
@@ -18,9 +18,6 @@
 
 package com.netease.arctic.iceberg.optimize;
 
-import com.netease.arctic.data.DataTreeNode;
-import com.netease.arctic.data.DefaultKeyedFile;
-import com.netease.arctic.scan.ArcticFileScanTask;
 import org.apache.iceberg.Accessor;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;

--- a/core/src/main/java/com/netease/arctic/iceberg/optimize/DeleteFilter.java
+++ b/core/src/main/java/com/netease/arctic/iceberg/optimize/DeleteFilter.java
@@ -18,6 +18,9 @@
 
 package com.netease.arctic.iceberg.optimize;
 
+import com.netease.arctic.data.DataTreeNode;
+import com.netease.arctic.data.DefaultKeyedFile;
+import com.netease.arctic.scan.ArcticFileScanTask;
 import org.apache.iceberg.Accessor;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -77,12 +80,24 @@ public abstract class DeleteFilter<T> {
     this.setFilterThreshold = DEFAULT_SET_FILTER_THRESHOLD;
     this.dataFile = task.file();
 
+    DataTreeNode dataNode = null;
+    if (task instanceof ArcticFileScanTask){
+      dataNode = DefaultKeyedFile.parseMetaFromFileName(task.file().path().toString()).node();
+    }
+
     ImmutableList.Builder<DeleteFile> posDeleteBuilder = ImmutableList.builder();
     ImmutableList.Builder<DeleteFile> eqDeleteBuilder = ImmutableList.builder();
     for (DeleteFile delete : task.deletes()) {
       switch (delete.content()) {
         case POSITION_DELETES:
-          posDeleteBuilder.add(delete);
+          if (task instanceof ArcticFileScanTask){
+            DataTreeNode pdNode = DefaultKeyedFile.parseMetaFromFileName(delete.path().toString()).node();
+            if (dataNode.index() == pdNode.index() && dataNode.mask() == pdNode.mask()) {
+              posDeleteBuilder.add(delete);
+            }
+          } else {
+            posDeleteBuilder.add(delete);
+          }
           break;
         case EQUALITY_DELETES:
           eqDeleteBuilder.add(delete);

--- a/core/src/main/java/com/netease/arctic/iceberg/optimize/DeleteFilter.java
+++ b/core/src/main/java/com/netease/arctic/iceberg/optimize/DeleteFilter.java
@@ -81,7 +81,7 @@ public abstract class DeleteFilter<T> {
     this.dataFile = task.file();
 
     DataTreeNode dataNode = null;
-    if (task instanceof ArcticFileScanTask){
+    if (task instanceof ArcticFileScanTask) {
       dataNode = DefaultKeyedFile.parseMetaFromFileName(task.file().path().toString()).node();
     }
 
@@ -90,7 +90,7 @@ public abstract class DeleteFilter<T> {
     for (DeleteFile delete : task.deletes()) {
       switch (delete.content()) {
         case POSITION_DELETES:
-          if (task instanceof ArcticFileScanTask){
+          if (task instanceof ArcticFileScanTask) {
             DataTreeNode pdNode = DefaultKeyedFile.parseMetaFromFileName(delete.path().toString()).node();
             if (dataNode.index() == pdNode.index() && dataNode.mask() == pdNode.mask()) {
               posDeleteBuilder.add(delete);

--- a/core/src/main/java/com/netease/arctic/iceberg/optimize/DeleteFilter.java
+++ b/core/src/main/java/com/netease/arctic/iceberg/optimize/DeleteFilter.java
@@ -79,25 +79,12 @@ public abstract class DeleteFilter<T> {
   protected DeleteFilter(FileScanTask task, Schema tableSchema, Schema requestedSchema) {
     this.setFilterThreshold = DEFAULT_SET_FILTER_THRESHOLD;
     this.dataFile = task.file();
-
-    DataTreeNode dataNode = null;
-    if (task instanceof ArcticFileScanTask) {
-      dataNode = DefaultKeyedFile.parseMetaFromFileName(task.file().path().toString()).node();
-    }
-
     ImmutableList.Builder<DeleteFile> posDeleteBuilder = ImmutableList.builder();
     ImmutableList.Builder<DeleteFile> eqDeleteBuilder = ImmutableList.builder();
     for (DeleteFile delete : task.deletes()) {
       switch (delete.content()) {
         case POSITION_DELETES:
-          if (task instanceof ArcticFileScanTask) {
-            DataTreeNode pdNode = DefaultKeyedFile.parseMetaFromFileName(delete.path().toString()).node();
-            if (dataNode.index() == pdNode.index() && dataNode.mask() == pdNode.mask()) {
-              posDeleteBuilder.add(delete);
-            }
-          } else {
-            posDeleteBuilder.add(delete);
-          }
+          posDeleteBuilder.add(delete);
           break;
         case EQUALITY_DELETES:
           eqDeleteBuilder.add(delete);

--- a/core/src/main/java/com/netease/arctic/io/reader/ArcticDeleteFilter.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/ArcticDeleteFilter.java
@@ -94,6 +94,9 @@ public abstract class ArcticDeleteFilter<T> {
   private final Accessor<StructLike> filePathAccessor;
   private final Set<String> pathSets;
 
+  private String currentDataPath;
+  private Set<Long> currentPosSet;
+
   protected ArcticDeleteFilter(
       KeyedTableScanTask keyedTableScanTask, Schema tableSchema,
       Schema requestedSchema, PrimaryKeySpec primaryKeySpec) {
@@ -176,6 +179,11 @@ public abstract class ArcticDeleteFilter<T> {
    */
   public CloseableIterable<T> filterNegate(CloseableIterable<T> records) {
     return applyEqDeletes(applyPosDeletes(records), applyEqDeletes());
+  }
+
+  public void setCurrentDataPath(String currentDataPath) {
+    this.currentDataPath = currentDataPath;
+    this.currentPosSet = null;
   }
 
   private ChangedLsn deleteLSN(StructLike structLike) {
@@ -323,7 +331,17 @@ public abstract class ArcticDeleteFilter<T> {
     Filter<T> filter = new Filter<T>() {
       @Override
       protected boolean shouldKeep(T item) {
-        Set<Long> posSet = positionMap.get(filePath(item));
+
+        Set<Long> posSet;
+        if (currentDataPath != null) {
+          if (currentPosSet == null){
+            currentPosSet = positionMap.get(currentDataPath);
+          }
+          posSet = currentPosSet;
+        } else {
+          posSet = positionMap.get(filePath(item));
+        }
+
         if (posSet == null) {
           return true;
         }

--- a/core/src/main/java/com/netease/arctic/io/reader/ArcticDeleteFilter.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/ArcticDeleteFilter.java
@@ -334,7 +334,7 @@ public abstract class ArcticDeleteFilter<T> {
 
         Set<Long> posSet;
         if (currentDataPath != null) {
-          if (currentPosSet == null){
+          if (currentPosSet == null) {
             currentPosSet = positionMap.get(currentDataPath);
           }
           posSet = currentPosSet;

--- a/trino/src/main/java/com/netease/arctic/trino/keyed/KeyedConnectorPageSource.java
+++ b/trino/src/main/java/com/netease/arctic/trino/keyed/KeyedConnectorPageSource.java
@@ -258,7 +258,9 @@ public class KeyedConnectorPageSource implements ConnectorPageSource {
     if (primaryKeyedFile.type() == DataFileType.BASE_FILE) {
       idToConstant.put(MetadataColumns.FILE_OFFSET_FILED_ID, Optional.of(Long.MAX_VALUE + ""));
     }
-    idToConstant.put(FILE_PATH.fieldId(), Optional.of(primaryKeyedFile.path().toString()));
+
+    arcticDeleteFilter.setCurrentDataPath(arcticFileScanTask.file().path().toString());
+
     return icebergPageSourceProvider.createPageSource(
         transaction,
         session,


### PR DESCRIPTION
1. Ensure posDeleteFiles and DataFIles in one Task is the same node.
2. Avoid data record need _filePath columns.