### PR TITLE
fix create table cant set colmun struct type

### DIFF
--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestKeyedTableDDL.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestKeyedTableDDL.java
@@ -48,6 +48,7 @@ public class TestKeyedTableDDL extends SparkTestBase {
     sql("create table {0}.{1} ( \n" +
         " id int , \n" +
         " name string , \n " +
+        " point struct<x: double NOT NULL, y: double NOT NULL> , \n " +
         " ts timestamp , \n" +
         " primary key (id) \n" +
         ") using arctic \n" +

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestCreateTableDDL.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestCreateTableDDL.java
@@ -164,7 +164,7 @@ public class TestCreateTableDDL extends SparkTestBase {
     Assert.assertNotNull(hiveTableA);
     rows = sql("desc table {0}.{1}", database, tableA);
     assertHiveDesc(rows,
-        Lists.newArrayList("id", "name"),
+        Lists.newArrayList("id", "name", "ts"),
         Lists.newArrayList());
 
     sql("use " + catalogNameHive);

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestCreateTableDDL.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestCreateTableDDL.java
@@ -134,6 +134,7 @@ public class TestCreateTableDDL extends SparkTestBase {
     sql("create table {0}.{1} ( \n" +
         " id int , \n" +
         " name string , \n " +
+        " ts timestamp , \n " +
         " primary key (id) \n" +
         ") using arctic \n" +
         " tblproperties ( \n" +
@@ -144,7 +145,9 @@ public class TestCreateTableDDL extends SparkTestBase {
     ArcticTable keyedTable = loadTable(identifierA);
     Types.StructType expectedSchema = Types.StructType.of(
         Types.NestedField.required(1, "id", Types.IntegerType.get()),
-        Types.NestedField.optional(2, "name", Types.StringType.get()));
+        Types.NestedField.optional(2, "name", Types.StringType.get()),
+        Types.NestedField.optional(3, "ts", Types.TimestampType.withZone())
+        );
     Assert.assertEquals("Schema should match expected",
         expectedSchema, keyedTable.schema().asStruct());
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
fix create table cant set colmun struct type and timestamp type

*(For example: The Arctic Flink dataStream API has already supported this configuration: 'scan.startup.mode', but it is not available with Flink SQL. We should expose this configuration to users when they are using Flink SQL.)*

## Brief change log

*(For example:)*
  - *Add the 'scan.startup.mode' configuration to the ArcticScanContext in the flink modules*
  - *The flink 1.12 and 1.14 versions are affected.*
  - *Add the documentation in the flink chapter*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
