### PR TITLE
[ARCTIC-296] hotfix: avoid submitting empty snapshots by default

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.descriptors.ConnectorDescriptorValidator;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.types.logical.RowType;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -109,7 +108,7 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
   public static final ConfigOption<Boolean> SUBMIT_EMPTY_SNAPSHOTS = ConfigOptions
       .key("submit.empty.snapshots")
       .booleanType()
-      .defaultValue(true)
+      .defaultValue(false)
       .withDescription("Optional submit empty snapshots to the arctic table, false means that writers will not emit" +
           " empty WriteResults to the committer operator, and reduce the number of snapshots in File Cache; true" +
           " means this job will submit empty snapshots to the table, it is suitable with some valid reasons, e.g." +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #296 
There is a flink running job without any data ingestion. But submitted too many empty snapshots and cost too much storage.


## Brief change log

*(For example:)*
  - *update the default value of the ArcticValidator.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no) no 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
