### PR TITLE
[ARCTIC-188][Flink][FollowUp] Avoiding submitting too much empty snapshots

### DIFF
--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -105,6 +105,15 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           " the current snapshot, \"latest\": read all incremental data in the change table starting from the" +
           " current snapshot (the current snapshot will be excluded).");
 
+  public static final ConfigOption<Boolean> SUBMIT_EMPTY_SNAPSHOTS = ConfigOptions
+      .key("submit.empty.snapshots")
+      .booleanType()
+      .defaultValue(true)
+      .withDescription("Optional submit empty snapshots to the arctic table, false means that writers will not emit" +
+          " empty WriteResults to the committer operator, and reduce the number of snapshots in File Cache; true" +
+          " means this job will submit empty snapshots to the table, it is suitable with some valid reasons, e.g." +
+          " advance watermark metadata stored in the table(https://github.com/apache/iceberg/pull/5561).");
+
   @Override
   public void validate(DescriptorProperties properties) {
     String emitMode = properties.getString(ARCTIC_EMIT_MODE);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -24,6 +24,7 @@ import com.netease.arctic.flink.shuffle.ShuffleRulePolicy;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.table.ArcticTable;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
@@ -59,6 +60,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private final int minFileSplitCount;
   private final ArcticTableLoader tableLoader;
   private final boolean upsert;
+  private final boolean submitEmptySnapshot;
 
   private transient org.apache.iceberg.io.TaskWriter<RowData> writer;
   private transient int subTaskId;
@@ -77,12 +79,16 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
       TaskWriterFactory<RowData> taskWriterFactory,
       int minFileSplitCount,
       ArcticTableLoader tableLoader,
-      boolean upsert) {
+      boolean upsert,
+      boolean submitEmptySnapshot) {
     this.shuffleRule = shuffleRule;
     this.taskWriterFactory = taskWriterFactory;
     this.minFileSplitCount = minFileSplitCount;
     this.tableLoader = tableLoader;
     this.upsert = upsert;
+    this.submitEmptySnapshot = submitEmptySnapshot;
+    LOG.info("ArcticFileWriter is created with minFileSplitCount: {}, upsert: {}, submitEmptySnapshot: {}",
+        minFileSplitCount, upsert, submitEmptySnapshot);
   }
 
   @Override
@@ -198,7 +204,24 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   }
 
   private void emit(WriteResult writeResult) {
-    output.collect(new StreamRecord<>(writeResult));
+    if (shouldEmit(writeResult)) {
+      // Only emit a non-empty WriteResult to committer operator, thus avoiding submitting too much empty snapshots.
+      output.collect(new StreamRecord<>(writeResult));
+    }
+  }
+
+  /**
+   * Whether to emit the WriteResult.
+   *
+   * @param writeResult the WriteResult to emit
+   * @return true if the WriteResult should be emitted, or the WriteResult isn't empty,
+   *         false only if the WriteResult is empty and the submitEmptySnapshot is false.
+   */
+  private boolean shouldEmit(WriteResult writeResult) {
+    return submitEmptySnapshot || (writeResult != null &&
+        (!ArrayUtils.isEmpty(writeResult.dataFiles()) ||
+            !ArrayUtils.isEmpty(writeResult.deleteFiles()) ||
+            !ArrayUtils.isEmpty(writeResult.referencedDataFiles())));
   }
 
   @VisibleForTesting


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In Flink 1.15 version, `ArcticFileWriter` should check whether the `WriteResult` is empty or not. Fix #188.

## Brief change log

  - `ArcticFileWriter` should check whether the `WriteResult` is empty or not in Flink 1.15.

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)