### PR TITLE
[ARCTIC-272][Flink] Sync Flink temporal join Arctic table to Flink 1.15

### DIFF
--- a/flink/v1.15/flink/pom.xml
+++ b/flink/v1.15/flink/pom.xml
@@ -334,6 +334,21 @@
             <scope>test</scope>
         </dependency>
 
+        <!--   for values test connector     -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- conflicts with the version in spring-cloud, so assign it explicitly here -->
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
@@ -19,11 +19,15 @@
 package com.netease.arctic.flink;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.WatermarkSpec;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * An util that converts flink table schema.
@@ -45,6 +49,77 @@ public class FlinkSchemaUtil {
       builder.primaryKey(primaryKeys.toArray(new String[0]));
     }
     return builder.build();
+  }
+
+  /**
+   * Add watermark info to help {@link com.netease.arctic.flink.table.FlinkSource}
+   * and {@link com.netease.arctic.flink.table.ArcticDynamicSource} distinguish the watermark field.
+   * For now, it only be used in the case of Arctic as dim-table.
+   */
+  public static TableSchema getPhysicalSchema(TableSchema tableSchema, boolean addWatermark) {
+    if (!addWatermark) {
+      return tableSchema;
+    }
+    TableSchema.Builder builder = filter(tableSchema, TableColumn::isPhysical);
+    tableSchema.getWatermarkSpecs().forEach(builder::watermark);
+    return builder.build();
+  }
+
+  /**
+   * filter watermark due to watermark is a virtual field for now, not in arctic physical table.
+   */
+  public static TableSchema filterWatermark(TableSchema tableSchema) {
+    List<WatermarkSpec> watermarkSpecs = tableSchema.getWatermarkSpecs();
+    if (watermarkSpecs.isEmpty()) {
+      return tableSchema;
+    }
+
+    Function<TableColumn, Boolean> filter = (tableColumn) -> {
+      boolean isWatermark = false;
+      for (WatermarkSpec spec : watermarkSpecs) {
+        if (spec.getRowtimeAttribute().equals(tableColumn.getName())) {
+          isWatermark = true;
+          break;
+        }
+      }
+      return !isWatermark;
+    };
+    return filter(tableSchema, filter).build();
+  }
+
+  /**
+   * If filter result is true, keep the column; otherwise, remove the column.
+   */
+  public static TableSchema.Builder filter(TableSchema tableSchema, Function<TableColumn, Boolean> filter) {
+    TableSchema.Builder builder = TableSchema.builder();
+
+    tableSchema
+        .getTableColumns()
+        .forEach(
+            tableColumn -> {
+              if (!filter.apply(tableColumn)) {
+                return;
+              }
+              builder.field(tableColumn.getName(), tableColumn.getType());
+            });
+    tableSchema
+        .getPrimaryKey()
+        .ifPresent(
+            uniqueConstraint ->
+                builder.primaryKey(
+                    uniqueConstraint.getName(),
+                    uniqueConstraint.getColumns().toArray(new String[0])));
+    return builder;
+  }
+
+  public static RowType toRowType(TableSchema tableSchema) {
+    LogicalType[] fields = new LogicalType[tableSchema.getFieldCount()];
+
+    for (int i = 0; i < fields.length; i++) {
+      TableColumn tableColumn = tableSchema.getTableColumn(i).get();
+      fields[i] = tableColumn.getType().getLogicalType();
+    }
+    return RowType.of(fields);
   }
 
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/InternalCatalogBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/InternalCatalogBuilder.java
@@ -39,6 +39,14 @@ public class InternalCatalogBuilder implements Serializable {
     return CatalogLoader.load(metastoreUrl, properties);
   }
 
