### PR TITLE
[ARCTIC-257][Flink] Flink source project pushdown would cause reading all fields to downstream

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -43,14 +43,17 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
@@ -108,13 +111,13 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
     this.arcticTable = arcticTable;
     this.properties = properties;
 
-    readSchema = arcticTable.schema();
     if (projectedSchema == null) {
+      readSchema = arcticTable.schema();
       flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     } else {
-      flinkSchemaRowType = (RowType) projectedSchema.toRowDataType().getLogicalType();
       readSchema = TypeUtil.reassignIds(
           FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema());
+      flinkSchemaRowType = (RowType) projectedSchema.toRowDataType().getLogicalType();
     }
   }
 
@@ -235,6 +238,16 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
 
   @Override
   public void applyProjection(int[][] projectedFields) {
+    int[] projectionFields = new int[projectedFields.length];
+    for (int i = 0; i < projectedFields.length; i++) {
+      org.apache.flink.util.Preconditions.checkArgument(
+          projectedFields[i].length == 1,
+          "Don't support nested projection now.");
+      projectionFields[i] = projectedFields[i][0];
+    }
+    final List<Types.NestedField> columns = readSchema.columns();
+    readSchema = new Schema(Arrays.stream(projectionFields).mapToObj(columns::get).collect(Collectors.toList()));
+    flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);
     }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 
 import java.util.HashMap;
