### PR TITLE
[ARCTIC-205][Flink] Throw the NoSuchTableException when the default catalog is an Arctic catalog in Flink SQL

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -158,6 +158,9 @@ public class ArcticCatalog extends AbstractCatalog {
   @Override
   public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
     TableIdentifier tableIdentifier = getTableIdentifier(tablePath);
+    if (!internalCatalog.tableExists(tableIdentifier)) {
+      throw new TableNotExistException(this.getName(), tablePath);
+    }
     ArcticTable table = internalCatalog.loadTable(tableIdentifier);
     Schema arcticSchema = table.schema();
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -160,6 +160,9 @@ public class ArcticCatalog extends AbstractCatalog {
   @Override
   public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
     TableIdentifier tableIdentifier = getTableIdentifier(tablePath);
+    if (!internalCatalog.tableExists(tableIdentifier)) {
+      throw new TableNotExistException(this.getName(), tablePath);
+    }
     ArcticTable table = internalCatalog.loadTable(tableIdentifier);
     Schema arcticSchema = table.schema();
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -160,6 +160,9 @@ public class ArcticCatalog extends AbstractCatalog {
   @Override
   public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
     TableIdentifier tableIdentifier = getTableIdentifier(tablePath);
+    if (!internalCatalog.tableExists(tableIdentifier)) {
+      throw new TableNotExistException(this.getName(), tablePath);
+    }
     ArcticTable table = internalCatalog.loadTable(tableIdentifier);
     Schema arcticSchema = table.schema();
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
```
Flink SQL> create catalog arctic with (

'type' ='arctic',
'metastore.url'='thrift://****/bdms_test_catalog');

Flink SQL> use catalog arctic;
[INFO] Execute statement succeed.

Flink SQL> use db;
[INFO] Execute statement succeed.

Flink SQL> show tables;
+----------------------+
| table name |
+----------------------+
| log_tab |
| log_table |
| log_table_outofindex |
| table_name |
+----------------------+
4 rows in set

Flink SQL> insert into log_table_outofindex /+ OPTIONS('arctic.emit.mode'='log')/ select id, '1', LOCALTIMESTAMP from default_catalog.default_database.source;
[ERROR] Could not execute SQL statement. Reason:
com.netease.arctic.shaded.org.apache.iceberg.exceptions.NoSuchTableException: load table failed bdms_test_catalog.db.default_catalog.

Flink SQL> use catalog default_catalog;
[INFO] Execute statement succeed.

Flink SQL> insert into arctic.db.log_table_outofindex /+ OPTIONS('arctic.emit.mode'='log')/ select id, '1', LOCALTIMESTAMP from default_catalog.default_database.source;

[INFO] Submitting SQL update statement to the cluster...
[INFO] SQL update statement has been successfully submitted to the cluster:
Job ID: 5ae484bc04ca630e5b4540168ee45e50

Flink SQL> show tables;
+------------+
| table name |
+------------+
| source |
+------------+
1 row in set
```
The `CatalogManager` catches the `TableNotExistException` when getting the table. Hence the `getTable` method of the `ArcticCatalog` should throw the `TableNotExistException` not `NoSuchTableException` when the given table doesn't exist.

Fix #205.

## Brief change log

  - The `getTable` method of the `ArcticCatalog` should throw the `TableNotExistException` if the given table doesn't exist.

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)