### PR TITLE
[ARCTIC-28] fix ams.sh running on mac os

### DIFF
--- a/dist/src/main/arctic-bin/bin/ams.sh
+++ b/dist/src/main/arctic-bin/bin/ams.sh
@@ -67,7 +67,7 @@ CMDS="$JAVA_RUN -Dlog.home=${LOG_DIR} -Dlog.dir=${LOG_DIR} -Duser.dir=${ARCTIC_H
 #0:pid bad and proc OK;   1:pid ok and proc bad;    2:pid bad
 function status(){
     test -e ${PID} || return 2
-    test -d /proc/$(cat ${PID}) && return 0 || return 1
+    test -n "$(ps -p $(cat ${PID}) -o pid=)" && return 0 || return 1
 }
 
 function start() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix #28. Mac os doesn't have /proc/PID, so we hava to find another way to determine whether the process is running both for linux and mac os.

## Brief change log

*(For example:)*
  - change ams.sh, replace `test -d /proc/PID` with `test -n $(ps -p PID -o pid=)`

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="867" alt="image" src="https://user-images.githubusercontent.com/103108928/187207508-bd9fd03a-2d7f-40d0-bddd-26eb8171fd70.png">
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/103108928/187208824-d3088fd0-6c75-4c11-a596-e8c69f44fd77.png">



- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
