### PR TITLE
fix duplicate commit properties logic

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/BaseKeyedTable.java
+++ b/core/src/main/java/com/netease/arctic/table/BaseKeyedTable.java
@@ -160,13 +160,7 @@ public class BaseKeyedTable implements KeyedTable {
 
   @Override
   public UpdateProperties updateProperties() {
-    UpdateProperties updateProperties = new UpdateKeyedTableProperties(this, tableMeta);
-    if (client != null) {
-      AmsTableTracer tracer = new AmsTableTracer(this, TrackerOperations.UPDATE_PROPERTIES, client);
-      return new TracedUpdateProperties(updateProperties, tracer);
-    } else {
-      return updateProperties;
-    }
+    return new UpdateKeyedTableProperties(this, tableMeta);
   }
 
   @Override

--- a/core/src/main/java/com/netease/arctic/trace/AmsTableTracer.java
+++ b/core/src/main/java/com/netease/arctic/trace/AmsTableTracer.java
@@ -171,7 +171,7 @@ public class AmsTableTracer implements TableTracer {
       commitMeta.setSchemaUpdateMeta(ddlCommitMeta);
       update = true;
     }
-    if (this.properties != null) {
+    if (this.properties != null && Constants.INNER_TABLE_BASE.equals(innerTable)) {
       commitMeta.setProperties(this.properties);
       update = true;
     }


### PR DESCRIPTION
There commit properties multipal in old logic, because the keyedTable and unkeyedTable both commit properties to ams. But keyedTable's base and change table are also unkeyedTable, so there may commit properties multipal.