+  public String getMetastoreUrl() {
+    return metastoreUrl;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
   public InternalCatalogBuilder() {
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -18,9 +18,12 @@
 
 package com.netease.arctic.flink.catalog;
 
+import com.google.common.base.Objects;
 import com.netease.arctic.NoSuchDatabaseException;
 import com.netease.arctic.flink.InternalCatalogBuilder;
+import com.netease.arctic.flink.catalog.factories.ArcticCatalogFactoryOptions;
 import com.netease.arctic.flink.table.DynamicTableFactory;
+import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.PrimaryKeySpec;
@@ -28,6 +31,7 @@ import com.netease.arctic.table.TableBuilder;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.WatermarkSpec;
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
@@ -68,12 +72,19 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC;
+import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 
 /**
  * Catalogs for arctic data lake.
  */
 public class ArcticCatalog extends AbstractCatalog {
   public static final String DEFAULT_DB = "default";
+
+  /**
+   * To distinguish 'CREATE TABLE LIKE' by checking stack
+   * {@link org.apache.flink.table.planner.operations.SqlCreateTableConverter#lookupLikeSourceTable}
+   */
+  public static final String SQL_LIKE_METHOD = "lookupLikeSourceTable";
 
   private final InternalCatalogBuilder catalogBuilder;
 
@@ -169,6 +180,7 @@ public class ArcticCatalog extends AbstractCatalog {
     RowType rowType = FlinkSchemaUtil.convert(arcticSchema);
     Map<String, String> arcticProperties = Maps.newHashMap(table.properties());
     fillTableProperties(arcticProperties);
+    fillTableMetaPropertiesIfLookupLike(arcticProperties, tableIdentifier);
 
     List<String> partitionKeys = toPartitionKeys(table.spec(), table.schema());
     return new CatalogTableImpl(
@@ -176,6 +188,35 @@ public class ArcticCatalog extends AbstractCatalog {
         partitionKeys,
         arcticProperties,
         null);
+  }
+
+  /**
+   * For now, 'CREATE TABLE LIKE' would be treated as the case which users want to add watermark in temporal join,
+   * as an alternative of lookup join, and use Arctic table as build table, i.e. right table.
+   * So the properties those required in temporal join will be put automatically.
+   * <p>
+   * If you don't want the properties, 'EXCLUDING ALL' is what you need.
+   * More details @see <a href="https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/create/#like">LIKE</a>
+   */
+  private void fillTableMetaPropertiesIfLookupLike(Map<String, String> properties, TableIdentifier tableIdentifier) {
+    StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+    boolean isLookupLike = false;
+    for (StackTraceElement stackTraceElement : stackTraceElements) {
+      if (Objects.equal(SQL_LIKE_METHOD, stackTraceElement.getMethodName())) {
+        isLookupLike = true;
+        break;
+      }
+    }
+
+    if (!isLookupLike) {
+      return;
+    }
+
+    properties.put(CONNECTOR.key(), DynamicTableFactory.IDENTIFIER);
+    properties.put(ArcticValidator.ARCTIC_CATALOG.key(), tableIdentifier.getCatalog());
+    properties.put(ArcticValidator.ARCTIC_TABLE.key(), tableIdentifier.getTableName());
+    properties.put(ArcticValidator.ARCTIC_DATABASE.key(), tableIdentifier.getDatabase());
+    properties.put(ArcticCatalogFactoryOptions.METASTORE_URL.key(), catalogBuilder.getMetastoreUrl());
   }
 
   private static List<String> toPartitionKeys(PartitionSpec spec, Schema icebergSchema) {
@@ -253,7 +294,20 @@ public class ArcticCatalog extends AbstractCatalog {
     validateFlinkTable(table);
 
     TableSchema tableSchema = table.getSchema();
-    Schema icebergSchema = FlinkSchemaUtil.convert(tableSchema);
+    TableSchema.Builder b = TableSchema.builder();
+
+    tableSchema.getTableColumns().forEach(c -> {
+      List<WatermarkSpec> ws = tableSchema.getWatermarkSpecs();
+      for (WatermarkSpec w : ws) {
+        if (w.getRowtimeAttribute().equals(c.getName())) {
+          return;
+        }
+      }
+      b.field(c.getName(), c.getType());
+    });
+    TableSchema tableSchemaWithoutWatermark = b.build();
+
+    Schema icebergSchema = FlinkSchemaUtil.convert(tableSchemaWithoutWatermark);
 
     TableBuilder tableBuilder = internalCatalog.newTableBuilder(
         getTableIdentifier(tablePath), icebergSchema);
@@ -295,9 +349,6 @@ public class ArcticCatalog extends AbstractCatalog {
       }
     });
 
-    if (!schema.getWatermarkSpecs().isEmpty()) {
-      throw new UnsupportedOperationException("Creating table with watermark specs is not supported yet.");
-    }
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/metric/MetricConstant.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/metric/MetricConstant.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.metric;
+
+/**
+ * metric constant
+ */
+public class MetricConstant {
+
+  /**
+   * The start time of arctic table's initialization when it used as build table in temporal join.
+   */
+  public static final String TEMPORAL_TABLE_INITIALIZATION_START_TIMESTAMP =
+      "temporalTableInitializationStartTimestamp";
+  /**
+   * The end time of arctic table's initialization when it used as build table in temporal join.
+   */
+  public static final String TEMPORAL_TABLE_INITIALIZATION_END_TIMESTAMP = "temporalTableInitializationEndTimestamp";
+
+}

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/metric/MetricsGenerator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/metric/MetricsGenerator.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.write;
+package com.netease.arctic.flink.metric;
 
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/AdaptHiveFlinkParquetReaders.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/AdaptHiveFlinkParquetReaders.java
@@ -385,8 +385,8 @@ public class AdaptHiveFlinkParquetReaders {
     public TimestampData read(TimestampData ignored) {
       long value = readLong();
       return TimestampData.fromLocalDateTime(Instant.ofEpochSecond(
-              Math.floorDiv(value, 1000_000),
-              Math.floorMod(value, 1000_000) * 1000)
+              Math.floorDiv(value, 1000_000L),
+              Math.floorMod(value, 1000_000L) * 1000)
           .atOffset(ZoneOffset.UTC)
           .toLocalDateTime());
     }
@@ -406,8 +406,8 @@ public class AdaptHiveFlinkParquetReaders {
     public TimestampData read(TimestampData ignored) {
       long value = readLong();
       return TimestampData.fromInstant(Instant.ofEpochSecond(
-          Math.floorDiv(value, 1000_000),
-          Math.floorMod(value, 1000_000) * 1000));
+          Math.floorDiv(value, 1000_000L),
+          Math.floorMod(value, 1000_000L) * 1000));
     }
 
     @Override
@@ -478,7 +478,7 @@ public class AdaptHiveFlinkParquetReaders {
     @Override
     public Integer read(Integer reuse) {
       // Discard microseconds since Flink uses millisecond unit for TIME type.
-      return (int) Math.floorDiv(column.nextLong(), 1000);
+      return (int) Math.floorDiv(column.nextLong(), 1000L);
     }
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumState.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumState.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read.hybrid.enumerator;
 
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplitState;
+import com.netease.arctic.flink.read.hybrid.split.TemporalJoinSplits;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -33,14 +34,18 @@ public class ArcticSourceEnumState {
   private final Collection<ArcticSplitState> pendingSplits;
   @Nullable
   private final long[] shuffleSplitRelation;
+  @Nullable
+  private final TemporalJoinSplits temporalJoinSplits;
 
   public ArcticSourceEnumState(
       Collection<ArcticSplitState> pendingSplits,
       @Nullable ArcticEnumeratorOffset lastEnumeratedOffset,
-      @Nullable long[] shuffleSplitRelation) {
+      @Nullable long[] shuffleSplitRelation,
+      @Nullable TemporalJoinSplits temporalJoinSplits) {
     this.pendingSplits = pendingSplits;
     this.lastEnumeratedOffset = lastEnumeratedOffset;
     this.shuffleSplitRelation = shuffleSplitRelation;
+    this.temporalJoinSplits = temporalJoinSplits;
   }
 
   @Nullable
@@ -55,5 +60,10 @@ public class ArcticSourceEnumState {
   @Nullable
   public long[] shuffleSplitRelation() {
     return shuffleSplitRelation;
+  }
+
+  @Nullable
+  public TemporalJoinSplits temporalJoinSplits() {
+    return temporalJoinSplits;
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumStateSerializer.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumStateSerializer.java
@@ -21,10 +21,14 @@ package com.netease.arctic.flink.read.hybrid.enumerator;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplitSerializer;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplitState;
+import com.netease.arctic.flink.read.hybrid.split.TemporalJoinSplits;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.util.InstantiationUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -34,6 +38,8 @@ import java.util.Objects;
  * Serializer that serializes and deserializes arctic enumerator {@link ArcticSourceEnumState}.
  */
 public class ArcticSourceEnumStateSerializer implements SimpleVersionedSerializer<ArcticSourceEnumState> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ArcticSourceEnumStateSerializer.class);
   private static final int VERSION = 1;
   private final ArcticSplitSerializer splitSerializer = ArcticSplitSerializer.INSTANCE;
   private final ArcticEnumeratorOffsetSerializer offsetSerializer = ArcticEnumeratorOffsetSerializer.INSTANCE;
@@ -77,6 +83,13 @@ public class ArcticSourceEnumStateSerializer implements SimpleVersionedSerialize
       for (long l : shuffleSplitRelation) {
         out.writeLong(l);
       }
+    }
+
+    out.writeBoolean(enumState.temporalJoinSplits() != null);
+    if (enumState.temporalJoinSplits() != null) {
+      byte[] temporalJoinSplits = InstantiationUtil.serializeObject(enumState.temporalJoinSplits());
+      out.writeInt(temporalJoinSplits.length);
+      out.write(temporalJoinSplits);
     }
 
     byte[] result = out.getCopyOfBuffer();
@@ -123,7 +136,18 @@ public class ArcticSourceEnumStateSerializer implements SimpleVersionedSerialize
         shuffleSplitRelation[i] = in.readLong();
       }
     }
-    return new ArcticSourceEnumState(pendingSplits, enumeratorOffset, shuffleSplitRelation);
 
+    TemporalJoinSplits temporalJoinSplits = null;
+    if (in.readBoolean()) {
+      byte[] bytes = new byte[in.readInt()];
+      in.read(bytes);
+      try {
+        temporalJoinSplits = InstantiationUtil.deserializeObject(bytes, TemporalJoinSplits.class.getClassLoader());
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException("deserialize FirstSplit error", e);
+      }
+    }
+
+    return new ArcticSourceEnumState(pendingSplits, enumeratorOffset, shuffleSplitRelation, temporalJoinSplits);
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -22,9 +22,12 @@ import com.netease.arctic.flink.read.hybrid.assigner.ShuffleSplitAssigner;
 import com.netease.arctic.flink.read.hybrid.assigner.SplitAssigner;
 import com.netease.arctic.flink.read.hybrid.reader.HybridSplitReader;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
+import com.netease.arctic.flink.read.hybrid.split.SplitRequestEvent;
+import com.netease.arctic.flink.read.hybrid.split.TemporalJoinSplits;
 import com.netease.arctic.flink.read.source.ArcticScanContext;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.table.KeyedTable;
+import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.iceberg.Snapshot;
@@ -33,8 +36,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
 
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.FILE_SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.FILE_SCAN_STARTUP_MODE_LATEST;
@@ -46,12 +51,28 @@ import static com.netease.arctic.flink.util.ArcticUtils.loadArcticTable;
 public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
   private static final Logger LOG = LoggerFactory.getLogger(ArcticSourceEnumerator.class);
   private transient KeyedTable keyedTable;
+  /**
+   * To record the snapshotId at the first planSplits.
+   * <p>
+   * If its value is null, it means that we don't need to generate watermark. Won't check.
+   */
+  private transient volatile TemporalJoinSplits temporalJoinSplits = null;
   private final ArcticTableLoader loader;
   private final SplitEnumeratorContext<ArcticSplit> context;
   private final ContinuousSplitPlanner continuousSplitPlanner;
   private final SplitAssigner splitAssigner;
   private final ArcticScanContext scanContext;
   private final long snapshotDiscoveryIntervalMs;
+  /**
+   * If true, using arctic table as build table.
+   * {@link ArcticSourceEnumerator} will notify {@link com.netease.arctic.flink.read.hybrid.reader.ArcticSourceReader}
+   * after ArcticReaders have finished reading all {@link TemporalJoinSplits}.
+   * Then {@link com.netease.arctic.flink.read.hybrid.reader.ArcticSourceReader} will emit a Watermark values
+   * Long.MAX_VALUE. Advancing TemporalJoinOperator's watermark can trigger the join operation and push the results to
+   * downstream. The watermark of Long.MAX_VALUE avoids affecting the watermark defined by user arbitrary  probe side
+   */
+  private final boolean dimTable;
+  private volatile boolean sourceEventBeforeFirstPlan = false;
   /**
    * snapshotId for the last enumerated snapshot. next incremental enumeration
    * should be based off this as the starting position.
@@ -65,7 +86,8 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
       SplitAssigner splitAssigner,
       ArcticTableLoader loader,
       ArcticScanContext scanContext,
-      @Nullable ArcticSourceEnumState enumState) {
+      @Nullable ArcticSourceEnumState enumState,
+      boolean dimTable) {
     super(enumContext, splitAssigner);
     this.loader = loader;
     this.context = enumContext;
@@ -76,7 +98,9 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
     this.enumeratorPosition = new AtomicReference<>();
     if (enumState != null) {
       this.enumeratorPosition.set(enumState.lastEnumeratedOffset());
+      this.temporalJoinSplits = enumState.temporalJoinSplits();
     }
+    this.dimTable = dimTable;
   }
 
   @Override
@@ -119,6 +143,18 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
   }
 
   private ContinuousEnumerationResult planSplits() {
+    ContinuousEnumerationResult result = doPlanSplits();
+    if (dimTable && temporalJoinSplits == null) {
+      temporalJoinSplits = new TemporalJoinSplits(result.splits(), context.metricGroup());
+      // the first SourceEvent may be faster than plan splits
+      if (result.isEmpty() && sourceEventBeforeFirstPlan) {
+        notifyReaders();
+      }
+    }
+    return result;
+  }
+
+  private ContinuousEnumerationResult doPlanSplits() {
     if (lock.get()) {
       LOG.info("prefix plan splits thread haven't finished.");
       return ContinuousEnumerationResult.EMPTY;
@@ -144,12 +180,56 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
   }
 
   @Override
+  public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+    super.handleSourceEvent(subtaskId, sourceEvent);
+    if (sourceEvent instanceof SplitRequestEvent) {
+      SplitRequestEvent splitRequestEvent = (SplitRequestEvent) sourceEvent;
+      Collection<String> finishedSplitIds = splitRequestEvent.finishedSplitIds();
+      if (dimTable) {
+        checkAndNotifyReader(finishedSplitIds);
+      }
+    } else {
+      throw new IllegalArgumentException(String.format("Received unknown event from subtask %d: %s",
+          subtaskId, sourceEvent.getClass().getCanonicalName()));
+    }
+  }
+
+  /**
+   * Check whether all first splits have been finished or not.
+   * After all finished, enumerator will send a {@link InitializationFinishedEvent} to notify all
+   * {@link com.netease.arctic.flink.read.hybrid.reader.ArcticSourceReader}.
+   *
+   * @param finishedSplitIds
+   */
+  public void checkAndNotifyReader(Collection<String> finishedSplitIds) {
+    if (temporalJoinSplits == null) {
+      sourceEventBeforeFirstPlan = true;
+      return;
+    }
+
+    if (temporalJoinSplits.hasNotifiedReader() ||
+        !temporalJoinSplits.removeAndReturnIfAllFinished(finishedSplitIds)) {
+      return;
+    }
+    notifyReaders();
+  }
+
+  private void notifyReaders() {
+    LOG.info("all splits finished, send events to readers");
+    IntStream.range(0, context.currentParallelism())
+        .forEach(i -> context.sendEventToSourceReader(i, InitializationFinishedEvent.INSTANCE));
+    temporalJoinSplits.clear();
+    temporalJoinSplits.notifyReader();
+  }
+
+  @Override
   public ArcticSourceEnumState snapshotState(long checkpointId) throws Exception {
     long[] shuffleSplitRelation = null;
     if (splitAssigner instanceof ShuffleSplitAssigner) {
       shuffleSplitRelation = ((ShuffleSplitAssigner) splitAssigner).serializePartitionIndex();
     }
-    return new ArcticSourceEnumState(splitAssigner.state(), enumeratorPosition.get(), shuffleSplitRelation);
+    return new ArcticSourceEnumState(splitAssigner.state(), enumeratorPosition.get(), shuffleSplitRelation,
+        temporalJoinSplits);
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/InitializationFinishedEvent.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/InitializationFinishedEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.hybrid.enumerator;
+
+import com.netease.arctic.flink.read.hybrid.reader.ArcticSourceReader;
+import org.apache.flink.api.connector.source.SourceEvent;
+
+/**
+ * {@link ArcticSourceReader} won't set timestamp to RowData until receiving this Event.
+ */
+public class InitializationFinishedEvent implements SourceEvent {
+  private static final long serialVersionUID = 1L;
+
+  public static final InitializationFinishedEvent INSTANCE = new InitializationFinishedEvent();
+}

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/StaticArcticSourceEnumerator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/StaticArcticSourceEnumerator.java
@@ -84,6 +84,6 @@ public class StaticArcticSourceEnumerator extends AbstractArcticEnumerator {
 
   @Override
   public ArcticSourceEnumState snapshotState(long checkpointId) throws Exception {
-    return new ArcticSourceEnumState(assigner.state(), null, null);
+    return new ArcticSourceEnumState(assigner.state(), null, null, null);
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/reader/ArcticSourceReader.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/reader/ArcticSourceReader.java
@@ -19,13 +19,20 @@
 package com.netease.arctic.flink.read.hybrid.reader;
 
 import com.netease.arctic.flink.read.ArcticSource;
+import com.netease.arctic.flink.read.hybrid.enumerator.InitializationFinishedEvent;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplitState;
 import com.netease.arctic.flink.read.hybrid.split.SplitRequestEvent;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -36,16 +43,27 @@ import java.util.Map;
  */
 public class ArcticSourceReader<T> extends
     SingleThreadMultiplexSourceReaderBase<ArcticRecordWithOffset<T>, T, ArcticSplit, ArcticSplitState> {
+
+  public static final Logger LOGGER = LoggerFactory.getLogger(ArcticSourceReader.class);
+
+  public ReaderOutput<T> output;
+  /**
+   * SourceEvents may be received before this#pollNext.
+   */
+  private volatile boolean maxWatermarkToBeEmitted = false;
+
+
   public ArcticSourceReader(
       ReaderFunction<T> readerFunction,
       Configuration config,
-      SourceReaderContext context) {
+      SourceReaderContext context,
+      boolean populateRowTime) {
     super(
         () -> new HybridSplitReader<>(
             readerFunction,
             context
         ),
-        new ArcticRecordEmitter<>(),
+        new ArcticRecordEmitter<T>(populateRowTime),
         config,
         context);
   }
@@ -77,4 +95,31 @@ public class ArcticSourceReader<T> extends
   private void requestSplit(Collection<String> finishedSplitIds) {
     context.sendSourceEventToCoordinator(new SplitRequestEvent(finishedSplitIds));
   }
+
+  @Override
+  public void handleSourceEvents(SourceEvent sourceEvent) {
+    if (!(sourceEvent instanceof InitializationFinishedEvent)) {
+      return;
+    }
+    LOGGER.info("receive InitializationFinishedEvent");
+    maxWatermarkToBeEmitted = true;
+    emitWatermarkIfNeeded();
+  }
+
+  private void emitWatermarkIfNeeded() {
+    if (this.output == null || !maxWatermarkToBeEmitted) {
+      return;
+    }
+    LOGGER.info("emit watermark");
+    output.emitWatermark(new Watermark(Long.MAX_VALUE));
+    maxWatermarkToBeEmitted = false;
+  }
+
+  @Override
+  public InputStatus pollNext(ReaderOutput<T> output) throws Exception {
+    this.output = output;
+    emitWatermarkIfNeeded();
+    return super.pollNext(output);
+  }
+
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/TemporalJoinSplits.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/TemporalJoinSplits.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.hybrid.split;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.netease.arctic.flink.metric.MetricConstant.TEMPORAL_TABLE_INITIALIZATION_END_TIMESTAMP;
+import static com.netease.arctic.flink.metric.MetricConstant.TEMPORAL_TABLE_INITIALIZATION_START_TIMESTAMP;
+
+/**
+ * If using arctic table as build-table, TemporalJoinSplits can record the first splits planned by Enumerator.
+ */
+public class TemporalJoinSplits implements Serializable {
+
+  public static final long serialVersionUID = 1L;
+  public static final Logger LOGGER = LoggerFactory.getLogger(TemporalJoinSplits.class);
+
+  private final MetricGroup metricGroup;
+  private final long startTimeMs = System.currentTimeMillis();
+  private Map<String, Boolean> splits;
+  private long unfinishedCount;
+  /**
+   * transient because it is necessary to notify reader again after failover.
+   */
+  private transient boolean hasNotifiedReader = false;
+
+  public TemporalJoinSplits(Collection<ArcticSplit> splits, MetricGroup metricGroup) {
+    Preconditions.checkNotNull(splits, "plan splits should not be null");
+    this.splits = splits.stream().map(SourceSplit::splitId).collect(Collectors.toMap((k) -> k, (i) -> false));
+
+    unfinishedCount = this.splits.size();
+    LOGGER.info("init splits at {}, size:{}", LocalDateTime.now(), unfinishedCount);
+    this.metricGroup = metricGroup;
+    if (metricGroup != null) {
+      metricGroup.gauge(TEMPORAL_TABLE_INITIALIZATION_START_TIMESTAMP, () -> startTimeMs);
+    }
+  }
+
+  public Map<String, Boolean> getSplits() {
+    return splits;
+  }
+
+  public synchronized void addSplitsBack(Collection<ArcticSplit> splits) {
+    if (this.splits == null || CollectionUtil.isNullOrEmpty(splits)) {
+      return;
+    }
+    splits.forEach((p) -> {
+      Boolean finished = this.splits.get(p.splitId());
+      if (finished == null || !finished) {
+        return;
+      }
+      unfinishedCount++;
+      LOGGER.debug("add back split:{} at {}", p, LocalDateTime.now());
+      this.splits.put(p.splitId(), false);
+    });
+  }
+
+  /**
+   * Remove finished splits.
+   *
+   * @return True if all splits are finished, otherwise false.
+   */
+  public synchronized boolean removeAndReturnIfAllFinished(Collection<String> finishedSplitIds) {
+    if (splits == null) {
+      return true;
+    }
+    if (CollectionUtil.isNullOrEmpty(finishedSplitIds)) {
+      return unfinishedCount == 0;
+    }
+
+    finishedSplitIds.forEach((p) -> {
+      Boolean finished = this.splits.get(p);
+      if (finished == null || finished) {
+        return;
+      }
+      unfinishedCount--;
+      this.splits.put(p, true);
+      LOGGER.debug("finish split:{} at {}", p, LocalDateTime.now());
+    });
+    if (unfinishedCount == 0) {
+      LOGGER.info("finish all splits at {}", LocalDateTime.now());
+      if (metricGroup != null) {
+        metricGroup.gauge(TEMPORAL_TABLE_INITIALIZATION_END_TIMESTAMP, System::currentTimeMillis);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  public synchronized void clear() {
+    if (unfinishedCount == 0) {
+      this.splits = null;
+    }
+  }
+
+  public boolean hasNotifiedReader() {
+    return hasNotifiedReader;
+  }
+
+  public void notifyReader() {
+    this.hasNotifiedReader = true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TemporalJoinSplits that = (TemporalJoinSplits) o;
+    return startTimeMs == that.startTimeMs &&
+        unfinishedCount == that.unfinishedCount &&
+        hasNotifiedReader == that.hasNotifiedReader &&
+        Objects.equals(metricGroup, that.metricGroup) &&
+        Objects.equals(splits, that.splits);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metricGroup, startTimeMs, splits, unfinishedCount, hasNotifiedReader);
+  }
+
+}

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -52,6 +52,7 @@ public class ShuffleHelper implements Serializable {
     if (table.spec() != null && !CollectionUtil.isNullOrEmpty(table.spec().fields())) {
       partitionKey = new PartitionKey(table.spec(), schema);
     }
+    schema = addFieldsNotInArctic(schema, rowType);
 
     if (table.isUnkeyedTable()) {
       return new ShuffleHelper(rowType, schema.asStruct(), partitionKey);
@@ -61,6 +62,29 @@ public class ShuffleHelper implements Serializable {
     PrimaryKeyData primaryKeyData = new PrimaryKeyData(keyedTable.primaryKeySpec(), schema);
     return new ShuffleHelper(keyedTable.primaryKeySpec().primaryKeyExisted(),
         primaryKeyData, partitionKey, rowType, schema.asStruct());
+  }
+
+  /**
+   * If using arctic table as build table, there will be an additional implicit field, valuing process time.
+   *
+   * @param schema  The physical schema in Arctic table
+   * @param rowType Flink RowData type.
+   * @return the Arctic Schema with additional implicit field.
+   */
+  public static Schema addFieldsNotInArctic(Schema schema, RowType rowType) {
+    Types.NestedField[] nestedFields = new Types.NestedField[rowType.getFieldCount()];
+
+    for (int i = 0; i < nestedFields.length; i++) {
+      RowType.RowField field = rowType.getFields().get(i);
+      Types.NestedField nestedField;
+      if ((nestedField = schema.findField(field.getName())) != null) {
+        nestedFields[i] = nestedField;
+      } else {
+        // for now, there is only one case that virtual watermark exist in RowData, but not in Arctic table schema.
+        nestedFields[i] = Types.NestedField.optional(-1, field.getName(), Types.TimestampType.withoutZone());
+      }
+    }
+    return new Schema(nestedFields);
   }
 
   /**

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_MODE;
@@ -113,7 +114,8 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     } else {
       flinkSchemaRowType = (RowType) projectedSchema.toRowDataType().getLogicalType();
-      readSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(projectedSchema), arcticTable.schema());
+      readSchema = TypeUtil.reassignIds(
+          FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema());
     }
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -20,6 +20,7 @@ package com.netease.arctic.flink.table;
 
 import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
@@ -48,6 +49,8 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
  * Flink table api that generates arctic base/change file source operators.
@@ -203,6 +206,10 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
 
   @Override
   public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
-    this.watermarkStrategy = watermarkStrategy;
+    Configuration conf = Configuration.fromMap(table.properties());
+    boolean dimTable = conf.get(DIM_TABLE_ENABLE);
+    if (!dimTable) {
+      this.watermarkStrategy = watermarkStrategy;
+    }
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -44,14 +44,20 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.source.FlinkInputFormat;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.PropertyUtil;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
+import static com.netease.arctic.flink.FlinkSchemaUtil.toRowType;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
  * An util class create arctic source data stream.
@@ -148,7 +154,7 @@ public class FlinkSource {
       if (projectedSchema == null) {
         contextBuilder.project(arcticTable.schema());
       } else {
-        contextBuilder.project(FlinkSchemaUtil.convert(arcticTable.schema(), projectedSchema));
+        contextBuilder.project(FlinkSchemaUtil.convert(arcticTable.schema(), filterWatermark(projectedSchema)));
       }
       contextBuilder.fromProperties(properties);
       ArcticScanContext scanContext = contextBuilder.build();
@@ -162,9 +168,24 @@ public class FlinkSource {
           scanContext.caseSensitive(),
           arcticTable.io()
       );
+
+      boolean dimTable = PropertyUtil.propertyAsBoolean(properties, DIM_TABLE_ENABLE.key(),
+          DIM_TABLE_ENABLE.defaultValue());
+      RowType rowType;
+      if (projectedSchema != null) {
+        // If dim table is enabled, we reserve a RowTime field in Emitter.
+        if (dimTable) {
+          rowType = toRowType(projectedSchema);
+        } else {
+          rowType = toRowType(filterWatermark(projectedSchema));
+        }
+      } else {
+        rowType = FlinkSchemaUtil.convert(scanContext.project());
+      }
+
       DataStreamSource<RowData> sourceStream = env.fromSource(
           new ArcticSource<>(tableLoader, scanContext, rowDataReaderFunction,
-              InternalTypeInfo.of(FlinkSchemaUtil.convert(scanContext.project())), arcticTable.name()),
+              InternalTypeInfo.of(rowType), arcticTable.name(), dimTable),
           watermarkStrategy, ArcticSource.class.getName());
       context.generateUid(ARCTIC_FILE_TRANSFORMATION).ifPresent(sourceStream::uid);
       return sourceStream;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -114,6 +114,30 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           " means this job will submit empty snapshots to the table, it is suitable with some valid reasons, e.g." +
           " advance watermark metadata stored in the table(https://github.com/apache/iceberg/pull/5561).");
 
+  public static final ConfigOption<String> ARCTIC_CATALOG =
+      ConfigOptions.key("arctic.catalog")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("underlying arctic catalog name.");
+
+  public static final ConfigOption<String> ARCTIC_DATABASE =
+      ConfigOptions.key("arctic.database")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("underlying arctic database name.");
+
+  public static final ConfigOption<String> ARCTIC_TABLE =
+      ConfigOptions.key("arctic.table")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("underlying arctic table name.");
+
+  public static final ConfigOption<Boolean> DIM_TABLE_ENABLE =
+      ConfigOptions.key("dim-table.enable")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("If it is true, Arctic source will generate watermark after stock data being read");
+
   @Override
   public void validate(DescriptorProperties properties) {
     String emitMode = properties.getString(ARCTIC_EMIT_MODE);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -18,21 +18,21 @@
 
 package com.netease.arctic.flink.util;
 
+import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.write.ArcticLogWriter;
-import com.netease.arctic.flink.write.MetricsGenerator;
 import com.netease.arctic.flink.write.hidden.HiddenLogWriter;
 import com.netease.arctic.flink.write.hidden.kafka.HiddenKafkaFactory;
 import com.netease.arctic.table.ArcticTable;
-import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.PrimaryKeySpec;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.IdGenerator;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION;
@@ -147,6 +148,11 @@ public class ArcticUtils {
     boolean toBase = overwrite;
     LOGGER.info("is write to base:{}", toBase);
     return toBase;
+  }
+
+  public static TimestampData getCurrentTimestampData(TimeZone timeZone) {
+    long ts = System.currentTimeMillis();
+    return TimestampData.fromEpochMillis(ts + timeZone.getOffset(ts));
   }
 
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.write;
 
+import com.netease.arctic.flink.metric.MetricsGenerator;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.write;
 
 import com.google.common.collect.Lists;
+import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.shuffle.RoundRobinShuffleRulePolicy;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.shuffle.ShuffleKey;

--- a/flink/v1.15/flink/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink/v1.15/flink/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -17,3 +17,4 @@
 #
 
 com.netease.arctic.flink.catalog.factories.ArcticCatalogFactory
+com.netease.arctic.flink.table.DynamicTableFactory

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/DynamicTableSourceTestBase.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/DynamicTableSourceTestBase.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.factories.TableFactoryHarness;
+
+import java.io.Serializable;
+
+public abstract class DynamicTableSourceTestBase extends TableFactoryHarness.ScanSourceBase implements
+    SupportsWatermarkPushDown, Serializable {
+
+  public static final long serialVersionUID = 1L;
+  private WatermarkStrategy<RowData> watermarkStrategy;
+
+  @Override
+  public ChangelogMode getChangelogMode() {
+    return ChangelogMode.all();
+  }
+
+  @Override
+  public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+    init();
+    return SourceFunctionProvider.of(
+        new SourceFunction<RowData>() {
+          @Override
+          public void run(SourceContext<RowData> ctx) {
+            WatermarkGenerator<RowData> generator =
+                watermarkStrategy.createWatermarkGenerator(() -> null);
+            WatermarkOutput output = new TestWatermarkOutput(ctx);
+            doRun(generator, output, ctx);
+          }
+
+          @Override
+          public void cancel() {
+          }
+        },
+        false);
+  }
+  public void init() {};
+
+  public abstract void doRun(WatermarkGenerator<RowData> generator, WatermarkOutput output,
+                             SourceFunction.SourceContext<RowData> ctx);
+
+  @Override
+  public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
+    this.watermarkStrategy = watermarkStrategy;
+  }
+
+  public class TestWatermarkOutput implements WatermarkOutput, Serializable {
+    public static final long serialVersionUID = 1L;
+    public SourceFunction.SourceContext<RowData> ctx;
+
+    public TestWatermarkOutput(SourceFunction.SourceContext<RowData> ctx) {
+      this.ctx = ctx;
+    }
+
+    @Override
+    public void emitWatermark(Watermark watermark) {
+      ctx.emitWatermark(
+          new org.apache.flink.streaming.api.watermark.Watermark(
+              watermark.getTimestamp()));
+    }
+
+    @Override
+    public void markIdle() {
+    }
+
+    @Override
+    public void markActive() {
+    }
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
@@ -20,6 +20,7 @@ package com.netease.arctic.flink;
 
 import com.netease.arctic.TableTestBase;
 import com.netease.arctic.flink.catalog.factories.ArcticCatalogFactoryOptions;
+import com.netease.arctic.flink.write.KeyedRowDataTaskWriterFactory;
 import com.netease.arctic.io.reader.GenericArcticDataReader;
 import com.netease.arctic.scan.CombinedScanTask;
 import com.netease.arctic.scan.KeyedTableScanTask;
@@ -49,12 +50,15 @@ import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IdentityPartitionConverters;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.MiniClusterResource;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -66,6 +70,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -270,5 +275,27 @@ public class FlinkTestBase extends TableTestBase {
 
   protected static RowData createRowData(Integer id, String name, String dateTime) {
     return createRowData(id, name, dateTime, RowKind.INSERT);
+  }
+
+  protected static void commit(KeyedTable keyedTable, WriteResult result, boolean base) {
+    if (base) {
+      AppendFiles baseAppend = keyedTable.baseTable().newAppend();
+      Arrays.stream(result.dataFiles()).forEach(baseAppend::appendFile);
+      baseAppend.commit();
+    } else {
+      AppendFiles changeAppend = keyedTable.changeTable().newAppend();
+      Arrays.stream(result.dataFiles()).forEach(changeAppend::appendFile);
+      changeAppend.commit();
+    }
+  }
+
+  protected static TaskWriter<RowData> createKeyedTaskWriter(KeyedTable keyedTable, RowType rowType, long transactionId,
+                                                             boolean base) {
+    KeyedRowDataTaskWriterFactory taskWriterFactory =
+        new KeyedRowDataTaskWriterFactory(keyedTable, rowType, base);
+    taskWriterFactory.setTransactionId(transactionId);
+    taskWriterFactory.setMask(3);
+    taskWriterFactory.initialize(0, 0);
+    return taskWriterFactory.create();
   }
 }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -479,7 +479,8 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         arcticScanContext,
         rowDataReaderFunction,
         typeInformation,
-        testKeyedTable.name());
+        testKeyedTable.name(),
+        false);
   }
 
   private RowDataReaderFunction initRowDataReadFunction() {

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/FlinkSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/FlinkSourceTest.java
@@ -55,7 +55,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.netease.arctic.flink.write.ArcticFileWriterTest.TARGET_FILE_SIZE;
-import static com.netease.arctic.flink.write.ArcticFileWriterTest.createTaskWriter;
+import static com.netease.arctic.flink.write.ArcticFileWriterTest.createUnkeyedTaskWriter;
 
 public class FlinkSourceTest extends FlinkTestBase {
 
@@ -68,7 +68,7 @@ public class FlinkSourceTest extends FlinkTestBase {
   }
 
   protected static void write(Collection<Object[]> data, Table table, RowType rowType) throws IOException {
-    try (TaskWriter<RowData> taskWriter = createTaskWriter(table, TARGET_FILE_SIZE, fileFormat, rowType)) {
+    try (TaskWriter<RowData> taskWriter = createUnkeyedTaskWriter(table, TARGET_FILE_SIZE, fileFormat, rowType)) {
       data.forEach(d -> {
         try {
           taskWriter.write(DataUtil.toRowData(d));

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumStateSerializerTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumStateSerializerTest.java
@@ -22,6 +22,7 @@ import com.netease.arctic.flink.read.FlinkSplitPlanner;
 import com.netease.arctic.flink.read.hybrid.assigner.ShuffleSplitAssigner;
 import com.netease.arctic.flink.read.hybrid.assigner.ShuffleSplitAssignerTest;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
+import com.netease.arctic.flink.read.hybrid.split.TemporalJoinSplits;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.junit.Assert;
 import org.junit.Test;
@@ -44,11 +45,14 @@ public class ArcticSourceEnumStateSerializerTest extends ShuffleSplitAssignerTes
 
     List<ArcticSplit> splitList = FlinkSplitPlanner.planFullTable(testKeyedTable, new AtomicInteger());
     shuffleSplitAssigner.onDiscoveredSplits(splitList);
+    TemporalJoinSplits splits = new TemporalJoinSplits(splitList, null);
 
     ArcticSourceEnumState expect = new ArcticSourceEnumState(
         shuffleSplitAssigner.state(),
         null,
-        shuffleSplitAssigner.serializePartitionIndex());
+        shuffleSplitAssigner.serializePartitionIndex(),
+        splits
+    );
 
     ArcticSourceEnumStateSerializer arcticSourceEnumStateSerializer = new ArcticSourceEnumStateSerializer();
     byte[] ser = arcticSourceEnumStateSerializer.serialize(expect);
@@ -80,5 +84,8 @@ public class ArcticSourceEnumStateSerializerTest extends ShuffleSplitAssignerTes
     }
 
     Assert.assertEquals(splitList.size(), actualSplits.size());
+
+    TemporalJoinSplits temporalJoinSplits = actual.temporalJoinSplits();
+    Assert.assertEquals(expect.temporalJoinSplits(), temporalJoinSplits);
   }
 }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/TemporalJoinSplitsThreadSafeTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/TemporalJoinSplitsThreadSafeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.hybrid.enumerator;
+
+import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
+import com.netease.arctic.flink.read.hybrid.split.TemporalJoinSplits;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class TemporalJoinSplitsThreadSafeTest {
+
+  @Test
+  public void testTemporalJoinSplits() {
+    List<String> allSplit = new LinkedList<>();
+    for (int i = 0; i < 100; i++) {
+      allSplit.add(UUID.randomUUID().toString());
+    }
+
+    Collection<ArcticSplit> arcticSplits = allSplit.stream().map(TestArcticSplit::of).collect(Collectors.toList());
+
+    for (int i = 0; i < 2; i++) {
+      round(allSplit, arcticSplits);
+    }
+  }
+
+  public void round(List<String> allSplit, Collection<ArcticSplit> arcticSplits) {
+    TemporalJoinSplits temporalJoinSplits = new TemporalJoinSplits(arcticSplits, null);
+    int n = allSplit.size();
+
+    List<String> s1 = new ArrayList<>(allSplit.subList(0, (int) (2.0 / 3 * n))),
+        s2 = new ArrayList<>(allSplit.subList((int) (1.0 / 3 * n), n));
+    Collections.shuffle(s1);
+    Collections.shuffle(s2);
+
+    List<ArcticSplit> as = new ArrayList<>(arcticSplits);
+    Collections.shuffle(as);
+    int an = as.size();
+    List<ArcticSplit> as1 = new ArrayList<>(as.subList(0, (int) (2.0 / 3 * an)));
+    List<ArcticSplit> as2 = new ArrayList<>(as.subList((int) (1.0 / 3 * an), an));
+    CompletableFuture<Void> f1 = CompletableFuture.runAsync(() ->
+        temporalJoinSplits.removeAndReturnIfAllFinished(s1)
+    );
+    CompletableFuture<Void> f2 = CompletableFuture.runAsync(() ->
+        temporalJoinSplits.addSplitsBack(as1)
+    );
+    CompletableFuture<Void> f3 = CompletableFuture.runAsync(() -> temporalJoinSplits.removeAndReturnIfAllFinished(s2));
+    CompletableFuture<Void> f4 = CompletableFuture.runAsync(() -> temporalJoinSplits.addSplitsBack(as2));
+    CompletableFuture.allOf(f1, f2, f3, f4).join();
+    Assert.assertTrue(temporalJoinSplits.removeAndReturnIfAllFinished(allSplit));
+  }
+
+  static class TestArcticSplit extends ArcticSplit {
+    private final String splitId;
+
+    public TestArcticSplit(String splitId) {
+      this.splitId = splitId;
+    }
+
+    public static TestArcticSplit of(String splitId) {
+      return new TestArcticSplit(splitId);
+    }
+
+    @Override
+    public Integer taskIndex() {
+      return null;
+    }
+
+    @Override
+    public void updateOffset(Object[] recordOffsets) {
+    }
+
+    @Override
+    public String splitId() {
+      return splitId;
+    }
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
@@ -146,7 +146,7 @@ public class RowDataReaderFunctionTest extends ContinuousSplitPlannerImplTest {
       for (RowData record : input) {
         taskWriter.write(record);
       }
-      commit(taskWriter.complete(), false);
+      commit(testKeyedTable, taskWriter.complete(), false);
     }
   }
 

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.table;
+
+import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableIdentifier;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.io.TaskWriter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.netease.arctic.ams.api.MockArcticMetastoreServer.TEST_CATALOG_NAME;
+import static com.netease.arctic.table.TableProperties.LOCATION;
+import static org.apache.flink.table.planner.factories.TestValuesTableFactory.registerData;
+
+public class TestJoin extends FlinkTestBase {
+
+  public static final Logger LOG = LoggerFactory.getLogger(TestJoin.class);
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static final String DB = PK_TABLE_ID.getDatabase();
+  private static final String TABLE = "test_keyed";
+
+  public void before() {
+    super.before();
+    super.config();
+  }
+
+  @After
+  public void after() {
+    sql("DROP TABLE IF EXISTS arcticCatalog." + DB + "." + TABLE);
+  }
+
+  @Test(timeout = 180000)
+  public void testRightEmptyLookupJoin() throws Exception {
+    getEnv().getCheckpointConfig().disableCheckpointing();
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{RowKind.INSERT, 1000004L, "a", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 1000015L, "b", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 1000011L, "c", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 1000022L, "d", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 1000021L, "e", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 1000016L, "e", LocalDateTime.now()});
+    String id = registerData(DataUtil.toRowList(data));
+    sql("CREATE TABLE `user` (id bigint, name string, op_time timestamp(3), watermark for op_time as op_time) " +
+        "with (" +
+        " 'connector' = 'values'," +
+        " 'bounded' = 'false'," +
+        " 'data-id' = '" + id + "' " +
+        " )");
+
+    sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
+
+    String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
+        " info int, id bigint, name STRING" +
+        ", PRIMARY KEY (id) NOT ENFORCED) WITH %s", table, toWithClause(tableProperties));
+    sql(sql);
+
+    sql("create table d (op_time timestamp(3), watermark for op_time as op_time) like %s", table);
+
+    TableResult result = exec("select u.name, u.id, dim.info, dim.name dname from `user` as u left join d " +
+        "/*+OPTIONS('streaming'='true', 'dim-table.enable'='true')*/ for system_time as of u.op_time as dim" +
+        " on u.id = dim.id");
+
+    CommonTestUtils.waitForJobStatus(result.getJobClient().get(), Lists.newArrayList(JobStatus.RUNNING));
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        Row row = iterator.next();
+        actual.add(row);
+      }
+    }
+    result.getJobClient().ifPresent(JobClient::cancel);
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{"a", 1000004L, null, null});
+    expected.add(new Object[]{"b", 1000015L, null, null});
+    expected.add(new Object[]{"c", 1000011L, null, null});
+    expected.add(new Object[]{"d", 1000022L, null, null});
+    expected.add(new Object[]{"e", 1000021L, null, null});
+    expected.add(new Object[]{"e", 1000016L, null, null});
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+  }
+
+  @Test(timeout = 180000)
+  public void testLookupJoin() throws Exception {
+    getEnv().getCheckpointConfig().disableCheckpointing();
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{RowKind.INSERT, 1L, "a", LocalDateTime.now().minusDays(3)});
+    data.add(new Object[]{RowKind.INSERT, 2L, "b", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 3L, "c", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 4L, "d", LocalDateTime.now().plusDays(3)});
+    data.add(new Object[]{RowKind.INSERT, 5L, "e", LocalDateTime.now().plusDays(3)});
+    data.add(new Object[]{RowKind.INSERT, 3L, "e", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 6L, "f", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 8L, "g", LocalDateTime.now()});
+    data.add(new Object[]{RowKind.INSERT, 9L, "h", LocalDateTime.now()});
+    String id = registerData(DataUtil.toRowList(data));
+    sql("CREATE TABLE `user` (id bigint, name string, op_time timestamp(3), watermark for op_time as op_time) " +
+        "with (" +
+        " 'connector' = 'values'," +
+        " 'bounded' = 'false'," +
+        " 'data-id' = '" + id + "' " +
+        " )");
+
+    sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
+
+    String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
+        " info int, id bigint, name STRING" +
+        ", PRIMARY KEY (id) NOT ENFORCED) WITH %s", table, toWithClause(tableProperties));
+    sql(sql);
+
+    TableSchema flinkSchema = TableSchema.builder()
+        .field("info", DataTypes.INT())
+        .field("id", DataTypes.BIGINT())
+        .field("name", DataTypes.STRING())
+        .build();
+    RowType rowType = (RowType) flinkSchema.toRowDataType().getLogicalType();
+    KeyedTable keyedTable = (KeyedTable) ArcticUtils.loadArcticTable(
+        ArcticTableLoader.of(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE), catalogBuilder));
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(keyedTable, rowType, 1, true);
+    List<RowData> baseData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 123, 1L, StringData.fromString("a")));
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 324, 2L, StringData.fromString("b")));
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 456, 3L, StringData.fromString("c")));
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 463, 4L, StringData.fromString("d")));
+    }};
+    for (RowData record : baseData) {
+      taskWriter.write(record);
+    }
+    commit(keyedTable, taskWriter.complete(), true);
+
+    writeChange(keyedTable, rowType, 1);
+
+    sql("create table d (op_time timestamp(3), watermark for op_time as op_time) like %s", table);
+
+    TableResult result = exec("select u.name, u.id, dim.info, dim.name dname from `user` as u left join d " +
+        "/*+OPTIONS('streaming'='true', 'dim-table.enable'='true')*/ for system_time as of u.op_time as dim" +
+        " on u.id = dim.id");
+
+    CommonTestUtils.waitForJobStatus(result.getJobClient().get(), Lists.newArrayList(JobStatus.RUNNING));
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        Row row = iterator.next();
+        actual.add(row);
+      }
+    }
+    result.getJobClient().ifPresent(JobClient::cancel);
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{"a", 1L, 123, "a"});
+    expected.add(new Object[]{"b", 2L, 324, "b"});
+    expected.add(new Object[]{"c", 3L, null, null});
+    expected.add(new Object[]{"d", 4L, 463, "d"});
+    expected.add(new Object[]{"e", 5L, 324, "john"});
+    expected.add(new Object[]{"e", 3L, null, null});
+    expected.add(new Object[]{"f", 6L, 324, "lily"});
+    expected.add(new Object[]{"g", 8L, null, null});
+    expected.add(new Object[]{"h", 9L, null, null});
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+  }
+
+  private void writeChange(KeyedTable keyedTable, RowType rowType, long tranctionId) {
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(keyedTable, rowType, tranctionId, false);
+    List<RowData> data = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 324, 5L, StringData.fromString("john")));
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 324, 6L, StringData.fromString("lily")));
+      add(GenericRowData.ofKind(
+          RowKind.DELETE, 324, 3L, StringData.fromString("jake1")));
+    }};
+    try {
+      for (RowData record : data) {
+        taskWriter.write(record);
+      }
+      commit(keyedTable, taskWriter.complete(), false);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -87,7 +87,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
     return harness;
   }
 
