### PR TITLE
[ARCTIC-108][Flink] Support projection push down to arctic source reader

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
@@ -60,7 +61,7 @@ import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_MODE_DE
  * Flink table api that generates source operators.
  */
 public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushDown,
-    SupportsLimitPushDown, SupportsWatermarkPushDown {
+    SupportsProjectionPushDown, SupportsLimitPushDown, SupportsWatermarkPushDown {
 
   public static final Logger LOG = LoggerFactory.getLogger(ArcticDynamicSource.class);
 
@@ -218,6 +219,22 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       return ((SupportsFilterPushDown) arcticDynamicSource).applyFilters(filters);
     } else {
       return Result.of(Collections.emptyList(), filters);
+    }
+  }
+
+  @Override
+  public boolean supportsNestedProjection() {
+    if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
+      return ((SupportsProjectionPushDown) arcticDynamicSource).supportsNestedProjection();
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public void applyProjection(int[][] projectedFields) {
+    if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
+      ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);
     }
   }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/KafkaDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/KafkaDynamicSource.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.table;
 
 import com.netease.arctic.flink.read.FlinkKafkaConsumer;
+import com.netease.arctic.flink.util.Projection;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
@@ -33,7 +34,7 @@ import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
-import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.GenericMapData;
@@ -56,6 +57,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -66,7 +68,7 @@ import java.util.stream.Stream;
  */
 @Internal
 public class KafkaDynamicSource
