### PR TITLE
[Arctic-278][Doc]: Adding Flink on adapt Arctic table documentation

### DIFF
--- a/site/docs/ch/flink/flink-get-started.md
+++ b/site/docs/ch/flink/flink-get-started.md
@@ -72,6 +72,13 @@ cp ../arctic-flink-runtime-1.12-0.3.0.jar lib
 cp ../flink-shaded-hadoop-2-uber-${HADOOP_VERSION}-10.0.jar lib
 ```
 
+## Hive兼容
+Arctic 0.3.1 版本开始支持 Hive 兼容的功能，可以通过 Flink 读取/写入 Arctic Hive 兼容表数据。当通过 Flink 操作 Hive 兼容表时，需要注意以下几点：
+1. Flink Runtime Jar 不包括 Hive 依赖的 Jar 包内容，需要手动将[ Hive 依赖的 Jar 包](https://repo1.maven.org/maven2/org/apache/hive/hive-exec/2.1.1/hive-exec-2.1.1.jar)放到 flink/lib 目录下；
+2. 创建分区表时，分区字段需要放在最后一列；当分区字段为多个字段时，需要全部放在最后；
+3. 对于 Hive 兼容表，[建表方式](flink-ddl.md)和[读写方式](flink-dml.md)与非 Hive 兼容的 Arctic 表一致；
+4. 支持 Hive 版本为 2.1.1
+
 ## Roadmap
 - [Arctic 表支持实时维表 JOIN](https://github.com/NetEase/arctic/issues/94)
 - [批模式下 MOR](https://github.com/NetEase/arctic/issues/5)


### PR DESCRIPTION
Resolve #278

#196 Arctic 0.3.1 have implemented parquet reader/writer for hive. Flink have to port to new API to support hive reading/writting. Here's the doc about Flink on adapt Arctic table.

## Brief change log

  - *Add the Flink on adapt Arctic table documentation in the flink chapter*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
