### PR TITLE
[Hive]Fix hive table name mapping

### DIFF
--- a/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMappingParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -193,6 +194,9 @@ public class ArcticHiveCatalog extends BaseArcticCatalog {
             throw new IllegalArgumentException("Unsupported partition transform:" +
                 partitionField.transform().toString());
           }
+          Preconditions.checkArgument(schema.columns().indexOf(schema.findField(partitionField.sourceId())) >=
+              (schema.columns().size() - partitionSpec.fields().size()), "Partition field should be at last of " +
+              "schema");
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Hive table need name mapping to read existed parquet files.
Name mapping is setted into table properties when creating table.
Name mapping should be generated with schema after table creating instead of before creating, becase field id would be reassigned when creating table.

## Brief change log

  - *Generate name mapping properties after table created.*
  - *Check hive table partition field is at laste of schema*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible


## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
