### PR TITLE
[ARCTIC-181][Flink] Reduce the number of allocated requests for new transaction IDs

### DIFF
--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -78,12 +78,15 @@ public class ArcticFileWriterTest extends FlinkTestBase {
     try (
         OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = createArcticStreamWriter(
             tableLoader)) {
+      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
+      Assert.assertNotNull(fileWriter.getWriter());
       // The first checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
 
       testHarness.prepareSnapshotPreBarrier(checkpointId);
+      Assert.assertNull(fileWriter.getWriter());
       Assert.assertEquals(1, testHarness.extractOutputValues().size());
       Assert.assertEquals(3, testHarness.extractOutputValues().get(0).dataFiles().length);
 
@@ -91,6 +94,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
       // The second checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-12T10:10:11.0"), 1);
+      Assert.assertNotNull(fileWriter.getWriter());
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-12T10:10:11.0"), 1);
 
@@ -103,7 +107,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
   }
 
   @Test
-  public void testSnapshotTwice() throws Exception {
+  public void testSnapshotMultipleTimes() throws Exception {
     long checkpointId = 1;
     long timestamp = 1;
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -25,6 +25,7 @@ import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.KeyedTable;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -32,6 +33,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
+import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
@@ -141,9 +143,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     table.io().doAs(() -> {
       completeAndEmitFiles();
 
-      // reassign transaction id
-      initTaskWriterFactory(null);
-      this.writer = taskWriterFactory.create();
+      this.writer = null;
       return null;
     });
   }
@@ -159,13 +159,22 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private void completeAndEmitFiles() throws IOException {
     // For bounded stream, it may don't enable the checkpoint mechanism so we'd better to emit the remaining
     // completed files to downstream before closing the writer so that we won't miss any of them.
-    emit(writer.complete());
+    if (writer != null) {
+      emit(writer.complete());
+    }
   }
 
   @Override
   public void processElement(StreamRecord<RowData> element) throws Exception {
     RowData row = element.getValue();
     table.io().doAs(() -> {
+      if (writer == null) {
+        // Reassign transaction id when processing the new file data to avoid the situation that there is no data
+        // written during the next checkpoint period.
+        initTaskWriterFactory(null);
+        this.writer = taskWriterFactory.create();
+      }
+
       if (upsert && RowKind.INSERT.equals(row.getRowKind())) {
         row.setRowKind(RowKind.DELETE);
         writer.write(row);
@@ -191,5 +200,10 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   private void emit(WriteResult writeResult) {
     output.collect(new StreamRecord<>(writeResult));
+  }
+
+  @VisibleForTesting
+  public TaskWriter<RowData> getWriter() {
+    return writer;
   }
 }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -78,12 +78,15 @@ public class ArcticFileWriterTest extends FlinkTestBase {
     try (
         OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = createArcticStreamWriter(
             tableLoader)) {
+      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
+      Assert.assertNotNull(fileWriter.getWriter());
       // The first checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
 
       testHarness.prepareSnapshotPreBarrier(checkpointId);
+      Assert.assertNull(fileWriter.getWriter());
       Assert.assertEquals(1, testHarness.extractOutputValues().size());
       Assert.assertEquals(3, testHarness.extractOutputValues().get(0).dataFiles().length);
 
@@ -91,6 +94,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
       // The second checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-12T10:10:11.0"), 1);
+      Assert.assertNotNull(fileWriter.getWriter());
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-12T10:10:11.0"), 1);
 
@@ -103,7 +107,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
   }
 
   @Test
-  public void testSnapshotTwice() throws Exception {
+  public void testSnapshotMultipleTimes() throws Exception {
     long checkpointId = 1;
     long timestamp = 1;
 


### PR DESCRIPTION
Fix #181.

`ArcticFileWriter` requests a new transaction ID for the next checkpoint period when the snapshot barrier arrives. But there is no data written during the next checkpoint period. `ArcticFileWriter` should be optimized that only requests new transaction ID if new data exists.

**The brief change log**
- `ArcticFileWriter` requests a new transaction ID when processing the new file data.