-    implements ScanTableSource, SupportsReadingMetadata, SupportsWatermarkPushDown {
+    implements ScanTableSource, SupportsReadingMetadata, SupportsProjectionPushDown, SupportsWatermarkPushDown {
 
   // --------------------------------------------------------------------------------------------
   // Mutable attributes
@@ -81,6 +83,11 @@ public class KafkaDynamicSource
    * Metadata that is appended at the end of a physical source row.
    */
   protected List<String> metadataKeys;
+
+  /**
+   * Field index paths of all fields that must be present in the physically produced data.
+   */
+  protected int[] projectedFields;
 
   /**
    * Watermark strategy that is used to generate per-partition watermark.
@@ -199,6 +206,7 @@ public class KafkaDynamicSource
     // Mutable attributes
     this.producedDataType = physicalDataType;
     this.metadataKeys = Collections.emptyList();
+    this.projectedFields = null;
     this.watermarkStrategy = null;
     // Kafka-specific attributes
     Preconditions.checkArgument(
@@ -232,7 +240,9 @@ public class KafkaDynamicSource
         createDeserialization(context, valueDecodingFormat, valueProjection, null);
 
     final TypeInformation<RowData> producedTypeInfo =
-        context.createTypeInformation(producedDataType);
+        context.createTypeInformation(Optional.ofNullable(projectedFields)
+            .map(Projection::of)
+            .map(p -> p.project(producedDataType)).orElse(producedDataType));
 
     final FlinkKafkaConsumer<RowData> kafkaConsumer =
         createKafkaConsumer(keyDeserialization, valueDeserialization, producedTypeInfo);
@@ -295,6 +305,23 @@ public class KafkaDynamicSource
   }
 
   @Override
+  public boolean supportsNestedProjection() {
+    // TODO: support nested projection
+    return false;
+  }
+
+  @Override
+  public void applyProjection(int[][] projectFields) {
+    this.projectedFields = new int[projectFields.length];
+    for (int i = 0; i < projectFields.length; i++) {
+      Preconditions.checkArgument(
+          projectFields[i].length == 1,
+          "Don't support nested projection now.");
+      this.projectedFields[i] = projectFields[i][0];
+    }
+  }
+
+  @Override
   public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
     this.watermarkStrategy = watermarkStrategy;
   }
@@ -352,6 +379,7 @@ public class KafkaDynamicSource
         Objects.equals(specificStartupOffsets, that.specificStartupOffsets) &&
         startupTimestampMillis == that.startupTimestampMillis &&
         Objects.equals(upsertMode, that.upsertMode) &&
+        Arrays.equals(projectedFields, that.projectedFields) &&
         Objects.equals(watermarkStrategy, that.watermarkStrategy);
   }
 
@@ -373,6 +401,7 @@ public class KafkaDynamicSource
         specificStartupOffsets,
         startupTimestampMillis,
         upsertMode,
+        projectedFields,
         watermarkStrategy);
   }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/Projection.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/Projection.java
@@ -1,0 +1,444 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.util;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
+
+/**
+ * {@link Projection} represents a list of (possibly nested) indexes that can be used to project
+ * data types. A row projection includes both reducing the accessible fields and reordering them.
+ *
+ * <p>NOTE: Copied from Flink.
+ */
+public abstract class Projection {
+
+  // sealed class
+  private Projection() {
+  }
+
+  /**
+   * Projects a (possibly nested) row data type by returning a new data type that only includes
+   * fields of the given index paths.
+   *
+   * <p>When extracting nested fields, the name of the resulting fields is the full path of the
+   * field separated by {@code _}. For example, the field {@code b} inside the row field {@code a}
+   * of the root {@link DataType} is named {@code a_b} in the result {@link DataType}. In case of
+   * naming conflicts the postfix notation '_$%d' is used, where {@code %d} is an arbitrary
+   * number, in order to generate a unique field name. For example if the root {@link DataType}
+   * includes both a field {@code a_b} and a nested row {@code a} with field {@code b}, the result
+   * {@link DataType} will contain one field named {@code a_b} and the other named {@code a_b_1}.
+   */
+  public abstract DataType project(DataType dataType);
+
+  /**
+   * Same as {@link #project(DataType)}, but accepting and returning {@link LogicalType}.
+   */
+  public LogicalType project(LogicalType logicalType) {
+    return this.project(TypeConversions.fromLogicalToDataType(logicalType)).getLogicalType();
+  }
+
+  /**
+   * @return {@code true} whether this projection is nested or not.
+   */
+  public abstract boolean isNested();
+
+  /**
+   * Perform a difference of this {@link Projection} with another {@link Projection}. The result
+   * of this operation is a new {@link Projection} retaining the same ordering of this instance
+   * but with the indexes from {@code other} removed. For example:
+   *
+   * <pre>
+   * <code>
+   * [4, 1, 0, 3, 2] - [4, 2] = [1, 0, 2]
+   * </code>
+   * </pre>
+   *
+   * <p>Note how the index {@code 3} in the minuend becomes {@code 2} because it's rescaled to
+   * project correctly a {@link RowData} or arity 3.
+   *
+   * @param other the subtrahend
+   * @throws IllegalArgumentException when {@code other} is nested.
+   */
+  public abstract Projection difference(Projection other);
+
+  /**
+   * Complement this projection. The returned projection is an ordered projection of fields from 0
+   * to {@code fieldsNumber} except the indexes in this {@link Projection}. For example:
+   *
+   * <pre>
+   * <code>
+   * [4, 2].complement(5) = [0, 1, 3]
+   * </code>
+   * </pre>
+   *
+   * @param fieldsNumber the size of the universe
+   * @throws IllegalStateException if this projection is nested.
+   */
+  public abstract Projection complement(int fieldsNumber);
+
+  /**
+   * Like {@link #complement(int)}, using the {@code dataType} fields count.
+   */
+  public Projection complement(DataType dataType) {
+    return complement(dataType.getLogicalType().getChildren().size());
+  }
+
+  /**
+   * Convert this instance to a projection of top level indexes. The array represents the mapping
+   * of the fields of the original {@link DataType}. For example, {@code [0, 2, 1]} specifies to
+   * include in the following order the 1st field, the 3rd field and the 2nd field of the row.
+   *
+   * @throws IllegalStateException if this projection is nested.
+   */
+  public abstract int[] toTopLevelIndexes();
+
+  /**
+   * Convert this instance to a nested projection index paths. The array represents the mapping of
+   * the fields of the original {@link DataType}, including nested rows. For example, {@code [[0,
+   * 2, 1], ...]} specifies to include the 2nd field of the 3rd field of the 1st field in the
+   * top-level row.
+   */
+  public abstract int[][] toNestedIndexes();
+
+  /**
+   * Create an empty {@link Projection}, that is a projection that projects no fields, returning
+   * an empty {@link DataType}.
+   */
+  public static Projection empty() {
+    return EmptyProjection.INSTANCE;
+  }
+
+  /**
+   * Create a {@link Projection} of the provided {@code indexes}.
+   *
+   * @see #toTopLevelIndexes()
+   */
+  public static Projection of(int[] indexes) {
+    if (indexes.length == 0) {
+      return empty();
+    }
+    return new TopLevelProjection(indexes);
+  }
+
+  /**
+   * Create a {@link Projection} of the provided {@code indexes}.
+   *
+   * @see #toNestedIndexes()
+   */
+  public static Projection of(int[][] indexes) {
+    if (indexes.length == 0) {
+      return empty();
+    }
+    return new NestedProjection(indexes);
+  }
+
+  /**
+   * Create a {@link Projection} of a field range.
+   */
+  public static Projection range(int startInclusive, int endExclusive) {
+    return new TopLevelProjection(IntStream.range(startInclusive, endExclusive).toArray());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Projection)) {
+      return false;
+    }
+    Projection other = (Projection) o;
+    if (!this.isNested() && !other.isNested()) {
+      return Arrays.equals(this.toTopLevelIndexes(), other.toTopLevelIndexes());
+    }
+    return Arrays.deepEquals(this.toNestedIndexes(), other.toNestedIndexes());
+  }
+
+  @Override
+  public int hashCode() {
+    if (isNested()) {
+      return Arrays.deepHashCode(toNestedIndexes());
+    }
+    return Arrays.hashCode(toTopLevelIndexes());
+  }
+
+  @Override
+  public String toString() {
+    if (isNested()) {
+      return "Nested projection = " + Arrays.deepToString(toNestedIndexes());
+    }
+    return "Top level projection = " + Arrays.toString(toTopLevelIndexes());
+  }
+
+  private static class EmptyProjection extends Projection {
+
+    static final EmptyProjection INSTANCE = new EmptyProjection();
+
+    private EmptyProjection() {
+    }
+
+    @Override
+    public DataType project(DataType dataType) {
+      return new NestedProjection(toNestedIndexes()).project(dataType);
+    }
+
+    @Override
+    public boolean isNested() {
+      return false;
+    }
+
+    @Override
+    public Projection difference(Projection projection) {
+      return this;
+    }
+
+    @Override
+    public Projection complement(int fieldsNumber) {
+      return new TopLevelProjection(IntStream.range(0, fieldsNumber).toArray());
+    }
+
+    @Override
+    public int[] toTopLevelIndexes() {
+      return new int[0];
+    }
+
+    @Override
+    public int[][] toNestedIndexes() {
+      return new int[0][];
+    }
+  }
+
+  private static class NestedProjection extends Projection {
+
+    final int[][] projection;
+    final boolean nested;
+
+    NestedProjection(int[][] projection) {
+      this.projection = projection;
+      this.nested = Arrays.stream(projection).anyMatch(arr -> arr.length > 1);
+    }
+
+    @Override
+    public DataType project(DataType dataType) {
+      final List<RowType.RowField> updatedFields = new ArrayList<>();
+      final List<DataType> updatedChildren = new ArrayList<>();
+      Set<String> nameDomain = new HashSet<>();
+      int duplicateCount = 0;
+      for (int[] indexPath : this.projection) {
+        DataType fieldType = dataType.getChildren().get(indexPath[0]);
+        LogicalType fieldLogicalType = fieldType.getLogicalType();
+        StringBuilder builder =
+            new StringBuilder(
+                ((RowType) dataType.getLogicalType())
+                    .getFieldNames()
+                    .get(indexPath[0]));
+        for (int index = 1; index < indexPath.length; index++) {
+          Preconditions.checkArgument(
+              fieldLogicalType.getTypeRoot() == ROW, "Row data type expected.");
+          RowType rowtype = ((RowType) fieldLogicalType);
+          builder.append("_").append(rowtype.getFieldNames().get(indexPath[index]));
+          fieldLogicalType = rowtype.getFields().get(indexPath[index]).getType();
+          fieldType = fieldType.getChildren().get(indexPath[index]);
+        }
+        String path = builder.toString();
+        while (nameDomain.contains(path)) {
+          path = builder.append("_$").append(duplicateCount++).toString();
+        }
+        updatedFields.add(new RowType.RowField(path, fieldLogicalType));
+        updatedChildren.add(fieldType);
+        nameDomain.add(path);
+      }
+      return new FieldsDataType(
+          new RowType(dataType.getLogicalType().isNullable(), updatedFields),
+          dataType.getConversionClass(),
+          updatedChildren);
+    }
+
+    @Override
+    public boolean isNested() {
+      return nested;
+    }
+
+    @Override
+    public Projection difference(Projection other) {
+      if (other.isNested()) {
+        throw new IllegalArgumentException(
+            "Cannot perform difference between nested projection and nested projection");
+      }
+      if (other instanceof EmptyProjection) {
+        return this;
+      }
+      if (!this.isNested()) {
+        return new TopLevelProjection(toTopLevelIndexes()).difference(other);
+      }
+
+      // Extract the indexes to exclude and sort them
+      int[] indexesToExclude = other.toTopLevelIndexes();
+      indexesToExclude = Arrays.copyOf(indexesToExclude, indexesToExclude.length);
+      Arrays.sort(indexesToExclude);
+
+      List<int[]> resultProjection =
+          Arrays.stream(projection).collect(Collectors.toCollection(ArrayList::new));
+
+      ListIterator<int[]> resultProjectionIterator = resultProjection.listIterator();
+      while (resultProjectionIterator.hasNext()) {
+        int[] indexArr = resultProjectionIterator.next();
+
+        // Let's check if the index is inside the indexesToExclude array
+        int searchResult = Arrays.binarySearch(indexesToExclude, indexArr[0]);
+        if (searchResult >= 0) {
+          // Found, we need to remove it
+          resultProjectionIterator.remove();
+        } else {
+          // Not found, let's compute the offset.
+          // Offset is the index where the projection index should be inserted in the
+          // indexesToExclude array
+          int offset = (-(searchResult) - 1);
+          if (offset != 0) {
+            indexArr[0] = indexArr[0] - offset;
+          }
+        }
+      }
+
+      return new NestedProjection(resultProjection.toArray(new int[0][]));
+    }
+
+    @Override
+    public Projection complement(int fieldsNumber) {
+      if (isNested()) {
+        throw new IllegalStateException("Cannot perform complement of a nested projection");
+      }
+      return new TopLevelProjection(toTopLevelIndexes()).complement(fieldsNumber);
+    }
+
+    @Override
+    public int[] toTopLevelIndexes() {
+      if (isNested()) {
+        throw new IllegalStateException(
+            "Cannot convert a nested projection to a top level projection");
+      }
+      return Arrays.stream(projection).mapToInt(arr -> arr[0]).toArray();
+    }
+
+    @Override
+    public int[][] toNestedIndexes() {
+      return projection;
+    }
+  }
+
+  private static class TopLevelProjection extends Projection {
+
+    final int[] projection;
+
+    TopLevelProjection(int[] projection) {
+      this.projection = projection;
+    }
+
+    @Override
+    public DataType project(DataType dataType) {
+      return new NestedProjection(toNestedIndexes()).project(dataType);
+    }
+
+    @Override
+    public boolean isNested() {
+      return false;
+    }
+
+    @Override
+    public Projection difference(Projection other) {
+      if (other.isNested()) {
+        throw new IllegalArgumentException(
+            "Cannot perform difference between top level projection and nested projection");
+      }
+      if (other instanceof EmptyProjection) {
+        return this;
+      }
+
+      // Extract the indexes to exclude and sort them
+      int[] indexesToExclude = other.toTopLevelIndexes();
+      indexesToExclude = Arrays.copyOf(indexesToExclude, indexesToExclude.length);
+      Arrays.sort(indexesToExclude);
+
+      List<Integer> resultProjection =
+          Arrays.stream(projection)
+              .boxed()
+              .collect(Collectors.toCollection(ArrayList::new));
+
+      ListIterator<Integer> resultProjectionIterator = resultProjection.listIterator();
+      while (resultProjectionIterator.hasNext()) {
+        int index = resultProjectionIterator.next();
+
+        // Let's check if the index is inside the indexesToExclude array
+        int searchResult = Arrays.binarySearch(indexesToExclude, index);
+        if (searchResult >= 0) {
+          // Found, we need to remove it
+          resultProjectionIterator.remove();
+        } else {
+          // Not found, let's compute the offset.
+          // Offset is the index where the projection index should be inserted in the
+          // indexesToExclude array
+          int offset = (-(searchResult) - 1);
+          if (offset != 0) {
+            resultProjectionIterator.set(index - offset);
+          }
+        }
+      }
+
+      return new TopLevelProjection(resultProjection.stream().mapToInt(i -> i).toArray());
+    }
+
+    @Override
+    public Projection complement(int fieldsNumber) {
+      int[] indexesToExclude = Arrays.copyOf(projection, projection.length);
+      Arrays.sort(indexesToExclude);
+
+      return new TopLevelProjection(
+          IntStream.range(0, fieldsNumber)
+              .filter(i -> Arrays.binarySearch(indexesToExclude, i) < 0)
+              .toArray());
+    }
+
+    @Override
+    public int[] toTopLevelIndexes() {
+      return projection;
+    }
+
+    @Override
+    public int[][] toNestedIndexes() {
+      return Arrays.stream(projection).mapToObj(i -> new int[] {i}).toArray(int[][]::new);
+    }
+  }
+}

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/util/ProjectionTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/util/ProjectionTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.util;
+
+import org.apache.flink.table.types.DataType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.BOOLEAN;
+import static org.apache.flink.table.api.DataTypes.DOUBLE;
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProjectionTest {
+
+  @Test
+  void testTopLevelProject() {
+    assertThat(
+        Projection.of(new int[] {2, 1})
+            .project(
+                ROW(
+                    FIELD("f0", BIGINT()),
+                    FIELD("f1", STRING()),
+                    FIELD("f2", INT()))))
+        .isEqualTo(ROW(FIELD("f2", INT()), FIELD("f1", STRING())));
+  }
+
+  @Test
+  void testNestedProject() {
+    final DataType thirdLevelRow =
+        ROW(FIELD("c0", BOOLEAN()), FIELD("c1", DOUBLE()), FIELD("c2", INT()));
+    final DataType secondLevelRow =
+        ROW(FIELD("b0", BOOLEAN()), FIELD("b1", thirdLevelRow), FIELD("b2", INT()));
+    final DataType topLevelRow =
+        ROW(FIELD("a0", INT()), FIELD("a1", secondLevelRow), FIELD("a1_b1_c0", INT()));
+
+    assertThat(Projection.of(new int[][] {{0}, {1, 1, 0}}).project(topLevelRow))
+        .isEqualTo(ROW(FIELD("a0", INT()), FIELD("a1_b1_c0", BOOLEAN())));
+    assertThat(Projection.of(new int[][] {{1, 1}, {0}}).project(topLevelRow))
+        .isEqualTo(ROW(FIELD("a1_b1", thirdLevelRow), FIELD("a0", INT())));
+    assertThat(
+        Projection.of(new int[][] {{1, 1, 2}, {1, 1, 1}, {1, 1, 0}})
+            .project(topLevelRow))
+        .isEqualTo(
+            ROW(
+                FIELD("a1_b1_c2", INT()),
+                FIELD("a1_b1_c1", DOUBLE()),
+                FIELD("a1_b1_c0", BOOLEAN())));
+    assertThat(Projection.of(new int[][] {{1, 1, 0}, {2}}).project(topLevelRow))
+        .isEqualTo(ROW(FIELD("a1_b1_c0", BOOLEAN()), FIELD("a1_b1_c0_$0", INT())));
+  }
+
+  @Test
+  void testIsNested() {
+    assertThat(Projection.of(new int[] {2, 1}).isNested()).isFalse();
+    assertThat(Projection.of(new int[][] {new int[] {1}, new int[] {3}}).isNested()).isFalse();
+    assertThat(
+        Projection.of(new int[][] {new int[] {1}, new int[] {1, 2}, new int[] {3}})
+            .isNested())
+        .isTrue();
+  }
+
+  @Test
+  void testDifference() {
+    assertThat(
+        Projection.of(new int[] {4, 1, 0, 3, 2})
+            .difference(Projection.of(new int[] {4, 2})))
+        .isEqualTo(Projection.of(new int[] {1, 0, 2}));
+
+    assertThat(
+        Projection.of(
+                new int[][] {
+                    new int[] {4},
+                    new int[] {1, 3},
+                    new int[] {0},
+                    new int[] {3, 1},
+                    new int[] {2}
+                })
+            .difference(Projection.of(new int[] {4, 2})))
+        .isEqualTo(
+            Projection.of(
+                new int[][] {new int[] {1, 3}, new int[] {0}, new int[] {2, 1}}));
+
+    assertThatThrownBy(
+        () ->
+            Projection.of(new int[] {1, 2, 3, 4})
+                .difference(
+                    Projection.of(
+                        new int[][] {
+                            new int[] {2}, new int[] {3, 4}
+                        })))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testComplement() {
+    assertThat(Projection.of(new int[] {4, 1, 2}).complement(5))
+        .isEqualTo(Projection.of(new int[] {0, 3}));
+
+    assertThat(
+        Projection.of(new int[][] {new int[] {4}, new int[] {1}, new int[] {2}})
+            .complement(5))
+        .isEqualTo(Projection.of(new int[] {0, 3}));
+
+    assertThatThrownBy(
+        () ->
+            Projection.of(
+                    new int[][] {
+                        new int[] {4}, new int[] {1, 3}, new int[] {2}
+                    })
+                .complement(10))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void testToTopLevelIndexes() {
+    assertThat(Projection.of(new int[] {1, 2, 3, 4}).toTopLevelIndexes())
+        .isEqualTo(new int[] {1, 2, 3, 4});
+
+    assertThat(
+        Projection.of(new int[][] {new int[] {4}, new int[] {1}, new int[] {2}})
+            .toTopLevelIndexes())
+        .isEqualTo(new int[] {4, 1, 2});
+
+    assertThatThrownBy(
+        () ->
+            Projection.of(
+                    new int[][] {
+                        new int[] {4}, new int[] {1, 3}, new int[] {2}
+                    })
+                .toTopLevelIndexes())
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void testToNestedIndexes() {
+    assertThat(Projection.of(new int[] {1, 2, 3, 4}).toNestedIndexes())
+        .isEqualTo(
+            new int[][] {new int[] {1}, new int[] {2}, new int[] {3}, new int[] {4}});
+    assertThat(
+        Projection.of(new int[][] {new int[] {4}, new int[] {1, 3}, new int[] {2}})
+            .toNestedIndexes())
+        .isEqualTo(new int[][] {new int[] {4}, new int[] {1, 3}, new int[] {2}});
+  }
+
+  @Test
+  void testEquals() {
+    assertThat(Projection.of(new int[][] {new int[] {1}, new int[] {2}, new int[] {3}}))
+        .isEqualTo(Projection.of(new int[] {1, 2, 3}));
+  }
+}

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
@@ -60,7 +61,7 @@ import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_MODE_DE
  * Flink table api that generates source operators.
  */
 public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushDown,
-    SupportsLimitPushDown, SupportsWatermarkPushDown {
+    SupportsProjectionPushDown, SupportsLimitPushDown, SupportsWatermarkPushDown {
 
   public static final Logger LOG = LoggerFactory.getLogger(ArcticDynamicSource.class);
 
@@ -218,6 +219,22 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       return ((SupportsFilterPushDown) arcticDynamicSource).applyFilters(filters);
     } else {
       return Result.of(Collections.emptyList(), filters);
+    }
+  }
+
+  @Override
+  public boolean supportsNestedProjection() {
+    if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
+      return ((SupportsProjectionPushDown) arcticDynamicSource).supportsNestedProjection();
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public void applyProjection(int[][] projectedFields) {
+    if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
+      ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);
     }
   }
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/Projection.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/Projection.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.util;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.ROW;
+
+/**
+ * {@link Projection} represents a list of (possibly nested) indexes that can be used to project
+ * data types. A row projection includes both reducing the accessible fields and reordering them.
+ *
+ * <p>NOTE: Copied from Flink.
+ */
+public abstract class Projection {
+
+  // sealed class
+  private Projection() {
+  }
+
+  /**
+   * Projects a (possibly nested) row data type by returning a new data type that only includes
+   * fields of the given index paths.
+   *
+   * <p>When extracting nested fields, the name of the resulting fields is the full path of the
+   * field separated by {@code _}. For example, the field {@code b} inside the row field {@code a}
+   * of the root {@link DataType} is named {@code a_b} in the result {@link DataType}. In case of
+   * naming conflicts the postfix notation '_$%d' is used, where {@code %d} is an arbitrary
+   * number, in order to generate a unique field name. For example if the root {@link DataType}
+   * includes both a field {@code a_b} and a nested row {@code a} with field {@code b}, the result
+   * {@link DataType} will contain one field named {@code a_b} and the other named {@code a_b_1}.
+   */
+  public abstract DataType project(DataType dataType);
+
+  /**
+   * Same as {@link #project(DataType)}, but accepting and returning {@link LogicalType}.
+   */
+  public LogicalType project(LogicalType logicalType) {
+    return this.project(TypeConversions.fromLogicalToDataType(logicalType)).getLogicalType();
+  }
+
+  /**
+   * @return {@code true} whether this projection is nested or not.
+   */
+  public abstract boolean isNested();
+
+  /**
+   * Perform a difference of this {@link Projection} with another {@link Projection}. The result
+   * of this operation is a new {@link Projection} retaining the same ordering of this instance
+   * but with the indexes from {@code other} removed. For example:
+   *
+   * <pre>
+   * <code>
+   * [4, 1, 0, 3, 2] - [4, 2] = [1, 0, 2]
+   * </code>
+   * </pre>
+   *
+   * <p>Note how the index {@code 3} in the minuend becomes {@code 2} because it's rescaled to
+   * project correctly a {@link RowData} or arity 3.
+   *
+   * @param other the subtrahend
+   * @throws IllegalArgumentException when {@code other} is nested.
+   */
+  public abstract Projection difference(Projection other);
+
+  /**
+   * Complement this projection. The returned projection is an ordered projection of fields from 0
+   * to {@code fieldsNumber} except the indexes in this {@link Projection}. For example:
+   *
+   * <pre>
+   * <code>
+   * [4, 2].complement(5) = [0, 1, 3]
+   * </code>
+   * </pre>
+   *
+   * @param fieldsNumber the size of the universe
+   * @throws IllegalStateException if this projection is nested.
+   */
+  public abstract Projection complement(int fieldsNumber);
+
+  /**
+   * Like {@link #complement(int)}, using the {@code dataType} fields count.
+   */
+  public Projection complement(DataType dataType) {
+    return complement(dataType.getLogicalType().getChildren().size());
+  }
+
+  /**
+   * Convert this instance to a projection of top level indexes. The array represents the mapping
+   * of the fields of the original {@link DataType}. For example, {@code [0, 2, 1]} specifies to
+   * include in the following order the 1st field, the 3rd field and the 2nd field of the row.
+   *
+   * @throws IllegalStateException if this projection is nested.
+   */
+  public abstract int[] toTopLevelIndexes();
+
+  /**
+   * Convert this instance to a nested projection index paths. The array represents the mapping of
+   * the fields of the original {@link DataType}, including nested rows. For example, {@code [[0,
+   * 2, 1], ...]} specifies to include the 2nd field of the 3rd field of the 1st field in the
+   * top-level row.
+   */
+  public abstract int[][] toNestedIndexes();
+
+  /**
+   * Create an empty {@link Projection}, that is a projection that projects no fields, returning
+   * an empty {@link DataType}.
+   */
+  public static Projection empty() {
+    return EmptyProjection.INSTANCE;
+  }
+
+  /**
+   * Create a {@link Projection} of the provided {@code indexes}.
+   *
+   * @see #toTopLevelIndexes()
+   */
+  public static Projection of(int[] indexes) {
+    if (indexes.length == 0) {
+      return empty();
+    }
+    return new TopLevelProjection(indexes);
+  }
+
+  /**
+   * Create a {@link Projection} of the provided {@code indexes}.
+   *
+   * @see #toNestedIndexes()
+   */
+  public static Projection of(int[][] indexes) {
+    if (indexes.length == 0) {
+      return empty();
+    }
+    return new NestedProjection(indexes);
+  }
+
+  /**
+   * Create a {@link Projection} of a field range.
+   */
+  public static Projection range(int startInclusive, int endExclusive) {
+    return new TopLevelProjection(IntStream.range(startInclusive, endExclusive).toArray());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Projection)) {
+      return false;
+    }
+    Projection other = (Projection) o;
+    if (!this.isNested() && !other.isNested()) {
+      return Arrays.equals(this.toTopLevelIndexes(), other.toTopLevelIndexes());
+    }
+    return Arrays.deepEquals(this.toNestedIndexes(), other.toNestedIndexes());
+  }
+
+  @Override
+  public int hashCode() {
+    if (isNested()) {
+      return Arrays.deepHashCode(toNestedIndexes());
+    }
+    return Arrays.hashCode(toTopLevelIndexes());
+  }
+
+  @Override
+  public String toString() {
+    if (isNested()) {
+      return "Nested projection = " + Arrays.deepToString(toNestedIndexes());
+    }
+    return "Top level projection = " + Arrays.toString(toTopLevelIndexes());
+  }
+
+  private static class EmptyProjection extends Projection {
+
+    static final EmptyProjection INSTANCE = new EmptyProjection();
+
+    private EmptyProjection() {
+    }
+
+    @Override
+    public DataType project(DataType dataType) {
+      return new NestedProjection(toNestedIndexes()).project(dataType);
+    }
+
+    @Override
+    public boolean isNested() {
+      return false;
+    }
+
+    @Override
+    public Projection difference(Projection projection) {
+      return this;
+    }
+
+    @Override
+    public Projection complement(int fieldsNumber) {
+      return new TopLevelProjection(IntStream.range(0, fieldsNumber).toArray());
+    }
+
+    @Override
+    public int[] toTopLevelIndexes() {
+      return new int[0];
+    }
+
+    @Override
+    public int[][] toNestedIndexes() {
+      return new int[0][];
+    }
+  }
+
+  private static class NestedProjection extends Projection {
+
+    final int[][] projection;
+    final boolean nested;
+
+    NestedProjection(int[][] projection) {
+      this.projection = projection;
+      this.nested = Arrays.stream(projection).anyMatch(arr -> arr.length > 1);
+    }
+
+    @Override
+    public DataType project(DataType dataType) {
+      final List<RowType.RowField> updatedFields = new ArrayList<>();
+      final List<DataType> updatedChildren = new ArrayList<>();
+      Set<String> nameDomain = new HashSet<>();
+      int duplicateCount = 0;
+      for (int[] indexPath : this.projection) {
+        DataType fieldType = dataType.getChildren().get(indexPath[0]);
+        LogicalType fieldLogicalType = fieldType.getLogicalType();
+        StringBuilder builder =
+            new StringBuilder(((RowType) dataType.getLogicalType()).getFieldNames().get(indexPath[0]));
+        for (int index = 1; index < indexPath.length; index++) {
+          Preconditions.checkArgument(fieldLogicalType.getTypeRoot() == ROW, "Row data type expected.");
+          RowType rowtype = ((RowType) fieldLogicalType);
+          builder.append("_").append(rowtype.getFieldNames().get(indexPath[index]));
+          fieldLogicalType = rowtype.getFields().get(indexPath[index]).getType();
+          fieldType = fieldType.getChildren().get(indexPath[index]);
+        }
+        String path = builder.toString();
+        while (nameDomain.contains(path)) {
+          path = builder.append("_$").append(duplicateCount++).toString();
+        }
+        updatedFields.add(new RowType.RowField(path, fieldLogicalType));
+        updatedChildren.add(fieldType);
+        nameDomain.add(path);
+      }
+      return new FieldsDataType(
+          new RowType(dataType.getLogicalType().isNullable(), updatedFields),
+          dataType.getConversionClass(),
+          updatedChildren);
+    }
+
+    @Override
+    public boolean isNested() {
+      return nested;
+    }
+
+    @Override
+    public Projection difference(Projection other) {
+      if (other.isNested()) {
+        throw new IllegalArgumentException("Cannot perform difference between nested projection and nested projection");
+      }
+      if (other instanceof EmptyProjection) {
+        return this;
+      }
+      if (!this.isNested()) {
+        return new TopLevelProjection(toTopLevelIndexes()).difference(other);
+      }
+
+      // Extract the indexes to exclude and sort them
+      int[] indexesToExclude = other.toTopLevelIndexes();
+      indexesToExclude = Arrays.copyOf(indexesToExclude, indexesToExclude.length);
+      Arrays.sort(indexesToExclude);
+
+      List<int[]> resultProjection = Arrays.stream(projection).collect(Collectors.toCollection(ArrayList::new));
+
+      ListIterator<int[]> resultProjectionIterator = resultProjection.listIterator();
+      while (resultProjectionIterator.hasNext()) {
+        int[] indexArr = resultProjectionIterator.next();
+
+        // Let's check if the index is inside the indexesToExclude array
+        int searchResult = Arrays.binarySearch(indexesToExclude, indexArr[0]);
+        if (searchResult >= 0) {
+          // Found, we need to remove it
+          resultProjectionIterator.remove();
+        } else {
+          // Not found, let's compute the offset.
+          // Offset is the index where the projection index should be inserted in the
+          // indexesToExclude array
+          int offset = (-(searchResult) - 1);
+          if (offset != 0) {
+            indexArr[0] = indexArr[0] - offset;
+          }
+        }
+      }
+
+      return new NestedProjection(resultProjection.toArray(new int[0][]));
+    }
+
+    @Override
+    public Projection complement(int fieldsNumber) {
+      if (isNested()) {
+        throw new IllegalStateException("Cannot perform complement of a nested projection");
+      }
+      return new TopLevelProjection(toTopLevelIndexes()).complement(fieldsNumber);
+    }
+
+    @Override
+    public int[] toTopLevelIndexes() {
+      if (isNested()) {
+        throw new IllegalStateException("Cannot convert a nested projection to a top level projection");
+      }
+      return Arrays.stream(projection).mapToInt(arr -> arr[0]).toArray();
+    }
+
+    @Override
+    public int[][] toNestedIndexes() {
+      return projection;
+    }
+  }
+
+  private static class TopLevelProjection extends Projection {
+
+    final int[] projection;
+
+    TopLevelProjection(int[] projection) {
+      this.projection = projection;
+    }
+
+    @Override
+    public DataType project(DataType dataType) {
+      return new NestedProjection(toNestedIndexes()).project(dataType);
+    }
+
+    @Override
+    public boolean isNested() {
+      return false;
+    }
+
+    @Override
+    public Projection difference(Projection other) {
+      if (other.isNested()) {
+        throw new IllegalArgumentException(
+            "Cannot perform difference between top level projection and nested projection");
+      }
+      if (other instanceof EmptyProjection) {
+        return this;
+      }
+
+      // Extract the indexes to exclude and sort them
+      int[] indexesToExclude = other.toTopLevelIndexes();
+      indexesToExclude = Arrays.copyOf(indexesToExclude, indexesToExclude.length);
+      Arrays.sort(indexesToExclude);
+
+      List<Integer> resultProjection =
+          Arrays.stream(projection).boxed().collect(Collectors.toCollection(ArrayList::new));
+
+      ListIterator<Integer> resultProjectionIterator = resultProjection.listIterator();
+      while (resultProjectionIterator.hasNext()) {
+        int index = resultProjectionIterator.next();
+
+        // Let's check if the index is inside the indexesToExclude array
+        int searchResult = Arrays.binarySearch(indexesToExclude, index);
+        if (searchResult >= 0) {
+          // Found, we need to remove it
+          resultProjectionIterator.remove();
+        } else {
+          // Not found, let's compute the offset.
+          // Offset is the index where the projection index should be inserted in the
+          // indexesToExclude array
+          int offset = (-(searchResult) - 1);
+          if (offset != 0) {
+            resultProjectionIterator.set(index - offset);
+          }
+        }
+      }
+
+      return new TopLevelProjection(resultProjection.stream().mapToInt(i -> i).toArray());
+    }
+
+    @Override
+    public Projection complement(int fieldsNumber) {
+      int[] indexesToExclude = Arrays.copyOf(projection, projection.length);
+      Arrays.sort(indexesToExclude);
+
+      return new TopLevelProjection(IntStream.range(0, fieldsNumber)
+          .filter(i -> Arrays.binarySearch(indexesToExclude, i) < 0)
+          .toArray());
+    }
+
+    @Override
+    public int[] toTopLevelIndexes() {
+      return projection;
+    }
+
+    @Override
+    public int[][] toNestedIndexes() {
+      return Arrays.stream(projection).mapToObj(i -> new int[] {i}).toArray(int[][]::new);
+    }
+  }
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/ProjectionTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/ProjectionTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.util;
+
+import org.apache.flink.table.types.DataType;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.BOOLEAN;
+import static org.apache.flink.table.api.DataTypes.DOUBLE;
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProjectionTest {
+
+  @Test
+  void testTopLevelProject() {
+    assertThat(
+        Projection.of(new int[] {2, 1})
+            .project(
+                ROW(
+                    FIELD("f0", BIGINT()),
+                    FIELD("f1", STRING()),
+                    FIELD("f2", INT()))))
+        .isEqualTo(ROW(FIELD("f2", INT()), FIELD("f1", STRING())));
+  }
+
+  @Test
+  void testNestedProject() {
+    final DataType thirdLevelRow =
+        ROW(FIELD("c0", BOOLEAN()), FIELD("c1", DOUBLE()), FIELD("c2", INT()));
+    final DataType secondLevelRow =
+        ROW(FIELD("b0", BOOLEAN()), FIELD("b1", thirdLevelRow), FIELD("b2", INT()));
+    final DataType topLevelRow =
+        ROW(FIELD("a0", INT()), FIELD("a1", secondLevelRow), FIELD("a1_b1_c0", INT()));
+
+    assertThat(Projection.of(new int[][] {{0}, {1, 1, 0}}).project(topLevelRow))
+        .isEqualTo(ROW(FIELD("a0", INT()), FIELD("a1_b1_c0", BOOLEAN())));
+    assertThat(Projection.of(new int[][] {{1, 1}, {0}}).project(topLevelRow))
+        .isEqualTo(ROW(FIELD("a1_b1", thirdLevelRow), FIELD("a0", INT())));
+    assertThat(
+        Projection.of(new int[][] {{1, 1, 2}, {1, 1, 1}, {1, 1, 0}})
+            .project(topLevelRow))
+        .isEqualTo(
+            ROW(
+                FIELD("a1_b1_c2", INT()),
+                FIELD("a1_b1_c1", DOUBLE()),
+                FIELD("a1_b1_c0", BOOLEAN())));
+    assertThat(Projection.of(new int[][] {{1, 1, 0}, {2}}).project(topLevelRow))
+        .isEqualTo(ROW(FIELD("a1_b1_c0", BOOLEAN()), FIELD("a1_b1_c0_$0", INT())));
+  }
+
+  @Test
+  void testIsNested() {
+    assertThat(Projection.of(new int[] {2, 1}).isNested()).isFalse();
+    assertThat(Projection.of(new int[][] {new int[] {1}, new int[] {3}}).isNested()).isFalse();
+    assertThat(
+        Projection.of(new int[][] {new int[] {1}, new int[] {1, 2}, new int[] {3}})
+            .isNested())
+        .isTrue();
+  }
+
+  @Test
+  void testDifference() {
+    assertThat(
+        Projection.of(new int[] {4, 1, 0, 3, 2})
+            .difference(Projection.of(new int[] {4, 2})))
+        .isEqualTo(Projection.of(new int[] {1, 0, 2}));
+
+    assertThat(
+        Projection.of(
+                new int[][] {
+                    new int[] {4},
+                    new int[] {1, 3},
+                    new int[] {0},
+                    new int[] {3, 1},
+                    new int[] {2}
+                })
+            .difference(Projection.of(new int[] {4, 2})))
+        .isEqualTo(
+            Projection.of(
+                new int[][] {new int[] {1, 3}, new int[] {0}, new int[] {2, 1}}));
+
+    assertThatThrownBy(
+        () ->
+            Projection.of(new int[] {1, 2, 3, 4})
+                .difference(
+                    Projection.of(
+                        new int[][] {
+                            new int[] {2}, new int[] {3, 4}
+                        })))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void testComplement() {
+    assertThat(Projection.of(new int[] {4, 1, 2}).complement(5))
+        .isEqualTo(Projection.of(new int[] {0, 3}));
+
+    assertThat(
+        Projection.of(new int[][] {new int[] {4}, new int[] {1}, new int[] {2}})
+            .complement(5))
+        .isEqualTo(Projection.of(new int[] {0, 3}));
+
+    assertThatThrownBy(
+        () ->
+            Projection.of(
+                    new int[][] {
+                        new int[] {4}, new int[] {1, 3}, new int[] {2}
+                    })
+                .complement(10))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void testToTopLevelIndexes() {
+    assertThat(Projection.of(new int[] {1, 2, 3, 4}).toTopLevelIndexes())
+        .isEqualTo(new int[] {1, 2, 3, 4});
+
+    assertThat(
+        Projection.of(new int[][] {new int[] {4}, new int[] {1}, new int[] {2}})
+            .toTopLevelIndexes())
+        .isEqualTo(new int[] {4, 1, 2});
+
+    assertThatThrownBy(
+        () ->
+            Projection.of(
+                    new int[][] {
+                        new int[] {4}, new int[] {1, 3}, new int[] {2}
+                    })
+                .toTopLevelIndexes())
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void testToNestedIndexes() {
+    assertThat(Projection.of(new int[] {1, 2, 3, 4}).toNestedIndexes())
+        .isEqualTo(
+            new int[][] {new int[] {1}, new int[] {2}, new int[] {3}, new int[] {4}});
+    assertThat(
+        Projection.of(new int[][] {new int[] {4}, new int[] {1, 3}, new int[] {2}})
+            .toNestedIndexes())
+        .isEqualTo(new int[][] {new int[] {4}, new int[] {1, 3}, new int[] {2}});
+  }
+
+  @Test
+  void testEquals() {
+    assertThat(Projection.of(new int[][] {new int[] {1}, new int[] {2}, new int[] {3}}))
+        .isEqualTo(Projection.of(new int[] {1, 2, 3}));
+  }
+}


### PR DESCRIPTION
Fix #108.

`ArcticDynamicSource` should implement the `SupportsProjectionPushDown` interface to accelerate data querying.

**The brief change log**
- `ArcticDynamicSource` and `KafkaDynamicSource` implement the `SupportsProjectionPushDown` interface to support `supportsNestedProjection` and `applyProjection` methods.