### PR TITLE
[ARCTIC-34][Flink] Support create and get timestamp(3) timestamp(0) type in the arctic table

### DIFF
--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.12
+ */
+class FlinkTypeToType extends FlinkTypeVisitor<Type> {
+
+  private final RowType root;
+  private int nextId;
+
+  FlinkTypeToType(RowType root) {
+    this.root = root;
+    // the root struct's fields use the first ids
+    this.nextId = root.getFieldCount();
+  }
+
+  private int getNextId() {
+    int next = nextId;
+    nextId += 1;
+    return next;
+  }
+
+  @Override
+  public Type visit(CharType charType) {
+    return Types.StringType.get();
+  }
+
+  @Override
+  public Type visit(VarCharType varCharType) {
+    return Types.StringType.get();
+  }
+
+  @Override
+  public Type visit(BooleanType booleanType) {
+    return Types.BooleanType.get();
+  }
+
+  @Override
+  public Type visit(BinaryType binaryType) {
+    return Types.FixedType.ofLength(binaryType.getLength());
+  }
+
+  @Override
+  public Type visit(VarBinaryType varBinaryType) {
+    return Types.BinaryType.get();
+  }
+
+  @Override
+  public Type visit(DecimalType decimalType) {
+    return Types.DecimalType.of(decimalType.getPrecision(), decimalType.getScale());
+  }
+
+  @Override
+  public Type visit(TinyIntType tinyIntType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(SmallIntType smallIntType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(IntType intType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(BigIntType bigIntType) {
+    return Types.LongType.get();
+  }
+
+  @Override
+  public Type visit(FloatType floatType) {
+    return Types.FloatType.get();
+  }
+
+  @Override
+  public Type visit(DoubleType doubleType) {
+    return Types.DoubleType.get();
+  }
+
+  @Override
+  public Type visit(DateType dateType) {
+    return Types.DateType.get();
+  }
+
+  @Override
+  public Type visit(TimeType timeType) {
+    return Types.TimeType.get();
+  }
+
+  @Override
+  public Type visit(TimestampType timestampType) {
+    return Types.TimestampType.withoutZone(timestampType.getPrecision());
+  }
+
+  @Override
+  public Type visit(LocalZonedTimestampType localZonedTimestampType) {
+    return Types.TimestampType.withZone(localZonedTimestampType.getPrecision());
+  }
+
+  @Override
+  public Type visit(ArrayType arrayType) {
+    Type elementType = arrayType.getElementType().accept(this);
+    if (arrayType.getElementType().isNullable()) {
+      return Types.ListType.ofOptional(getNextId(), elementType);
+    } else {
+      return Types.ListType.ofRequired(getNextId(), elementType);
+    }
+  }
+
+  @Override
+  public Type visit(MultisetType multisetType) {
+    Type elementType = multisetType.getElementType().accept(this);
+    return Types.MapType.ofRequired(getNextId(), getNextId(), elementType, Types.IntegerType.get());
+  }
+
+  @Override
+  public Type visit(MapType mapType) {
+    // keys in map are not allowed to be null.
+    Type keyType = mapType.getKeyType().accept(this);
+    Type valueType = mapType.getValueType().accept(this);
+    if (mapType.getValueType().isNullable()) {
+      return Types.MapType.ofOptional(getNextId(), getNextId(), keyType, valueType);
+    } else {
+      return Types.MapType.ofRequired(getNextId(), getNextId(), keyType, valueType);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("ReferenceEquality")
+  public Type visit(RowType rowType) {
+    List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(rowType.getFieldCount());
+    boolean isRoot = root == rowType;
+
+    List<Type> types =
+        rowType.getFields().stream()
+            .map(f -> f.getType().accept(this))
+            .collect(Collectors.toList());
+
+    for (int i = 0; i < rowType.getFieldCount(); i++) {
+      int id = isRoot ? i : getNextId();
+
+      RowType.RowField field = rowType.getFields().get(i);
+      String name = field.getName();
+      String comment = field.getDescription().orElse(null);
+
+      if (field.getType().isNullable()) {
+        newFields.add(Types.NestedField.optional(id, name, types.get(i), comment));
+      } else {
+        newFields.add(Types.NestedField.required(id, name, types.get(i), comment));
+      }
+    }
+
+    return Types.StructType.of(newFields);
+  }
+}

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.12
+ */
+class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
+  TypeToFlinkType() {
+  }
+
+  @Override
+  public LogicalType schema(Schema schema, LogicalType structType) {
+    return structType;
+  }
+
+  @Override
+  public LogicalType struct(Types.StructType struct, List<LogicalType> fieldResults) {
+    List<Types.NestedField> fields = struct.fields();
+
+    List<RowType.RowField> flinkFields = Lists.newArrayListWithExpectedSize(fieldResults.size());
+    for (int i = 0; i < fields.size(); i += 1) {
+      Types.NestedField field = fields.get(i);
+      LogicalType type = fieldResults.get(i);
+      RowType.RowField flinkField =
+          new RowType.RowField(field.name(), type.copy(field.isOptional()), field.doc());
+      flinkFields.add(flinkField);
+    }
+
+    return new RowType(flinkFields);
+  }
+
+  @Override
+  public LogicalType field(Types.NestedField field, LogicalType fieldResult) {
+    return fieldResult;
+  }
+
+  @Override
+  public LogicalType list(Types.ListType list, LogicalType elementResult) {
+    return new ArrayType(elementResult.copy(list.isElementOptional()));
+  }
+
+  @Override
+  public LogicalType map(Types.MapType map, LogicalType keyResult, LogicalType valueResult) {
+    // keys in map are not allowed to be null.
+    return new MapType(keyResult.copy(false), valueResult.copy(map.isValueOptional()));
+  }
+
+  @Override
+  public LogicalType primitive(Type.PrimitiveType primitive) {
+    switch (primitive.typeId()) {
+      case BOOLEAN:
+        return new BooleanType();
+      case INTEGER:
+        return new IntType();
+      case LONG:
+        return new BigIntType();
+      case FLOAT:
+        return new FloatType();
+      case DOUBLE:
+        return new DoubleType();
+      case DATE:
+        return new DateType();
+      case TIME:
+        // For the type: Flink only support TimeType with default precision (second) now. The
+        // precision of time is
+        // not supported in Flink, so we can think of it as a simple time type directly.
+        // For the data: Flink uses int that support mills to represent time data, so it supports
+        // mills precision.
+        return new TimeType();
+      case TIMESTAMP:
+        Types.TimestampType timestamp = (Types.TimestampType) primitive;
+        if (timestamp.shouldAdjustToUTC()) {
+          // MICROS
+          return new LocalZonedTimestampType(timestamp.precision());
+        } else {
+          // MICROS
+          return new TimestampType(timestamp.precision());
+        }
+      case STRING:
+        return new VarCharType(VarCharType.MAX_LENGTH);
+      case UUID:
+        // UUID length is 16
+        return new BinaryType(16);
+      case FIXED:
+        Types.FixedType fixedType = (Types.FixedType) primitive;
+        return new BinaryType(fixedType.length());
+      case BINARY:
+        return new VarBinaryType(VarBinaryType.MAX_LENGTH);
+      case DECIMAL:
+        Types.DecimalType decimal = (Types.DecimalType) primitive;
+        return new DecimalType(decimal.precision(), decimal.scale());
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot convert unknown type to Flink: " + primitive);
+    }
+  }
+}

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/types/Types.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/types/Types.java
@@ -1,0 +1,899 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Type.NestedType;
+import org.apache.iceberg.types.Type.PrimitiveType;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.12
+ */
+public class Types {
+
+  private Types() {
+  }
+
+  private static ImmutableMap<String, PrimitiveType> TYPES;
+
+  private static final Pattern FIXED = Pattern.compile("fixed\\[(\\d+)\\]");
+  private static final Pattern DECIMAL = Pattern.compile("decimal\\((\\d+),\\s+(\\d+)\\)");
+
+  static {
+    ImmutableMap.Builder<String, PrimitiveType> builder = ImmutableMap.<String, PrimitiveType>builder()
+        .put(BooleanType.get().toString(), BooleanType.get())
+        .put(IntegerType.get().toString(), IntegerType.get())
+        .put(LongType.get().toString(), LongType.get())
+        .put(FloatType.get().toString(), FloatType.get())
+        .put(DoubleType.get().toString(), DoubleType.get())
+        .put(DateType.get().toString(), DateType.get())
+        .put(TimeType.get().toString(), TimeType.get())
+        .put(StringType.get().toString(), StringType.get())
+        .put(UUIDType.get().toString(), UUIDType.get())
+        .put(BinaryType.get().toString(), BinaryType.get());
+    for (int precision = 0; precision <= 9; precision++) {
+      builder = builder.put(TimestampType.withZone(precision).toString(), TimestampType.withZone(precision))
+          .put(TimestampType.withoutZone(precision).toString(), TimestampType.withoutZone(precision));
+    }
+    TYPES = builder.build();
+  }
+
+  public static PrimitiveType fromPrimitiveString(String typeString) {
+    String lowerTypeString = typeString.toLowerCase(Locale.ROOT);
+    if (TYPES.containsKey(lowerTypeString)) {
+      return TYPES.get(lowerTypeString);
+    }
+
+    Matcher fixed = FIXED.matcher(lowerTypeString);
+    if (fixed.matches()) {
+      return FixedType.ofLength(Integer.parseInt(fixed.group(1)));
+    }
+
+    Matcher decimal = DECIMAL.matcher(lowerTypeString);
+    if (decimal.matches()) {
+      return DecimalType.of(Integer.parseInt(decimal.group(1)), Integer.parseInt(decimal.group(2)));
+    }
+
+    throw new IllegalArgumentException("Cannot parse type string to primitive: " + typeString);
+  }
+
+  public static class BooleanType extends PrimitiveType {
+    private static final BooleanType INSTANCE = new BooleanType();
+
+    public static BooleanType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.BOOLEAN;
+    }
+
+    @Override
+    public String toString() {
+      return "boolean";
+    }
+  }
+
+  public static class IntegerType extends PrimitiveType {
+    private static final IntegerType INSTANCE = new IntegerType();
+
+    public static IntegerType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.INTEGER;
+    }
+
+    @Override
+    public String toString() {
+      return "int";
+    }
+  }
+
+  public static class LongType extends PrimitiveType {
+    private static final LongType INSTANCE = new LongType();
+
+    public static LongType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.LONG;
+    }
+
+    @Override
+    public String toString() {
+      return "long";
+    }
+  }
+
+  public static class FloatType extends PrimitiveType {
+    private static final FloatType INSTANCE = new FloatType();
+
+    public static FloatType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.FLOAT;
+    }
+
+    @Override
+    public String toString() {
+      return "float";
+    }
+  }
+
+  public static class DoubleType extends PrimitiveType {
+    private static final DoubleType INSTANCE = new DoubleType();
+
+    public static DoubleType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DOUBLE;
+    }
+
+    @Override
+    public String toString() {
+      return "double";
+    }
+  }
+
+  public static class DateType extends PrimitiveType {
+    private static final DateType INSTANCE = new DateType();
+
+    public static DateType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DATE;
+    }
+
+    @Override
+    public String toString() {
+      return "date";
+    }
+  }
+
+  public static class TimeType extends PrimitiveType {
+    private static final TimeType INSTANCE = new TimeType();
+
+    public static TimeType get() {
+      return INSTANCE;
+    }
+
+    private TimeType() {
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.TIME;
+    }
+
+    @Override
+    public String toString() {
+      return "time";
+    }
+  }
+
+  public static class TimestampType extends PrimitiveType {
+    public static final int DEFAULT_PRECISION = 6;
+    private static final TimestampType INSTANCE_WITH_ZONE = withZone(DEFAULT_PRECISION);
+    private static final TimestampType INSTANCE_WITHOUT_ZONE = withoutZone(DEFAULT_PRECISION);
+
+    public static TimestampType withZone(int precision) {
+      return new TimestampType(precision, true);
+    }
+
+    public static TimestampType withZone() {
+      return INSTANCE_WITH_ZONE;
+    }
+
+    public static TimestampType withoutZone() {
+      return INSTANCE_WITHOUT_ZONE;
+    }
+
+    public static TimestampType withoutZone(int precision) {
+      return new TimestampType(precision, false);
+    }
+
+    private final int precision;
+    private final boolean adjustToUTC;
+
+    private TimestampType(int precision, boolean adjustToUTC) {
+      this.precision = precision;
+      this.adjustToUTC = adjustToUTC;
+    }
+
+    public int precision() {
+      return precision;
+    }
+
+    public boolean shouldAdjustToUTC() {
+      return adjustToUTC;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.TIMESTAMP;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s(%d)", adjustToUTC ? "timestamptz" : "timestamp", precision);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof TimestampType)) {
+        return false;
+      }
+
+      TimestampType timestampType = (TimestampType) o;
+      return adjustToUTC == timestampType.adjustToUTC;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(TimestampType.class, adjustToUTC);
+    }
+  }
+
+  public static class StringType extends PrimitiveType {
+    private static final StringType INSTANCE = new StringType();
+
+    public static StringType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.STRING;
+    }
+
+    @Override
+    public String toString() {
+      return "string";
+    }
+  }
+
+  public static class UUIDType extends PrimitiveType {
+    private static final UUIDType INSTANCE = new UUIDType();
+
+    public static UUIDType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.UUID;
+    }
+
+    @Override
+    public String toString() {
+      return "uuid";
+    }
+  }
+
+  public static class FixedType extends PrimitiveType {
+    public static FixedType ofLength(int length) {
+      return new FixedType(length);
+    }
+
+    private final int length;
+
+    private FixedType(int length) {
+      this.length = length;
+    }
+
+    public int length() {
+      return length;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.FIXED;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("fixed[%d]", length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof FixedType)) {
+        return false;
+      }
+
+      FixedType fixedType = (FixedType) o;
+      return length == fixedType.length;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(FixedType.class, length);
+    }
+  }
+
+  public static class BinaryType extends PrimitiveType {
+    private static final BinaryType INSTANCE = new BinaryType();
+
+    public static BinaryType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.BINARY;
+    }
+
+    @Override
+    public String toString() {
+      return "binary";
+    }
+  }
+
+  public static class DecimalType extends PrimitiveType {
+    public static DecimalType of(int precision, int scale) {
+      return new DecimalType(precision, scale);
+    }
+
+    private final int scale;
+    private final int precision;
+
+    private DecimalType(int precision, int scale) {
+      Preconditions.checkArgument(
+          precision <= 38,
+          "Decimals with precision larger than 38 are not supported: %s",
+          precision);
+      this.scale = scale;
+      this.precision = precision;
+    }
+
+    public int scale() {
+      return scale;
+    }
+
+    public int precision() {
+      return precision;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DECIMAL;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("decimal(%d, %d)", precision, scale);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof DecimalType)) {
+        return false;
+      }
+
+      DecimalType that = (DecimalType) o;
+      if (scale != that.scale) {
+        return false;
+      }
+      return precision == that.precision;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(DecimalType.class, scale, precision);
+    }
+  }
+
+  public static class NestedField implements Serializable {
+    public static NestedField optional(int id, String name, Type type) {
+      return new NestedField(true, id, name, type, null);
+    }
+
+    public static NestedField optional(int id, String name, Type type, String doc) {
+      return new NestedField(true, id, name, type, doc);
+    }
+
+    public static NestedField required(int id, String name, Type type) {
+      return new NestedField(false, id, name, type, null);
+    }
+
+    public static NestedField required(int id, String name, Type type, String doc) {
+      return new NestedField(false, id, name, type, doc);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type) {
+      return new NestedField(isOptional, id, name, type, null);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
+      return new NestedField(isOptional, id, name, type, doc);
+    }
+
+    private final boolean isOptional;
+    private final int id;
+    private final String name;
+    private final Type type;
+    private final String doc;
+
+    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
+      Preconditions.checkNotNull(name, "Name cannot be null");
+      Preconditions.checkNotNull(type, "Type cannot be null");
+      this.isOptional = isOptional;
+      this.id = id;
+      this.name = name;
+      this.type = type;
+      this.doc = doc;
+    }
+
+    public boolean isOptional() {
+      return isOptional;
+    }
+
+    public NestedField asOptional() {
+      if (isOptional) {
+        return this;
+      }
+      return new NestedField(true, id, name, type, doc);
+    }
+
+    public boolean isRequired() {
+      return !isOptional;
+    }
+
+    public NestedField asRequired() {
+      if (!isOptional) {
+        return this;
+      }
+      return new NestedField(false, id, name, type, doc);
+    }
+
+    public int fieldId() {
+      return id;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public Type type() {
+      return type;
+    }
+
+    public String doc() {
+      return doc;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%d: %s: %s %s", id, name, isOptional ? "optional" : "required", type) +
+          (doc != null ? " (" + doc + ")" : "");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof NestedField)) {
+        return false;
+      }
+
+      NestedField that = (NestedField) o;
+      if (isOptional != that.isOptional) {
+        return false;
+      } else if (id != that.id) {
+        return false;
+      } else if (!name.equals(that.name)) {
+        return false;
+      } else if (!Objects.equals(doc, that.doc)) {
+        return false;
+      }
+      return type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(NestedField.class, id, isOptional, name, type);
+    }
+  }
+
+  public static class StructType extends NestedType {
+    private static final Joiner FIELD_SEP = Joiner.on(", ");
+
+    public static StructType of(NestedField... fields) {
+      return of(Arrays.asList(fields));
+    }
+
+    public static StructType of(List<NestedField> fields) {
+      return new StructType(fields);
+    }
+
+    private final NestedField[] fields;
+
+    // lazy values
+    private transient List<NestedField> fieldList = null;
+    private transient Map<String, NestedField> fieldsByName = null;
+    private transient Map<String, NestedField> fieldsByLowerCaseName = null;
+    private transient Map<Integer, NestedField> fieldsById = null;
+
+    private StructType(List<NestedField> fields) {
+      Preconditions.checkNotNull(fields, "Field list cannot be null");
+      this.fields = new NestedField[fields.size()];
+      for (int i = 0; i < this.fields.length; i += 1) {
+        this.fields[i] = fields.get(i);
+      }
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public NestedField field(String name) {
+      return lazyFieldsByName().get(name);
+    }
+
+    @Override
+    public NestedField field(int id) {
+      return lazyFieldsById().get(id);
+    }
+
+    public NestedField caseInsensitiveField(String name) {
+      return lazyFieldsByLowerCaseName().get(name.toLowerCase(Locale.ROOT));
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      NestedField field = field(name);
+      if (field != null) {
+        return field.type();
+      }
+      return null;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.STRUCT;
+    }
+
+    @Override
+    public boolean isStructType() {
+      return true;
+    }
+
+    @Override
+    public StructType asStructType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("struct<%s>", FIELD_SEP.join(fields));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof StructType)) {
+        return false;
+      }
+
+      StructType that = (StructType) o;
+      return Arrays.equals(fields, that.fields);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(NestedField.class, Arrays.hashCode(fields));
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fieldList == null) {
+        this.fieldList = ImmutableList.copyOf(fields);
+      }
+      return fieldList;
+    }
+
+    private Map<String, NestedField> lazyFieldsByName() {
+      if (fieldsByName == null) {
+        ImmutableMap.Builder<String, NestedField> byNameBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byNameBuilder.put(field.name(), field);
+        }
+        fieldsByName = byNameBuilder.build();
+      }
+      return fieldsByName;
+    }
+
+    private Map<String, NestedField> lazyFieldsByLowerCaseName() {
+      if (fieldsByLowerCaseName == null) {
+        ImmutableMap.Builder<String, NestedField> byLowerCaseNameBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byLowerCaseNameBuilder.put(field.name().toLowerCase(Locale.ROOT), field);
+        }
+        fieldsByLowerCaseName = byLowerCaseNameBuilder.build();
+      }
+      return fieldsByLowerCaseName;
+    }
+
+    private Map<Integer, NestedField> lazyFieldsById() {
+      if (fieldsById == null) {
+        ImmutableMap.Builder<Integer, NestedField> byIdBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byIdBuilder.put(field.fieldId(), field);
+        }
+        this.fieldsById = byIdBuilder.build();
+      }
+      return fieldsById;
+    }
+  }
+
+  public static class ListType extends NestedType {
+    public static ListType ofOptional(int elementId, Type elementType) {
+      Preconditions.checkNotNull(elementType, "Element type cannot be null");
+      return new ListType(NestedField.optional(elementId, "element", elementType));
+    }
+
+    public static ListType ofRequired(int elementId, Type elementType) {
+      Preconditions.checkNotNull(elementType, "Element type cannot be null");
+      return new ListType(NestedField.required(elementId, "element", elementType));
+    }
+
+    private final NestedField elementField;
+    private transient List<NestedField> fields = null;
+
+    private ListType(NestedField elementField) {
+      this.elementField = elementField;
+    }
+
+    public Type elementType() {
+      return elementField.type();
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      if ("element".equals(name)) {
+        return elementType();
+      }
+      return null;
+    }
+
+    @Override
+    public NestedField field(int id) {
+      if (elementField.fieldId() == id) {
+        return elementField;
+      }
+      return null;
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public int elementId() {
+      return elementField.fieldId();
+    }
+
+    public boolean isElementRequired() {
+      return !elementField.isOptional;
+    }
+
+    public boolean isElementOptional() {
+      return elementField.isOptional;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.LIST;
+    }
+
+    @Override
+    public boolean isListType() {
+      return true;
+    }
+
+    @Override
+    public ListType asListType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("list<%s>", elementField.type());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof ListType)) {
+        return false;
+      }
+
+      ListType listType = (ListType) o;
+      return elementField.equals(listType.elementField);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(ListType.class, elementField);
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fields == null) {
+        this.fields = ImmutableList.of(elementField);
+      }
+      return fields;
+    }
+  }
+
+  public static class MapType extends NestedType {
+    public static MapType ofOptional(int keyId, int valueId, Type keyType, Type valueType) {
+      Preconditions.checkNotNull(valueType, "Value type cannot be null");
+      return new MapType(
+          NestedField.required(keyId, "key", keyType),
+          NestedField.optional(valueId, "value", valueType));
+    }
+
+    public static MapType ofRequired(int keyId, int valueId, Type keyType, Type valueType) {
+      Preconditions.checkNotNull(valueType, "Value type cannot be null");
+      return new MapType(
+          NestedField.required(keyId, "key", keyType),
+          NestedField.required(valueId, "value", valueType));
+    }
+
+    private final NestedField keyField;
+    private final NestedField valueField;
+    private transient List<NestedField> fields = null;
+
+    private MapType(NestedField keyField, NestedField valueField) {
+      this.keyField = keyField;
+      this.valueField = valueField;
+    }
+
+    public Type keyType() {
+      return keyField.type();
+    }
+
+    public Type valueType() {
+      return valueField.type();
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      if ("key".equals(name)) {
+        return keyField.type();
+      } else if ("value".equals(name)) {
+        return valueField.type();
+      }
+      return null;
+    }
+
+    @Override
+    public NestedField field(int id) {
+      if (keyField.fieldId() == id) {
+        return keyField;
+      } else if (valueField.fieldId() == id) {
+        return valueField;
+      }
+      return null;
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public int keyId() {
+      return keyField.fieldId();
+    }
+
+    public int valueId() {
+      return valueField.fieldId();
+    }
+
+    public boolean isValueRequired() {
+      return !valueField.isOptional;
+    }
+
+    public boolean isValueOptional() {
+      return valueField.isOptional;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.MAP;
+    }
+
+    @Override
+    public boolean isMapType() {
+      return true;
+    }
+
+    @Override
+    public MapType asMapType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("map<%s, %s>", keyField.type(), valueField.type());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof MapType)) {
+        return false;
+      }
+
+      MapType mapType = (MapType) o;
+      if (!keyField.equals(mapType.keyField)) {
+        return false;
+      }
+      return valueField.equals(mapType.valueField);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(MapType.class, keyField, valueField);
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fields == null) {
+        this.fields = ImmutableList.of(keyField, valueField);
+      }
+      return fields;
+    }
+  }
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.14
+ */
+class FlinkTypeToType extends FlinkTypeVisitor<Type> {
+
+  private final RowType root;
+  private int nextId;
+
+  FlinkTypeToType(RowType root) {
+    this.root = root;
+    // the root struct's fields use the first ids
+    this.nextId = root.getFieldCount();
+  }
+
+  private int getNextId() {
+    int next = nextId;
+    nextId += 1;
+    return next;
+  }
+
+  @Override
+  public Type visit(CharType charType) {
+    return Types.StringType.get();
+  }
+
+  @Override
+  public Type visit(VarCharType varCharType) {
+    return Types.StringType.get();
+  }
+
+  @Override
+  public Type visit(BooleanType booleanType) {
+    return Types.BooleanType.get();
+  }
+
+  @Override
+  public Type visit(BinaryType binaryType) {
+    return Types.FixedType.ofLength(binaryType.getLength());
+  }
+
+  @Override
+  public Type visit(VarBinaryType varBinaryType) {
+    return Types.BinaryType.get();
+  }
+
+  @Override
+  public Type visit(DecimalType decimalType) {
+    return Types.DecimalType.of(decimalType.getPrecision(), decimalType.getScale());
+  }
+
+  @Override
+  public Type visit(TinyIntType tinyIntType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(SmallIntType smallIntType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(IntType intType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(BigIntType bigIntType) {
+    return Types.LongType.get();
+  }
+
+  @Override
+  public Type visit(FloatType floatType) {
+    return Types.FloatType.get();
+  }
+
+  @Override
+  public Type visit(DoubleType doubleType) {
+    return Types.DoubleType.get();
+  }
+
+  @Override
+  public Type visit(DateType dateType) {
+    return Types.DateType.get();
+  }
+
+  @Override
+  public Type visit(TimeType timeType) {
+    return Types.TimeType.get();
+  }
+
+  @Override
+  public Type visit(TimestampType timestampType) {
+    return Types.TimestampType.withoutZone(timestampType.getPrecision());
+  }
+
+  @Override
+  public Type visit(LocalZonedTimestampType localZonedTimestampType) {
+    return Types.TimestampType.withZone(localZonedTimestampType.getPrecision());
+  }
+
+  @Override
+  public Type visit(ArrayType arrayType) {
+    Type elementType = arrayType.getElementType().accept(this);
+    if (arrayType.getElementType().isNullable()) {
+      return Types.ListType.ofOptional(getNextId(), elementType);
+    } else {
+      return Types.ListType.ofRequired(getNextId(), elementType);
+    }
+  }
+
+  @Override
+  public Type visit(MultisetType multisetType) {
+    Type elementType = multisetType.getElementType().accept(this);
+    return Types.MapType.ofRequired(getNextId(), getNextId(), elementType, Types.IntegerType.get());
+  }
+
+  @Override
+  public Type visit(MapType mapType) {
+    // keys in map are not allowed to be null.
+    Type keyType = mapType.getKeyType().accept(this);
+    Type valueType = mapType.getValueType().accept(this);
+    if (mapType.getValueType().isNullable()) {
+      return Types.MapType.ofOptional(getNextId(), getNextId(), keyType, valueType);
+    } else {
+      return Types.MapType.ofRequired(getNextId(), getNextId(), keyType, valueType);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("ReferenceEquality")
+  public Type visit(RowType rowType) {
+    List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(rowType.getFieldCount());
+    boolean isRoot = root == rowType;
+
+    List<Type> types =
+        rowType.getFields().stream()
+            .map(f -> f.getType().accept(this))
+            .collect(Collectors.toList());
+
+    for (int i = 0; i < rowType.getFieldCount(); i++) {
+      int id = isRoot ? i : getNextId();
+
+      RowType.RowField field = rowType.getFields().get(i);
+      String name = field.getName();
+      String comment = field.getDescription().orElse(null);
+
+      if (field.getType().isNullable()) {
+        newFields.add(Types.NestedField.optional(id, name, types.get(i), comment));
+      } else {
+        newFields.add(Types.NestedField.required(id, name, types.get(i), comment));
+      }
+    }
+
+    return Types.StructType.of(newFields);
+  }
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.14
+ */
+class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
+  TypeToFlinkType() {
+  }
+
+  @Override
+  public LogicalType schema(Schema schema, LogicalType structType) {
+    return structType;
+  }
+
+  @Override
+  public LogicalType struct(Types.StructType struct, List<LogicalType> fieldResults) {
+    List<Types.NestedField> fields = struct.fields();
+
+    List<RowType.RowField> flinkFields = Lists.newArrayListWithExpectedSize(fieldResults.size());
+    for (int i = 0; i < fields.size(); i += 1) {
+      Types.NestedField field = fields.get(i);
+      LogicalType type = fieldResults.get(i);
+      RowType.RowField flinkField =
+          new RowType.RowField(field.name(), type.copy(field.isOptional()), field.doc());
+      flinkFields.add(flinkField);
+    }
+
+    return new RowType(flinkFields);
+  }
+
+  @Override
+  public LogicalType field(Types.NestedField field, LogicalType fieldResult) {
+    return fieldResult;
+  }
+
+  @Override
+  public LogicalType list(Types.ListType list, LogicalType elementResult) {
+    return new ArrayType(elementResult.copy(list.isElementOptional()));
+  }
+
+  @Override
+  public LogicalType map(Types.MapType map, LogicalType keyResult, LogicalType valueResult) {
+    // keys in map are not allowed to be null.
+    return new MapType(keyResult.copy(false), valueResult.copy(map.isValueOptional()));
+  }
+
+  @Override
+  public LogicalType primitive(Type.PrimitiveType primitive) {
+    switch (primitive.typeId()) {
+      case BOOLEAN:
+        return new BooleanType();
+      case INTEGER:
+        return new IntType();
+      case LONG:
+        return new BigIntType();
+      case FLOAT:
+        return new FloatType();
+      case DOUBLE:
+        return new DoubleType();
+      case DATE:
+        return new DateType();
+      case TIME:
+        // For the type: Flink only support TimeType with default precision (second) now. The
+        // precision of time is
+        // not supported in Flink, so we can think of it as a simple time type directly.
+        // For the data: Flink uses int that support mills to represent time data, so it supports
+        // mills precision.
+        return new TimeType();
+      case TIMESTAMP:
+        Types.TimestampType timestamp = (Types.TimestampType) primitive;
+        if (timestamp.shouldAdjustToUTC()) {
+          // MICROS
+          return new LocalZonedTimestampType(timestamp.precision());
+        } else {
+          // MICROS
+          return new TimestampType(timestamp.precision());
+        }
+      case STRING:
+        return new VarCharType(VarCharType.MAX_LENGTH);
+      case UUID:
+        // UUID length is 16
+        return new BinaryType(16);
+      case FIXED:
+        Types.FixedType fixedType = (Types.FixedType) primitive;
+        return new BinaryType(fixedType.length());
+      case BINARY:
+        return new VarBinaryType(VarBinaryType.MAX_LENGTH);
+      case DECIMAL:
+        Types.DecimalType decimal = (Types.DecimalType) primitive;
+        return new DecimalType(decimal.precision(), decimal.scale());
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot convert unknown type to Flink: " + primitive);
+    }
+  }
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/types/Types.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/types/Types.java
@@ -1,0 +1,899 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Type.NestedType;
+import org.apache.iceberg.types.Type.PrimitiveType;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.14
+ */
+public class Types {
+
+  private Types() {
+  }
+
+  private static ImmutableMap<String, PrimitiveType> TYPES;
+
+  private static final Pattern FIXED = Pattern.compile("fixed\\[(\\d+)\\]");
+  private static final Pattern DECIMAL = Pattern.compile("decimal\\((\\d+),\\s+(\\d+)\\)");
+
+  static {
+    ImmutableMap.Builder<String, PrimitiveType> builder = ImmutableMap.<String, PrimitiveType>builder()
+        .put(BooleanType.get().toString(), BooleanType.get())
+        .put(IntegerType.get().toString(), IntegerType.get())
+        .put(LongType.get().toString(), LongType.get())
+        .put(FloatType.get().toString(), FloatType.get())
+        .put(DoubleType.get().toString(), DoubleType.get())
+        .put(DateType.get().toString(), DateType.get())
+        .put(TimeType.get().toString(), TimeType.get())
+        .put(StringType.get().toString(), StringType.get())
+        .put(UUIDType.get().toString(), UUIDType.get())
+        .put(BinaryType.get().toString(), BinaryType.get());
+    for (int precision = 0; precision <= 9; precision++) {
+      builder = builder.put(TimestampType.withZone(precision).toString(), TimestampType.withZone(precision))
+          .put(TimestampType.withoutZone(precision).toString(), TimestampType.withoutZone(precision));
+    }
+    TYPES = builder.build();
+  }
+
+  public static PrimitiveType fromPrimitiveString(String typeString) {
+    String lowerTypeString = typeString.toLowerCase(Locale.ROOT);
+    if (TYPES.containsKey(lowerTypeString)) {
+      return TYPES.get(lowerTypeString);
+    }
+
+    Matcher fixed = FIXED.matcher(lowerTypeString);
+    if (fixed.matches()) {
+      return FixedType.ofLength(Integer.parseInt(fixed.group(1)));
+    }
+
+    Matcher decimal = DECIMAL.matcher(lowerTypeString);
+    if (decimal.matches()) {
+      return DecimalType.of(Integer.parseInt(decimal.group(1)), Integer.parseInt(decimal.group(2)));
+    }
+
+    throw new IllegalArgumentException("Cannot parse type string to primitive: " + typeString);
+  }
+
+  public static class BooleanType extends PrimitiveType {
+    private static final BooleanType INSTANCE = new BooleanType();
+
+    public static BooleanType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.BOOLEAN;
+    }
+
+    @Override
+    public String toString() {
+      return "boolean";
+    }
+  }
+
+  public static class IntegerType extends PrimitiveType {
+    private static final IntegerType INSTANCE = new IntegerType();
+
+    public static IntegerType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.INTEGER;
+    }
+
+    @Override
+    public String toString() {
+      return "int";
+    }
+  }
+
+  public static class LongType extends PrimitiveType {
+    private static final LongType INSTANCE = new LongType();
+
+    public static LongType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.LONG;
+    }
+
+    @Override
+    public String toString() {
+      return "long";
+    }
+  }
+
+  public static class FloatType extends PrimitiveType {
+    private static final FloatType INSTANCE = new FloatType();
+
+    public static FloatType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.FLOAT;
+    }
+
+    @Override
+    public String toString() {
+      return "float";
+    }
+  }
+
+  public static class DoubleType extends PrimitiveType {
+    private static final DoubleType INSTANCE = new DoubleType();
+
+    public static DoubleType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DOUBLE;
+    }
+
+    @Override
+    public String toString() {
+      return "double";
+    }
+  }
+
+  public static class DateType extends PrimitiveType {
+    private static final DateType INSTANCE = new DateType();
+
+    public static DateType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DATE;
+    }
+
+    @Override
+    public String toString() {
+      return "date";
+    }
+  }
+
+  public static class TimeType extends PrimitiveType {
+    private static final TimeType INSTANCE = new TimeType();
+
+    public static TimeType get() {
+      return INSTANCE;
+    }
+
+    private TimeType() {
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.TIME;
+    }
+
+    @Override
+    public String toString() {
+      return "time";
+    }
+  }
+
+  public static class TimestampType extends PrimitiveType {
+    public static final int DEFAULT_PRECISION = 6;
+    private static final TimestampType INSTANCE_WITH_ZONE = withZone(DEFAULT_PRECISION);
+    private static final TimestampType INSTANCE_WITHOUT_ZONE = withoutZone(DEFAULT_PRECISION);
+
+    public static TimestampType withZone(int precision) {
+      return new TimestampType(precision, true);
+    }
+
+    public static TimestampType withZone() {
+      return INSTANCE_WITH_ZONE;
+    }
+
+    public static TimestampType withoutZone() {
+      return INSTANCE_WITHOUT_ZONE;
+    }
+
+    public static TimestampType withoutZone(int precision) {
+      return new TimestampType(precision, false);
+    }
+
+    private final int precision;
+    private final boolean adjustToUTC;
+
+    private TimestampType(int precision, boolean adjustToUTC) {
+      this.precision = precision;
+      this.adjustToUTC = adjustToUTC;
+    }
+
+    public int precision() {
+      return precision;
+    }
+
+    public boolean shouldAdjustToUTC() {
+      return adjustToUTC;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.TIMESTAMP;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s(%d)", adjustToUTC ? "timestamptz" : "timestamp", precision);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof TimestampType)) {
+        return false;
+      }
+
+      TimestampType timestampType = (TimestampType) o;
+      return adjustToUTC == timestampType.adjustToUTC;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(TimestampType.class, adjustToUTC);
+    }
+  }
+
+  public static class StringType extends PrimitiveType {
+    private static final StringType INSTANCE = new StringType();
+
+    public static StringType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.STRING;
+    }
+
+    @Override
+    public String toString() {
+      return "string";
+    }
+  }
+
+  public static class UUIDType extends PrimitiveType {
+    private static final UUIDType INSTANCE = new UUIDType();
+
+    public static UUIDType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.UUID;
+    }
+
+    @Override
+    public String toString() {
+      return "uuid";
+    }
+  }
+
+  public static class FixedType extends PrimitiveType {
+    public static FixedType ofLength(int length) {
+      return new FixedType(length);
+    }
+
+    private final int length;
+
+    private FixedType(int length) {
+      this.length = length;
+    }
+
+    public int length() {
+      return length;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.FIXED;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("fixed[%d]", length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof FixedType)) {
+        return false;
+      }
+
+      FixedType fixedType = (FixedType) o;
+      return length == fixedType.length;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(FixedType.class, length);
+    }
+  }
+
+  public static class BinaryType extends PrimitiveType {
+    private static final BinaryType INSTANCE = new BinaryType();
+
+    public static BinaryType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.BINARY;
+    }
+
+    @Override
+    public String toString() {
+      return "binary";
+    }
+  }
+
+  public static class DecimalType extends PrimitiveType {
+    public static DecimalType of(int precision, int scale) {
+      return new DecimalType(precision, scale);
+    }
+
+    private final int scale;
+    private final int precision;
+
+    private DecimalType(int precision, int scale) {
+      Preconditions.checkArgument(
+          precision <= 38,
+          "Decimals with precision larger than 38 are not supported: %s",
+          precision);
+      this.scale = scale;
+      this.precision = precision;
+    }
+
+    public int scale() {
+      return scale;
+    }
+
+    public int precision() {
+      return precision;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DECIMAL;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("decimal(%d, %d)", precision, scale);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof DecimalType)) {
+        return false;
+      }
+
+      DecimalType that = (DecimalType) o;
+      if (scale != that.scale) {
+        return false;
+      }
+      return precision == that.precision;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(DecimalType.class, scale, precision);
+    }
+  }
+
+  public static class NestedField implements Serializable {
+    public static NestedField optional(int id, String name, Type type) {
+      return new NestedField(true, id, name, type, null);
+    }
+
+    public static NestedField optional(int id, String name, Type type, String doc) {
+      return new NestedField(true, id, name, type, doc);
+    }
+
+    public static NestedField required(int id, String name, Type type) {
+      return new NestedField(false, id, name, type, null);
+    }
+
+    public static NestedField required(int id, String name, Type type, String doc) {
+      return new NestedField(false, id, name, type, doc);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type) {
+      return new NestedField(isOptional, id, name, type, null);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
+      return new NestedField(isOptional, id, name, type, doc);
+    }
+
+    private final boolean isOptional;
+    private final int id;
+    private final String name;
+    private final Type type;
+    private final String doc;
+
+    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
+      Preconditions.checkNotNull(name, "Name cannot be null");
+      Preconditions.checkNotNull(type, "Type cannot be null");
+      this.isOptional = isOptional;
+      this.id = id;
+      this.name = name;
+      this.type = type;
+      this.doc = doc;
+    }
+
+    public boolean isOptional() {
+      return isOptional;
+    }
+
+    public NestedField asOptional() {
+      if (isOptional) {
+        return this;
+      }
+      return new NestedField(true, id, name, type, doc);
+    }
+
+    public boolean isRequired() {
+      return !isOptional;
+    }
+
+    public NestedField asRequired() {
+      if (!isOptional) {
+        return this;
+      }
+      return new NestedField(false, id, name, type, doc);
+    }
+
+    public int fieldId() {
+      return id;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public Type type() {
+      return type;
+    }
+
+    public String doc() {
+      return doc;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%d: %s: %s %s", id, name, isOptional ? "optional" : "required", type) +
+          (doc != null ? " (" + doc + ")" : "");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof NestedField)) {
+        return false;
+      }
+
+      NestedField that = (NestedField) o;
+      if (isOptional != that.isOptional) {
+        return false;
+      } else if (id != that.id) {
+        return false;
+      } else if (!name.equals(that.name)) {
+        return false;
+      } else if (!Objects.equals(doc, that.doc)) {
+        return false;
+      }
+      return type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(NestedField.class, id, isOptional, name, type);
+    }
+  }
+
+  public static class StructType extends NestedType {
+    private static final Joiner FIELD_SEP = Joiner.on(", ");
+
+    public static StructType of(NestedField... fields) {
+      return of(Arrays.asList(fields));
+    }
+
+    public static StructType of(List<NestedField> fields) {
+      return new StructType(fields);
+    }
+
+    private final NestedField[] fields;
+
+    // lazy values
+    private transient List<NestedField> fieldList = null;
+    private transient Map<String, NestedField> fieldsByName = null;
+    private transient Map<String, NestedField> fieldsByLowerCaseName = null;
+    private transient Map<Integer, NestedField> fieldsById = null;
+
+    private StructType(List<NestedField> fields) {
+      Preconditions.checkNotNull(fields, "Field list cannot be null");
+      this.fields = new NestedField[fields.size()];
+      for (int i = 0; i < this.fields.length; i += 1) {
+        this.fields[i] = fields.get(i);
+      }
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public NestedField field(String name) {
+      return lazyFieldsByName().get(name);
+    }
+
+    @Override
+    public NestedField field(int id) {
+      return lazyFieldsById().get(id);
+    }
+
+    public NestedField caseInsensitiveField(String name) {
+      return lazyFieldsByLowerCaseName().get(name.toLowerCase(Locale.ROOT));
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      NestedField field = field(name);
+      if (field != null) {
+        return field.type();
+      }
+      return null;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.STRUCT;
+    }
+
+    @Override
+    public boolean isStructType() {
+      return true;
+    }
+
+    @Override
+    public StructType asStructType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("struct<%s>", FIELD_SEP.join(fields));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof StructType)) {
+        return false;
+      }
+
+      StructType that = (StructType) o;
+      return Arrays.equals(fields, that.fields);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(NestedField.class, Arrays.hashCode(fields));
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fieldList == null) {
+        this.fieldList = ImmutableList.copyOf(fields);
+      }
+      return fieldList;
+    }
+
+    private Map<String, NestedField> lazyFieldsByName() {
+      if (fieldsByName == null) {
+        ImmutableMap.Builder<String, NestedField> byNameBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byNameBuilder.put(field.name(), field);
+        }
+        fieldsByName = byNameBuilder.build();
+      }
+      return fieldsByName;
+    }
+
+    private Map<String, NestedField> lazyFieldsByLowerCaseName() {
+      if (fieldsByLowerCaseName == null) {
+        ImmutableMap.Builder<String, NestedField> byLowerCaseNameBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byLowerCaseNameBuilder.put(field.name().toLowerCase(Locale.ROOT), field);
+        }
+        fieldsByLowerCaseName = byLowerCaseNameBuilder.build();
+      }
+      return fieldsByLowerCaseName;
+    }
+
+    private Map<Integer, NestedField> lazyFieldsById() {
+      if (fieldsById == null) {
+        ImmutableMap.Builder<Integer, NestedField> byIdBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byIdBuilder.put(field.fieldId(), field);
+        }
+        this.fieldsById = byIdBuilder.build();
+      }
+      return fieldsById;
+    }
+  }
+
+  public static class ListType extends NestedType {
+    public static ListType ofOptional(int elementId, Type elementType) {
+      Preconditions.checkNotNull(elementType, "Element type cannot be null");
+      return new ListType(NestedField.optional(elementId, "element", elementType));
+    }
+
+    public static ListType ofRequired(int elementId, Type elementType) {
+      Preconditions.checkNotNull(elementType, "Element type cannot be null");
+      return new ListType(NestedField.required(elementId, "element", elementType));
+    }
+
+    private final NestedField elementField;
+    private transient List<NestedField> fields = null;
+
+    private ListType(NestedField elementField) {
+      this.elementField = elementField;
+    }
+
+    public Type elementType() {
+      return elementField.type();
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      if ("element".equals(name)) {
+        return elementType();
+      }
+      return null;
+    }
+
+    @Override
+    public NestedField field(int id) {
+      if (elementField.fieldId() == id) {
+        return elementField;
+      }
+      return null;
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public int elementId() {
+      return elementField.fieldId();
+    }
+
+    public boolean isElementRequired() {
+      return !elementField.isOptional;
+    }
+
+    public boolean isElementOptional() {
+      return elementField.isOptional;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.LIST;
+    }
+
+    @Override
+    public boolean isListType() {
+      return true;
+    }
+
+    @Override
+    public ListType asListType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("list<%s>", elementField.type());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof ListType)) {
+        return false;
+      }
+
+      ListType listType = (ListType) o;
+      return elementField.equals(listType.elementField);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(ListType.class, elementField);
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fields == null) {
+        this.fields = ImmutableList.of(elementField);
+      }
+      return fields;
+    }
+  }
+
+  public static class MapType extends NestedType {
+    public static MapType ofOptional(int keyId, int valueId, Type keyType, Type valueType) {
+      Preconditions.checkNotNull(valueType, "Value type cannot be null");
+      return new MapType(
+          NestedField.required(keyId, "key", keyType),
+          NestedField.optional(valueId, "value", valueType));
+    }
+
+    public static MapType ofRequired(int keyId, int valueId, Type keyType, Type valueType) {
+      Preconditions.checkNotNull(valueType, "Value type cannot be null");
+      return new MapType(
+          NestedField.required(keyId, "key", keyType),
+          NestedField.required(valueId, "value", valueType));
+    }
+
+    private final NestedField keyField;
+    private final NestedField valueField;
+    private transient List<NestedField> fields = null;
+
+    private MapType(NestedField keyField, NestedField valueField) {
+      this.keyField = keyField;
+      this.valueField = valueField;
+    }
+
+    public Type keyType() {
+      return keyField.type();
+    }
+
+    public Type valueType() {
+      return valueField.type();
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      if ("key".equals(name)) {
+        return keyField.type();
+      } else if ("value".equals(name)) {
+        return valueField.type();
+      }
+      return null;
+    }
+
+    @Override
+    public NestedField field(int id) {
+      if (keyField.fieldId() == id) {
+        return keyField;
+      } else if (valueField.fieldId() == id) {
+        return valueField;
+      }
+      return null;
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public int keyId() {
+      return keyField.fieldId();
+    }
+
+    public int valueId() {
+      return valueField.fieldId();
+    }
+
+    public boolean isValueRequired() {
+      return !valueField.isOptional;
+    }
+
+    public boolean isValueOptional() {
+      return valueField.isOptional;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.MAP;
+    }
+
+    @Override
+    public boolean isMapType() {
+      return true;
+    }
+
+    @Override
+    public MapType asMapType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("map<%s, %s>", keyField.type(), valueField.type());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof MapType)) {
+        return false;
+      }
+
+      MapType mapType = (MapType) o;
+      if (!keyField.equals(mapType.keyField)) {
+        return false;
+      }
+      return valueField.equals(mapType.valueField);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(MapType.class, keyField, valueField);
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fields == null) {
+        this.fields = ImmutableList.of(keyField, valueField);
+      }
+      return fields;
+    }
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.15
+ */
+class FlinkTypeToType extends FlinkTypeVisitor<Type> {
+
+  private final RowType root;
+  private int nextId;
+
+  FlinkTypeToType(RowType root) {
+    this.root = root;
+    // the root struct's fields use the first ids
+    this.nextId = root.getFieldCount();
+  }
+
+  private int getNextId() {
+    int next = nextId;
+    nextId += 1;
+    return next;
+  }
+
+  @Override
+  public Type visit(CharType charType) {
+    return Types.StringType.get();
+  }
+
+  @Override
+  public Type visit(VarCharType varCharType) {
+    return Types.StringType.get();
+  }
+
+  @Override
+  public Type visit(BooleanType booleanType) {
+    return Types.BooleanType.get();
+  }
+
+  @Override
+  public Type visit(BinaryType binaryType) {
+    return Types.FixedType.ofLength(binaryType.getLength());
+  }
+
+  @Override
+  public Type visit(VarBinaryType varBinaryType) {
+    return Types.BinaryType.get();
+  }
+
+  @Override
+  public Type visit(DecimalType decimalType) {
+    return Types.DecimalType.of(decimalType.getPrecision(), decimalType.getScale());
+  }
+
+  @Override
+  public Type visit(TinyIntType tinyIntType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(SmallIntType smallIntType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(IntType intType) {
+    return Types.IntegerType.get();
+  }
+
+  @Override
+  public Type visit(BigIntType bigIntType) {
+    return Types.LongType.get();
+  }
+
+  @Override
+  public Type visit(FloatType floatType) {
+    return Types.FloatType.get();
+  }
+
+  @Override
+  public Type visit(DoubleType doubleType) {
+    return Types.DoubleType.get();
+  }
+
+  @Override
+  public Type visit(DateType dateType) {
+    return Types.DateType.get();
+  }
+
+  @Override
+  public Type visit(TimeType timeType) {
+    return Types.TimeType.get();
+  }
+
+  @Override
+  public Type visit(TimestampType timestampType) {
+    return Types.TimestampType.withoutZone(timestampType.getPrecision());
+  }
+
+  @Override
+  public Type visit(LocalZonedTimestampType localZonedTimestampType) {
+    return Types.TimestampType.withZone(localZonedTimestampType.getPrecision());
+  }
+
+  @Override
+  public Type visit(ArrayType arrayType) {
+    Type elementType = arrayType.getElementType().accept(this);
+    if (arrayType.getElementType().isNullable()) {
+      return Types.ListType.ofOptional(getNextId(), elementType);
+    } else {
+      return Types.ListType.ofRequired(getNextId(), elementType);
+    }
+  }
+
+  @Override
+  public Type visit(MultisetType multisetType) {
+    Type elementType = multisetType.getElementType().accept(this);
+    return Types.MapType.ofRequired(getNextId(), getNextId(), elementType, Types.IntegerType.get());
+  }
+
+  @Override
+  public Type visit(MapType mapType) {
+    // keys in map are not allowed to be null.
+    Type keyType = mapType.getKeyType().accept(this);
+    Type valueType = mapType.getValueType().accept(this);
+    if (mapType.getValueType().isNullable()) {
+      return Types.MapType.ofOptional(getNextId(), getNextId(), keyType, valueType);
+    } else {
+      return Types.MapType.ofRequired(getNextId(), getNextId(), keyType, valueType);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("ReferenceEquality")
+  public Type visit(RowType rowType) {
+    List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(rowType.getFieldCount());
+    boolean isRoot = root == rowType;
+
+    List<Type> types =
+        rowType.getFields().stream()
+            .map(f -> f.getType().accept(this))
+            .collect(Collectors.toList());
+
+    for (int i = 0; i < rowType.getFieldCount(); i++) {
+      int id = isRoot ? i : getNextId();
+
+      RowType.RowField field = rowType.getFields().get(i);
+      String name = field.getName();
+      String comment = field.getDescription().orElse(null);
+
+      if (field.getType().isNullable()) {
+        newFields.add(Types.NestedField.optional(id, name, types.get(i), comment));
+      } else {
+        newFields.add(Types.NestedField.required(id, name, types.get(i), comment));
+      }
+    }
+
+    return Types.StructType.of(newFields);
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.15
+ */
+class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
+  TypeToFlinkType() {
+  }
+
+  @Override
+  public LogicalType schema(Schema schema, LogicalType structType) {
+    return structType;
+  }
+
+  @Override
+  public LogicalType struct(Types.StructType struct, List<LogicalType> fieldResults) {
+    List<Types.NestedField> fields = struct.fields();
+
+    List<RowType.RowField> flinkFields = Lists.newArrayListWithExpectedSize(fieldResults.size());
+    for (int i = 0; i < fields.size(); i += 1) {
+      Types.NestedField field = fields.get(i);
+      LogicalType type = fieldResults.get(i);
+      RowType.RowField flinkField =
+          new RowType.RowField(field.name(), type.copy(field.isOptional()), field.doc());
+      flinkFields.add(flinkField);
+    }
+
+    return new RowType(flinkFields);
+  }
+
+  @Override
+  public LogicalType field(Types.NestedField field, LogicalType fieldResult) {
+    return fieldResult;
+  }
+
+  @Override
+  public LogicalType list(Types.ListType list, LogicalType elementResult) {
+    return new ArrayType(elementResult.copy(list.isElementOptional()));
+  }
+
+  @Override
+  public LogicalType map(Types.MapType map, LogicalType keyResult, LogicalType valueResult) {
+    // keys in map are not allowed to be null.
+    return new MapType(keyResult.copy(false), valueResult.copy(map.isValueOptional()));
+  }
+
+  @Override
+  public LogicalType primitive(Type.PrimitiveType primitive) {
+    switch (primitive.typeId()) {
+      case BOOLEAN:
+        return new BooleanType();
+      case INTEGER:
+        return new IntType();
+      case LONG:
+        return new BigIntType();
+      case FLOAT:
+        return new FloatType();
+      case DOUBLE:
+        return new DoubleType();
+      case DATE:
+        return new DateType();
+      case TIME:
+        // For the type: Flink only support TimeType with default precision (second) now. The
+        // precision of time is
+        // not supported in Flink, so we can think of it as a simple time type directly.
+        // For the data: Flink uses int that support mills to represent time data, so it supports
+        // mills precision.
+        return new TimeType();
+      case TIMESTAMP:
+        Types.TimestampType timestamp = (Types.TimestampType) primitive;
+        if (timestamp.shouldAdjustToUTC()) {
+          // MICROS
+          return new LocalZonedTimestampType(timestamp.precision());
+        } else {
+          // MICROS
+          return new TimestampType(timestamp.precision());
+        }
+      case STRING:
+        return new VarCharType(VarCharType.MAX_LENGTH);
+      case UUID:
+        // UUID length is 16
+        return new BinaryType(16);
+      case FIXED:
+        Types.FixedType fixedType = (Types.FixedType) primitive;
+        return new BinaryType(fixedType.length());
+      case BINARY:
+        return new VarBinaryType(VarBinaryType.MAX_LENGTH);
+      case DECIMAL:
+        Types.DecimalType decimal = (Types.DecimalType) primitive;
+        return new DecimalType(decimal.precision(), decimal.scale());
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot convert unknown type to Flink: " + primitive);
+    }
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/types/Types.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/types/Types.java
@@ -1,0 +1,899 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Type.NestedType;
+import org.apache.iceberg.types.Type.PrimitiveType;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Copied from iceberg 0.12.x to support flink 1.15
+ */
+public class Types {
+
+  private Types() {
+  }
+
+  private static ImmutableMap<String, PrimitiveType> TYPES;
+
+  private static final Pattern FIXED = Pattern.compile("fixed\\[(\\d+)\\]");
+  private static final Pattern DECIMAL = Pattern.compile("decimal\\((\\d+),\\s+(\\d+)\\)");
+
+  static {
+    ImmutableMap.Builder<String, PrimitiveType> builder = ImmutableMap.<String, PrimitiveType>builder()
+        .put(BooleanType.get().toString(), BooleanType.get())
+        .put(IntegerType.get().toString(), IntegerType.get())
+        .put(LongType.get().toString(), LongType.get())
+        .put(FloatType.get().toString(), FloatType.get())
+        .put(DoubleType.get().toString(), DoubleType.get())
+        .put(DateType.get().toString(), DateType.get())
+        .put(TimeType.get().toString(), TimeType.get())
+        .put(StringType.get().toString(), StringType.get())
+        .put(UUIDType.get().toString(), UUIDType.get())
+        .put(BinaryType.get().toString(), BinaryType.get());
+    for (int precision = 0; precision <= 9; precision++) {
+      builder = builder.put(TimestampType.withZone(precision).toString(), TimestampType.withZone(precision))
+          .put(TimestampType.withoutZone(precision).toString(), TimestampType.withoutZone(precision));
+    }
+    TYPES = builder.build();
+  }
+
+  public static PrimitiveType fromPrimitiveString(String typeString) {
+    String lowerTypeString = typeString.toLowerCase(Locale.ROOT);
+    if (TYPES.containsKey(lowerTypeString)) {
+      return TYPES.get(lowerTypeString);
+    }
+
+    Matcher fixed = FIXED.matcher(lowerTypeString);
+    if (fixed.matches()) {
+      return FixedType.ofLength(Integer.parseInt(fixed.group(1)));
+    }
+
+    Matcher decimal = DECIMAL.matcher(lowerTypeString);
+    if (decimal.matches()) {
+      return DecimalType.of(Integer.parseInt(decimal.group(1)), Integer.parseInt(decimal.group(2)));
+    }
+
+    throw new IllegalArgumentException("Cannot parse type string to primitive: " + typeString);
+  }
+
+  public static class BooleanType extends PrimitiveType {
+    private static final BooleanType INSTANCE = new BooleanType();
+
+    public static BooleanType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.BOOLEAN;
+    }
+
+    @Override
+    public String toString() {
+      return "boolean";
+    }
+  }
+
+  public static class IntegerType extends PrimitiveType {
+    private static final IntegerType INSTANCE = new IntegerType();
+
+    public static IntegerType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.INTEGER;
+    }
+
+    @Override
+    public String toString() {
+      return "int";
+    }
+  }
+
+  public static class LongType extends PrimitiveType {
+    private static final LongType INSTANCE = new LongType();
+
+    public static LongType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.LONG;
+    }
+
+    @Override
+    public String toString() {
+      return "long";
+    }
+  }
+
+  public static class FloatType extends PrimitiveType {
+    private static final FloatType INSTANCE = new FloatType();
+
+    public static FloatType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.FLOAT;
+    }
+
+    @Override
+    public String toString() {
+      return "float";
+    }
+  }
+
+  public static class DoubleType extends PrimitiveType {
+    private static final DoubleType INSTANCE = new DoubleType();
+
+    public static DoubleType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DOUBLE;
+    }
+
+    @Override
+    public String toString() {
+      return "double";
+    }
+  }
+
+  public static class DateType extends PrimitiveType {
+    private static final DateType INSTANCE = new DateType();
+
+    public static DateType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DATE;
+    }
+
+    @Override
+    public String toString() {
+      return "date";
+    }
+  }
+
+  public static class TimeType extends PrimitiveType {
+    private static final TimeType INSTANCE = new TimeType();
+
+    public static TimeType get() {
+      return INSTANCE;
+    }
+
+    private TimeType() {
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.TIME;
+    }
+
+    @Override
+    public String toString() {
+      return "time";
+    }
+  }
+
+  public static class TimestampType extends PrimitiveType {
+    public static final int DEFAULT_PRECISION = 6;
+    private static final TimestampType INSTANCE_WITH_ZONE = withZone(DEFAULT_PRECISION);
+    private static final TimestampType INSTANCE_WITHOUT_ZONE = withoutZone(DEFAULT_PRECISION);
+
+    public static TimestampType withZone(int precision) {
+      return new TimestampType(precision, true);
+    }
+
+    public static TimestampType withZone() {
+      return INSTANCE_WITH_ZONE;
+    }
+
+    public static TimestampType withoutZone() {
+      return INSTANCE_WITHOUT_ZONE;
+    }
+
+    public static TimestampType withoutZone(int precision) {
+      return new TimestampType(precision, false);
+    }
+
+    private final int precision;
+    private final boolean adjustToUTC;
+
+    private TimestampType(int precision, boolean adjustToUTC) {
+      this.precision = precision;
+      this.adjustToUTC = adjustToUTC;
+    }
+
+    public int precision() {
+      return precision;
+    }
+
+    public boolean shouldAdjustToUTC() {
+      return adjustToUTC;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.TIMESTAMP;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s(%d)", adjustToUTC ? "timestamptz" : "timestamp", precision);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof TimestampType)) {
+        return false;
+      }
+
+      TimestampType timestampType = (TimestampType) o;
+      return adjustToUTC == timestampType.adjustToUTC;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(TimestampType.class, adjustToUTC);
+    }
+  }
+
+  public static class StringType extends PrimitiveType {
+    private static final StringType INSTANCE = new StringType();
+
+    public static StringType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.STRING;
+    }
+
+    @Override
+    public String toString() {
+      return "string";
+    }
+  }
+
+  public static class UUIDType extends PrimitiveType {
+    private static final UUIDType INSTANCE = new UUIDType();
+
+    public static UUIDType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.UUID;
+    }
+
+    @Override
+    public String toString() {
+      return "uuid";
+    }
+  }
+
+  public static class FixedType extends PrimitiveType {
+    public static FixedType ofLength(int length) {
+      return new FixedType(length);
+    }
+
+    private final int length;
+
+    private FixedType(int length) {
+      this.length = length;
+    }
+
+    public int length() {
+      return length;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.FIXED;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("fixed[%d]", length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof FixedType)) {
+        return false;
+      }
+
+      FixedType fixedType = (FixedType) o;
+      return length == fixedType.length;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(FixedType.class, length);
+    }
+  }
+
+  public static class BinaryType extends PrimitiveType {
+    private static final BinaryType INSTANCE = new BinaryType();
+
+    public static BinaryType get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.BINARY;
+    }
+
+    @Override
+    public String toString() {
+      return "binary";
+    }
+  }
+
+  public static class DecimalType extends PrimitiveType {
+    public static DecimalType of(int precision, int scale) {
+      return new DecimalType(precision, scale);
+    }
+
+    private final int scale;
+    private final int precision;
+
+    private DecimalType(int precision, int scale) {
+      Preconditions.checkArgument(
+          precision <= 38,
+          "Decimals with precision larger than 38 are not supported: %s",
+          precision);
+      this.scale = scale;
+      this.precision = precision;
+    }
+
+    public int scale() {
+      return scale;
+    }
+
+    public int precision() {
+      return precision;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.DECIMAL;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("decimal(%d, %d)", precision, scale);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof DecimalType)) {
+        return false;
+      }
+
+      DecimalType that = (DecimalType) o;
+      if (scale != that.scale) {
+        return false;
+      }
+      return precision == that.precision;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(DecimalType.class, scale, precision);
+    }
+  }
+
+  public static class NestedField implements Serializable {
+    public static NestedField optional(int id, String name, Type type) {
+      return new NestedField(true, id, name, type, null);
+    }
+
+    public static NestedField optional(int id, String name, Type type, String doc) {
+      return new NestedField(true, id, name, type, doc);
+    }
+
+    public static NestedField required(int id, String name, Type type) {
+      return new NestedField(false, id, name, type, null);
+    }
+
+    public static NestedField required(int id, String name, Type type, String doc) {
+      return new NestedField(false, id, name, type, doc);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type) {
+      return new NestedField(isOptional, id, name, type, null);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
+      return new NestedField(isOptional, id, name, type, doc);
+    }
+
+    private final boolean isOptional;
+    private final int id;
+    private final String name;
+    private final Type type;
+    private final String doc;
+
+    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
+      Preconditions.checkNotNull(name, "Name cannot be null");
+      Preconditions.checkNotNull(type, "Type cannot be null");
+      this.isOptional = isOptional;
+      this.id = id;
+      this.name = name;
+      this.type = type;
+      this.doc = doc;
+    }
+
+    public boolean isOptional() {
+      return isOptional;
+    }
+
+    public NestedField asOptional() {
+      if (isOptional) {
+        return this;
+      }
+      return new NestedField(true, id, name, type, doc);
+    }
+
+    public boolean isRequired() {
+      return !isOptional;
+    }
+
+    public NestedField asRequired() {
+      if (!isOptional) {
+        return this;
+      }
+      return new NestedField(false, id, name, type, doc);
+    }
+
+    public int fieldId() {
+      return id;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public Type type() {
+      return type;
+    }
+
+    public String doc() {
+      return doc;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%d: %s: %s %s", id, name, isOptional ? "optional" : "required", type) +
+          (doc != null ? " (" + doc + ")" : "");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof NestedField)) {
+        return false;
+      }
+
+      NestedField that = (NestedField) o;
+      if (isOptional != that.isOptional) {
+        return false;
+      } else if (id != that.id) {
+        return false;
+      } else if (!name.equals(that.name)) {
+        return false;
+      } else if (!Objects.equals(doc, that.doc)) {
+        return false;
+      }
+      return type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(NestedField.class, id, isOptional, name, type);
+    }
+  }
+
+  public static class StructType extends NestedType {
+    private static final Joiner FIELD_SEP = Joiner.on(", ");
+
+    public static StructType of(NestedField... fields) {
+      return of(Arrays.asList(fields));
+    }
+
+    public static StructType of(List<NestedField> fields) {
+      return new StructType(fields);
+    }
+
+    private final NestedField[] fields;
+
+    // lazy values
+    private transient List<NestedField> fieldList = null;
+    private transient Map<String, NestedField> fieldsByName = null;
+    private transient Map<String, NestedField> fieldsByLowerCaseName = null;
+    private transient Map<Integer, NestedField> fieldsById = null;
+
+    private StructType(List<NestedField> fields) {
+      Preconditions.checkNotNull(fields, "Field list cannot be null");
+      this.fields = new NestedField[fields.size()];
+      for (int i = 0; i < this.fields.length; i += 1) {
+        this.fields[i] = fields.get(i);
+      }
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public NestedField field(String name) {
+      return lazyFieldsByName().get(name);
+    }
+
+    @Override
+    public NestedField field(int id) {
+      return lazyFieldsById().get(id);
+    }
+
+    public NestedField caseInsensitiveField(String name) {
+      return lazyFieldsByLowerCaseName().get(name.toLowerCase(Locale.ROOT));
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      NestedField field = field(name);
+      if (field != null) {
+        return field.type();
+      }
+      return null;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.STRUCT;
+    }
+
+    @Override
+    public boolean isStructType() {
+      return true;
+    }
+
+    @Override
+    public StructType asStructType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("struct<%s>", FIELD_SEP.join(fields));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof StructType)) {
+        return false;
+      }
+
+      StructType that = (StructType) o;
+      return Arrays.equals(fields, that.fields);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(NestedField.class, Arrays.hashCode(fields));
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fieldList == null) {
+        this.fieldList = ImmutableList.copyOf(fields);
+      }
+      return fieldList;
+    }
+
+    private Map<String, NestedField> lazyFieldsByName() {
+      if (fieldsByName == null) {
+        ImmutableMap.Builder<String, NestedField> byNameBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byNameBuilder.put(field.name(), field);
+        }
+        fieldsByName = byNameBuilder.build();
+      }
+      return fieldsByName;
+    }
+
+    private Map<String, NestedField> lazyFieldsByLowerCaseName() {
+      if (fieldsByLowerCaseName == null) {
+        ImmutableMap.Builder<String, NestedField> byLowerCaseNameBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byLowerCaseNameBuilder.put(field.name().toLowerCase(Locale.ROOT), field);
+        }
+        fieldsByLowerCaseName = byLowerCaseNameBuilder.build();
+      }
+      return fieldsByLowerCaseName;
+    }
+
+    private Map<Integer, NestedField> lazyFieldsById() {
+      if (fieldsById == null) {
+        ImmutableMap.Builder<Integer, NestedField> byIdBuilder = ImmutableMap.builder();
+        for (NestedField field : fields) {
+          byIdBuilder.put(field.fieldId(), field);
+        }
+        this.fieldsById = byIdBuilder.build();
+      }
+      return fieldsById;
+    }
+  }
+
+  public static class ListType extends NestedType {
+    public static ListType ofOptional(int elementId, Type elementType) {
+      Preconditions.checkNotNull(elementType, "Element type cannot be null");
+      return new ListType(NestedField.optional(elementId, "element", elementType));
+    }
+
+    public static ListType ofRequired(int elementId, Type elementType) {
+      Preconditions.checkNotNull(elementType, "Element type cannot be null");
+      return new ListType(NestedField.required(elementId, "element", elementType));
+    }
+
+    private final NestedField elementField;
+    private transient List<NestedField> fields = null;
+
+    private ListType(NestedField elementField) {
+      this.elementField = elementField;
+    }
+
+    public Type elementType() {
+      return elementField.type();
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      if ("element".equals(name)) {
+        return elementType();
+      }
+      return null;
+    }
+
+    @Override
+    public NestedField field(int id) {
+      if (elementField.fieldId() == id) {
+        return elementField;
+      }
+      return null;
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public int elementId() {
+      return elementField.fieldId();
+    }
+
+    public boolean isElementRequired() {
+      return !elementField.isOptional;
+    }
+
+    public boolean isElementOptional() {
+      return elementField.isOptional;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.LIST;
+    }
+
+    @Override
+    public boolean isListType() {
+      return true;
+    }
+
+    @Override
+    public ListType asListType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("list<%s>", elementField.type());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof ListType)) {
+        return false;
+      }
+
+      ListType listType = (ListType) o;
+      return elementField.equals(listType.elementField);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(ListType.class, elementField);
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fields == null) {
+        this.fields = ImmutableList.of(elementField);
+      }
+      return fields;
+    }
+  }
+
+  public static class MapType extends NestedType {
+    public static MapType ofOptional(int keyId, int valueId, Type keyType, Type valueType) {
+      Preconditions.checkNotNull(valueType, "Value type cannot be null");
+      return new MapType(
+          NestedField.required(keyId, "key", keyType),
+          NestedField.optional(valueId, "value", valueType));
+    }
+
+    public static MapType ofRequired(int keyId, int valueId, Type keyType, Type valueType) {
+      Preconditions.checkNotNull(valueType, "Value type cannot be null");
+      return new MapType(
+          NestedField.required(keyId, "key", keyType),
+          NestedField.required(valueId, "value", valueType));
+    }
+
+    private final NestedField keyField;
+    private final NestedField valueField;
+    private transient List<NestedField> fields = null;
+
+    private MapType(NestedField keyField, NestedField valueField) {
+      this.keyField = keyField;
+      this.valueField = valueField;
+    }
+
+    public Type keyType() {
+      return keyField.type();
+    }
+
+    public Type valueType() {
+      return valueField.type();
+    }
+
+    @Override
+    public Type fieldType(String name) {
+      if ("key".equals(name)) {
+        return keyField.type();
+      } else if ("value".equals(name)) {
+        return valueField.type();
+      }
+      return null;
+    }
+
+    @Override
+    public NestedField field(int id) {
+      if (keyField.fieldId() == id) {
+        return keyField;
+      } else if (valueField.fieldId() == id) {
+        return valueField;
+      }
+      return null;
+    }
+
+    @Override
+    public List<NestedField> fields() {
+      return lazyFieldList();
+    }
+
+    public int keyId() {
+      return keyField.fieldId();
+    }
+
+    public int valueId() {
+      return valueField.fieldId();
+    }
+
+    public boolean isValueRequired() {
+      return !valueField.isOptional;
+    }
+
+    public boolean isValueOptional() {
+      return valueField.isOptional;
+    }
+
+    @Override
+    public TypeID typeId() {
+      return TypeID.MAP;
+    }
+
+    @Override
+    public boolean isMapType() {
+      return true;
+    }
+
+    @Override
+    public MapType asMapType() {
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("map<%s, %s>", keyField.type(), valueField.type());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof MapType)) {
+        return false;
+      }
+
+      MapType mapType = (MapType) o;
+      if (!keyField.equals(mapType.keyField)) {
+        return false;
+      }
+      return valueField.equals(mapType.valueField);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(MapType.class, keyField, valueField);
+    }
+
+    private List<NestedField> lazyFieldList() {
+      if (fields == null) {
+        this.fields = ImmutableList.of(keyField, valueField);
+      }
+      return fields;
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?

Create an Iceberg table that has a timestamp-type column with a precision equal to 0 by Flink SQL.

Using the below DDL to create a watermark definition table like the iceberg table would be failed.
```create table hadoop_catalog.db.dim (id int, name string, opt timestamp(0), primary key (id) not enforced) ;```

```create table arctic_dim ( watermark for opt as opt - interval '5' second) like hadoop_catalog.db.dim;```

org.apache.flink.table.api.ValidationException: Invalid data type of time field for watermark definition. The field must be of type TIMESTAMP(p) or TIMESTAMP_LTZ(p), the supported precision 'p' is from 0 to 3, but the time field type is TIMESTAMP(6)

The [TypeToFlinkType](https://github.com/apache/iceberg/blob/master/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java#L111) default converts it to Flink timestamp type with precision 6.

Fix #34 .

## Brief change log

- Overwrite the `Types`, `FlinkTypeToType` and `TypeToFlinkType` class in Iceberg to covert the timestamp type with precision.

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)