-  public static TaskWriter<RowData> createTaskWriter(Table table, long targetFileSize, FileFormat format,
+  public static TaskWriter<RowData> createUnkeyedTaskWriter(Table table, long targetFileSize, FileFormat format,
                                                      RowType rowType) {
     TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(
         SerializableTable.copyOf(table), rowType, targetFileSize, format, null);

--- a/flink/v1.15/flink/src/test/resources/log4j.properties
+++ b/flink/v1.15/flink/src/test/resources/log4j.properties
@@ -18,6 +18,7 @@
 
 log4j.rootLogger=error, console
 log4j.logger.com.netease.arctic=info
+log4j.logger.org.apache.flink=info
 log4j.logger.state.change.logger=fatal
 
 log4j.appender.console=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There are some requirements for real-time data widening. Now hive supports lookup join, but this solution is not available for production, and the hive table needs to be loaded into memory. Large tables are prone to oom problems. Besides, neither Iceberg nor Hudi support lookup joins.

Here is a summary proposal:
Flink affords the event time temporal join. The right table will be used as a version table, and its data can be managed in rocksdb instead of memory.

```
-- create a left table, using localtimestamp as event time.
create table source (
  ...,
  arcitc_process_time AS LOCALTIMESTAMP,
  WATERMARK FOR arcitc_process_time AS arcitc_process_time,
) with (...);

create table arctic_dim (...) with ('connector'='arctic', 'dim-table.enabled'='true');
```

select * from source as O left join arctic_dim FOR SYSTEM_TIME AS OF O.arcitc_process_time as P on O.id = P.id;
The arctic source will automatically create a custom watermark strategy if `dim-table.enabled` equals true.

## Brief change log

  - Sync #127 to module arctic-flink-1.15

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)