@@ -151,7 +152,9 @@ public class FlinkSource {
       RowDataReaderFunction rowDataReaderFunction = new RowDataReaderFunction(
           flinkConf,
           arcticTable.schema(),
-          arcticTable.schema(),
+          projectedSchema == null ?
+              arcticTable.schema() :
+              TypeUtil.reassignIds(FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema()),
           arcticTable.asKeyedTable().primaryKeySpec(),
           scanContext.nameMapping(),
           scanContext.caseSensitive(),

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -152,9 +152,7 @@ public class FlinkSource {
       RowDataReaderFunction rowDataReaderFunction = new RowDataReaderFunction(
           flinkConf,
           arcticTable.schema(),
-          projectedSchema == null ?
-              arcticTable.schema() :
-              TypeUtil.reassignIds(FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema()),
+          scanContext.project(),
           arcticTable.asKeyedTable().primaryKeySpec(),
           scanContext.nameMapping(),
           scanContext.caseSensitive(),

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -165,7 +165,7 @@ public class TestKeyed extends FlinkTestBase {
         ")*/ select id, name, op_time_tz, op_time from input");
 
     List<Row> actual =
-        sql("select id, name, op_time, op_time_tz from arcticCatalog." + db + "." + TABLE +
+        sql("select id, op_time, op_time_tz from arcticCatalog." + db + "." + TABLE +
             "/*+ OPTIONS(" +
             "'arctic.read.mode'='file'" +
             ", 'streaming'='false'" +
@@ -173,13 +173,13 @@ public class TestKeyed extends FlinkTestBase {
             "");
 
     List<Object[]> expected = new LinkedList<>();
-    expected.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0"),
+    expected.add(new Object[]{RowKind.INSERT, 1000004, LocalDateTime.parse("2022-06-17T10:10:11.0"),
         LocalDateTime.parse("2022-06-17T10:10:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0"),
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, LocalDateTime.parse("2022-06-17T10:11:11.0"),
         LocalDateTime.parse("2022-06-17T10:11:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0"),
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, LocalDateTime.parse("2022-06-17T10:11:11.0"),
         LocalDateTime.parse("2022-06-17T10:11:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0"),
+    expected.add(new Object[]{RowKind.INSERT, 1000015, LocalDateTime.parse("2022-06-17T10:10:11.0"),
         LocalDateTime.parse("2022-06-17T10:10:11.0").atZone(ZoneId.systemDefault()).toInstant()});
 
     Assert.assertTrue(CollectionUtils.isEqualCollection(DataUtil.toRowList(expected), actual));

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -43,14 +43,17 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
@@ -108,13 +111,13 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
     this.arcticTable = arcticTable;
     this.properties = properties;
 
-    readSchema = arcticTable.schema();
     if (projectedSchema == null) {
+      readSchema = arcticTable.schema();
       flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     } else {
-      flinkSchemaRowType = (RowType) projectedSchema.toRowDataType().getLogicalType();
       readSchema = TypeUtil.reassignIds(
           FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema());
+      flinkSchemaRowType = (RowType) projectedSchema.toRowDataType().getLogicalType();
     }
   }
 
@@ -235,6 +238,16 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
 
   @Override
   public void applyProjection(int[][] projectedFields) {
+    int[] projectionFields = new int[projectedFields.length];
+    for (int i = 0; i < projectedFields.length; i++) {
+      org.apache.flink.util.Preconditions.checkArgument(
+          projectedFields[i].length == 1,
+          "Don't support nested projection now.");
+      projectionFields[i] = projectedFields[i][0];
+    }
+    final List<Types.NestedField> columns = readSchema.columns();
+    readSchema = new Schema(Arrays.stream(projectionFields).mapToObj(columns::get).collect(Collectors.toList()));
+    flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);
     }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.source.FlinkInputFormat;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 
 import java.util.HashMap;
@@ -152,7 +153,9 @@ public class FlinkSource {
       RowDataReaderFunction rowDataReaderFunction = new RowDataReaderFunction(
           flinkConf,
           arcticTable.schema(),
-          arcticTable.schema(),
+          projectedSchema == null ?
+              arcticTable.schema() :
+              TypeUtil.reassignIds(FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema()),
           arcticTable.asKeyedTable().primaryKeySpec(),
           scanContext.nameMapping(),
           scanContext.caseSensitive(),

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -153,9 +153,7 @@ public class FlinkSource {
       RowDataReaderFunction rowDataReaderFunction = new RowDataReaderFunction(
           flinkConf,
           arcticTable.schema(),
-          projectedSchema == null ?
-              arcticTable.schema() :
-              TypeUtil.reassignIds(FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema()),
+          scanContext.project(),
           arcticTable.asKeyedTable().primaryKeySpec(),
           scanContext.nameMapping(),
           scanContext.caseSensitive(),

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -169,7 +169,7 @@ public class TestKeyed extends FlinkTestBase {
         ")*/ select id, name, op_time_tz, op_time from input");
 
     List<Row> actual =
-        sql("select id, name, op_time, op_time_tz from arcticCatalog." + db + "." + TABLE +
+        sql("select id, op_time, op_time_tz from arcticCatalog." + db + "." + TABLE +
             "/*+ OPTIONS(" +
             "'arctic.read.mode'='file'" +
             ", 'streaming'='false'" +
@@ -177,13 +177,13 @@ public class TestKeyed extends FlinkTestBase {
             "");
 
     List<Object[]> expected = new LinkedList<>();
-    expected.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0"),
+    expected.add(new Object[]{RowKind.INSERT, 1000004, LocalDateTime.parse("2022-06-17T10:10:11.0"),
         LocalDateTime.parse("2022-06-17T10:10:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0"),
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, LocalDateTime.parse("2022-06-17T10:11:11.0"),
         LocalDateTime.parse("2022-06-17T10:11:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0"),
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, LocalDateTime.parse("2022-06-17T10:11:11.0"),
         LocalDateTime.parse("2022-06-17T10:11:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0"),
+    expected.add(new Object[]{RowKind.INSERT, 1000015, LocalDateTime.parse("2022-06-17T10:10:11.0"),
         LocalDateTime.parse("2022-06-17T10:10:11.0").atZone(ZoneId.systemDefault()).toInstant()});
 
     Assert.assertTrue(CollectionUtils.isEqualCollection(DataUtil.toRowList(expected), actual));

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.source.FlinkInputFormat;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 
 import java.util.HashMap;
@@ -162,7 +163,9 @@ public class FlinkSource {
       RowDataReaderFunction rowDataReaderFunction = new RowDataReaderFunction(
           flinkConf,
           arcticTable.schema(),
-          arcticTable.schema(),
+          projectedSchema == null ?
+              arcticTable.schema() :
+              TypeUtil.reassignIds(FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema()),
           arcticTable.asKeyedTable().primaryKeySpec(),
           scanContext.nameMapping(),
           scanContext.caseSensitive(),

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -163,9 +163,7 @@ public class FlinkSource {
       RowDataReaderFunction rowDataReaderFunction = new RowDataReaderFunction(
           flinkConf,
           arcticTable.schema(),
-          projectedSchema == null ?
-              arcticTable.schema() :
-              TypeUtil.reassignIds(FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema()),
+          scanContext.project(),
           arcticTable.asKeyedTable().primaryKeySpec(),
           scanContext.nameMapping(),
           scanContext.caseSensitive(),

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -169,7 +169,7 @@ public class TestKeyed extends FlinkTestBase {
         ")*/ select id, name, op_time_tz, op_time from input");
 
     List<Row> actual =
-        sql("select id, name, op_time, op_time_tz from arcticCatalog." + db + "." + TABLE +
+        sql("select id, op_time, op_time_tz from arcticCatalog." + db + "." + TABLE +
             "/*+ OPTIONS(" +
             "'arctic.read.mode'='file'" +
             ", 'streaming'='false'" +
@@ -177,13 +177,13 @@ public class TestKeyed extends FlinkTestBase {
             "");
 
     List<Object[]> expected = new LinkedList<>();
-    expected.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0"),
+    expected.add(new Object[]{RowKind.INSERT, 1000004, LocalDateTime.parse("2022-06-17T10:10:11.0"),
         LocalDateTime.parse("2022-06-17T10:10:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0"),
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, LocalDateTime.parse("2022-06-17T10:11:11.0"),
         LocalDateTime.parse("2022-06-17T10:11:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0"),
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, LocalDateTime.parse("2022-06-17T10:11:11.0"),
         LocalDateTime.parse("2022-06-17T10:11:11.0").atZone(ZoneId.systemDefault()).toInstant()});
-    expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0"),
+    expected.add(new Object[]{RowKind.INSERT, 1000015, LocalDateTime.parse("2022-06-17T10:10:11.0"),
         LocalDateTime.parse("2022-06-17T10:10:11.0").atZone(ZoneId.systemDefault()).toInstant()});
 
     Assert.assertTrue(CollectionUtils.isEqualCollection(DataUtil.toRowList(expected), actual));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Select partial fields from arctic table, but there will be all fields without projecting. It will cause unmatched rowtype and real rowdata. And shuffle is using all fields `RowType`, which may cause `ArrayIndexOutOfBoundsException`. 

Fix #257.

## Brief change log

  - Update `readSchema` and `flinkSchemaRowType` with the projection fields for `SupportsProjectionPushDown#applyProjection`.
  - Use `scanContext#project` for the projected schema of `RowDataReaderFunction`.

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)