### PR TITLE
[ARCTIC-240] fix data lose after optimize for mysql sysdb with REPEATABLE READ

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/BaseOptimizeTaskRuntime.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/BaseOptimizeTaskRuntime.java
@@ -26,7 +26,7 @@ import com.netease.arctic.ams.api.OptimizeTaskId;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-public class BaseOptimizeTaskRuntime {
+public class BaseOptimizeTaskRuntime implements Cloneable {
   public static final long INVALID_TIME = 0;
   private OptimizeTaskId optimizeTaskId;
   private OptimizeStatus status = OptimizeStatus.Init;
@@ -201,5 +201,14 @@ public class BaseOptimizeTaskRuntime {
         ", attemptId='" + attemptId +
         ", targetFiles=" + targetFiles +
         '}';
+  }
+
+  @Override
+  public BaseOptimizeTaskRuntime clone() {
+    try {
+      return (BaseOptimizeTaskRuntime) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/IJDBCService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/IJDBCService.java
@@ -24,6 +24,7 @@ import com.netease.arctic.ams.server.utils.JDBCSqlSessionFactoryProvider;
 import org.apache.ibatis.io.ResolverUtil;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.TransactionIsolationLevel;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +43,12 @@ public abstract class IJDBCService {
   }
 
   public SqlSession getSqlSession(boolean autoCommit) {
-    return getSqlSessionFactory().openSession(autoCommit);
+    if (autoCommit) {
+      return this.getSqlSessionFactory().openSession(true);
+    } else {
+      // when openSession with TransactionIsolationLevel, autoCommit is always set to false
+      return this.getSqlSessionFactory().openSession(TransactionIsolationLevel.READ_COMMITTED);
+    }
   }
 
   public <T> T getMapper(SqlSession sqlSession, Class<T> type) {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As described in #240, for mysql with isolation level RR as sysdb, optimize will lose data because of dead lock.

## Brief change log

*(For example:)*
  - Set sysdb connection session isolation level to READ_COMMITTED
  - update optimize task runtime in memory only after update sysdb success

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
