### PR TITLE
[ARCTIC-320][Spark]support unset properties

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkCatalog.java
@@ -223,6 +223,8 @@ public class ArcticSparkCatalog implements TableCatalog, SupportsNamespaces {
         schemaChanges.add(change);
       } else if (change instanceof SetProperty) {
         propertyChanges.add(change);
+      } else if (change instanceof RemoveProperty) {
+        propertyChanges.add(change);
       } else {
         throw new UnsupportedOperationException("Cannot apply unknown table change: " + change);
       }

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestAlterKeyedTable.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestAlterKeyedTable.java
@@ -204,7 +204,19 @@ public class TestAlterKeyedTable extends SparkTestBase {
     Assert.assertEquals("val1", keyedTable.properties().get("test.props1"));
     Assert.assertEquals("new-value", keyedTable.properties().get("test.props2"));
     Assert.assertEquals("val3", keyedTable.properties().get("test.props3"));
+  }
 
+  @Test
+  public void testAlterTableUnsetProperties() {
+    sql("ALTER TABLE {0}.{1} SET TBLPROPERTIES " +
+        "( ''test.props2'' = ''new-value'', ''test.props3'' = ''val3'' )", database, tableName);
+    sql("ALTER TABLE {0}.{1} UNSET TBLPROPERTIES " +
+        "( ''test.props2'' )", database, tableName);
 
+    ArcticTable keyedTable = loadTable(catalogNameArctic, database, tableName);
+
+    Assert.assertEquals("val1", keyedTable.properties().get("test.props1"));
+    Assert.assertNull(keyedTable.properties().get("test.props2"));
+    Assert.assertEquals("val3", keyedTable.properties().get("test.props3"));
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix #320. 
fix bug when unset keyed table properties, remind "Cannot apply unknown table change: unset"


## Brief change log

*(For example:)*
  - *Add the 'scan.startup.mode' configuration to the ArcticScanContext in the flink modules*
  - *The flink 1.12 and 1.14 versions are affected.*
  - *Add the documentation in the flink chapter*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
