### PR TITLE
[bugfix] Using Math.abs() make the hashcode positive.

### DIFF
--- a/core/src/main/java/com/netease/arctic/data/PrimaryKeyData.java
+++ b/core/src/main/java/com/netease/arctic/data/PrimaryKeyData.java
@@ -124,7 +124,8 @@ public class PrimaryKeyData implements StructLike, Serializable {
 
   @Override
   public int hashCode() {
-    return Arrays.hashCode(primaryTuple);
+    int hashcode = Math.abs(Arrays.hashCode(primaryTuple));
+    return hashcode == Integer.MIN_VALUE ? Integer.MAX_VALUE : hashcode;
   }
 
   public DataTreeNode treeNode(long mask) {

--- a/core/src/main/java/com/netease/arctic/utils/NodeFilter.java
+++ b/core/src/main/java/com/netease/arctic/utils/NodeFilter.java
@@ -57,6 +57,6 @@ public class NodeFilter<T> extends Filter<T> {
     }
 
     primaryKey.primaryKey(asStructLike.apply(record));
-    return sourceNodes.stream().anyMatch(node -> (Math.abs(primaryKey.hashCode()) & node.mask()) == node.index());
+    return sourceNodes.stream().anyMatch(node -> (primaryKey.hashCode() & node.mask()) == node.index());
   }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -108,7 +108,8 @@ public class ShuffleHelper implements Serializable {
 
   public int hashPartitionValue(RowData rowData) {
     partitionKey.partition(rowDataWrapper.wrap(rowData));
-    return partitionKey.hashCode();
+    int hashcode = Math.abs(partitionKey.hashCode());
+    return hashcode == Integer.MIN_VALUE ? Integer.MAX_VALUE : hashcode;
   }
 
   public int hashKeyValue(RowData rowData) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -114,7 +114,6 @@ public class ShuffleHelper implements Serializable {
 
   public int hashKeyValue(RowData rowData) {
     primaryKeyData.primaryKey(rowDataWrapper.wrap(rowData));
-    int hashcode = Math.abs(primaryKeyData.hashCode());
-    return hashcode == Integer.MIN_VALUE ? Integer.MAX_VALUE : hashcode;
+    return primaryKeyData.hashCode();
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -108,11 +108,13 @@ public class ShuffleHelper implements Serializable {
 
   public int hashPartitionValue(RowData rowData) {
     partitionKey.partition(rowDataWrapper.wrap(rowData));
-    return Math.abs(partitionKey.hashCode());
+    int hashcode = Math.abs(partitionKey.hashCode());
+    return hashcode == Integer.MIN_VALUE ? Integer.MAX_VALUE : hashcode;
   }
 
   public int hashKeyValue(RowData rowData) {
     primaryKeyData.primaryKey(rowDataWrapper.wrap(rowData));
-    return Math.abs(primaryKeyData.hashCode());
+    int hashcode = Math.abs(primaryKeyData.hashCode());
+    return hashcode == Integer.MIN_VALUE ? Integer.MAX_VALUE : hashcode;
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -108,11 +108,11 @@ public class ShuffleHelper implements Serializable {
 
   public int hashPartitionValue(RowData rowData) {
     partitionKey.partition(rowDataWrapper.wrap(rowData));
-    return partitionKey.hashCode();
+    return Math.abs(partitionKey.hashCode());
   }
 
   public int hashKeyValue(RowData rowData) {
     primaryKeyData.primaryKey(rowDataWrapper.wrap(rowData));
-    return primaryKeyData.hashCode();
+    return Math.abs(primaryKeyData.hashCode());
   }
 }


### PR DESCRIPTION
Fixed the log/file shuffle OutOfIndexExp which is caused by the hashcode of the record is not positive.

**the main change log**:
**ShuffleHelper.hashPartitionValue(RowData)** and **ShuffleHelper.hashPartitionValue(RowData)**