### PR TITLE
[ARCTIC-323] make hive-exec optional

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveCommit.java
@@ -10,6 +10,7 @@ import com.netease.arctic.hive.HMSClient;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.hive.utils.HivePartitionUtil;
 import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.utils.FileUtil;
 import com.netease.arctic.utils.SerializationUtil;
@@ -39,7 +40,7 @@ public class SupportHiveCommit extends BaseOptimizeCommit {
                            Map<String, List<OptimizeTaskItem>> optimizeTasksToCommit,
                            Consumer<OptimizeTaskItem> updateTargetFiles) {
     super(arcticTable, optimizeTasksToCommit);
-    Preconditions.checkArgument(HiveTableUtil.isHive(arcticTable), "The table not support hive");
+    Preconditions.checkArgument(TableTypeUtil.isHive(arcticTable), "The table not support hive");
     this.updateTargetFiles = updateTargetFiles;
   }
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveFullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveFullOptimizePlan.java
@@ -22,7 +22,7 @@ import com.google.common.base.Preconditions;
 import com.netease.arctic.ams.api.DataFileInfo;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.hive.table.SupportHive;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableProperties;
 import org.apache.commons.collections.CollectionUtils;
@@ -53,7 +53,7 @@ public class SupportHiveFullOptimizePlan extends FullOptimizePlan {
     super(arcticTable, tableOptimizeRuntime, baseTableFileList, posDeleteFileList,
         partitionTaskRunning, queueId, currentTime, snapshotIsCached);
 
-    Preconditions.checkArgument(HiveTableUtil.isHive(arcticTable), "The table not support hive");
+    Preconditions.checkArgument(TableTypeUtil.isHive(arcticTable), "The table not support hive");
     hiveLocation = ((SupportHive) arcticTable).hiveLocation();
     excludeLocations.add(hiveLocation);
   }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveMajorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveMajorOptimizePlan.java
@@ -5,7 +5,7 @@ import com.netease.arctic.ams.api.DataFileInfo;
 import com.netease.arctic.ams.api.OptimizeType;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.hive.table.SupportHive;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableProperties;
 import org.apache.commons.collections.CollectionUtils;
@@ -39,7 +39,7 @@ public class SupportHiveMajorOptimizePlan extends MajorOptimizePlan {
     super(arcticTable, tableOptimizeRuntime, baseTableFileList, posDeleteFileList,
         partitionTaskRunning, queueId, currentTime, snapshotIsCached);
 
-    Preconditions.checkArgument(HiveTableUtil.isHive(arcticTable), "The table not support hive");
+    Preconditions.checkArgument(TableTypeUtil.isHive(arcticTable), "The table not support hive");
     hiveLocation = ((SupportHive) arcticTable).hiveLocation();
     excludeLocations.add(hiveLocation);
   }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
@@ -51,7 +51,7 @@ import com.netease.arctic.catalog.ArcticCatalog;
 import com.netease.arctic.catalog.CatalogLoader;
 import com.netease.arctic.data.DataFileType;
 import com.netease.arctic.hive.table.SupportHive;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
@@ -130,6 +130,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Initial optimize tasks.
+   *
    * @param optimizeTasks -
    */
   public void initOptimizeTasks(List<OptimizeTaskItem> optimizeTasks) {
@@ -141,6 +142,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Initial TableOptimizeRuntime.
+   *
    * @param runtime -
    * @return this for chain
    */
@@ -189,6 +191,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get table identifier.
+   *
    * @return TableIdentifier
    */
   public TableIdentifier getTableIdentifier() {
@@ -197,7 +200,8 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get Arctic Table, refresh if expired.
-   * @return  ArcticTable
+   *
+   * @return ArcticTable
    */
   public ArcticTable getArcticTable() {
     if (arcticTable == null) {
@@ -208,6 +212,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get arcticTable, refresh immediately or not.
+   *
    * @param forceRefresh - refresh immediately
    * @return ArcticTable
    */
@@ -218,7 +223,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * If arctic table is KeyedTable.
-   * 
+   *
    * @return true/false
    */
   public boolean isKeyedTable() {
@@ -230,6 +235,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get cached quota, cache will be updated when arctic table refresh.
+   *
    * @return quota
    */
   public double getQuotaCache() {
@@ -270,6 +276,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Update optimize task result, Failed or Prepared.
+   *
    * @param optimizeTaskStat - optimizeTaskStat
    */
   public void updateOptimizeTaskStat(OptimizeTaskStat optimizeTaskStat) {
@@ -309,6 +316,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Build current table optimize info.
+   *
    * @return TableOptimizeInfo
    */
   public TableOptimizeInfo buildTableOptimizeInfo() {
@@ -698,6 +706,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Commit optimize tasks.
+   *
    * @throws Exception -
    */
   public void commitOptimizeTasks() throws Exception {
@@ -719,7 +728,7 @@ public class TableOptimizeItem extends IJDBCService {
       if (MapUtils.isNotEmpty(tasksToCommit)) {
         LOG.info("{} get {} tasks of {} partitions to commit", tableIdentifier, taskCount, tasksToCommit.size());
         BaseOptimizeCommit optimizeCommit;
-        if (HiveTableUtil.isHive(getArcticTable())) {
+        if (TableTypeUtil.isHive(getArcticTable())) {
           optimizeCommit = new SupportHiveCommit(getArcticTable(true),
               tasksToCommit, OptimizeTaskItem::persistTargetFiles);
         } else {
@@ -743,6 +752,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get all optimize tasks.
+   *
    * @return list of all optimize tasks
    */
   public List<OptimizeTaskItem> getOptimizeTasks() {
@@ -751,7 +761,8 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get Full Plan.
-   * @param queueId -
+   *
+   * @param queueId     -
    * @param currentTime -
    * @return -
    */
@@ -773,7 +784,8 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get Major Plan.
-   * @param queueId -
+   *
+   * @param queueId     -
    * @param currentTime -
    * @return -
    */
@@ -795,7 +807,8 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get Minor Plan.
-   * @param queueId -
+   *
+   * @param queueId     -
    * @param currentTime -
    * @return -
    */
@@ -815,6 +828,7 @@ public class TableOptimizeItem extends IJDBCService {
 
   /**
    * Get optimizeRuntime.
+   *
    * @return -
    */
   public TableOptimizeRuntime getTableOptimizeRuntime() {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/SupportHiveSyncService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/SupportHiveSyncService.java
@@ -28,7 +28,7 @@ import com.netease.arctic.catalog.CatalogLoader;
 import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.hive.utils.HivePartitionUtil;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.UnkeyedTable;
@@ -94,7 +94,7 @@ public class SupportHiveSyncService implements ISupportHiveSyncService {
         ArcticCatalog catalog =
             CatalogLoader.load(ServiceContainer.getTableMetastoreHandler(), tableIdentifier.getCatalog());
         ArcticTable arcticTable = catalog.loadTable(tableIdentifier);
-        if (!HiveTableUtil.isHive(arcticTable)) {
+        if (!TableTypeUtil.isHive(arcticTable)) {
           LOG.debug("[{}] {} is not a support hive table", traceId, tableIdentifier);
           return;
         }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/TableExpireService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/TableExpireService.java
@@ -32,7 +32,7 @@ import com.netease.arctic.catalog.ArcticCatalog;
 import com.netease.arctic.catalog.CatalogLoader;
 import com.netease.arctic.data.DefaultKeyedFile;
 import com.netease.arctic.data.PrimaryKeyedFile;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
@@ -115,7 +115,7 @@ public class TableExpireService implements ITableExpireService {
                 TableProperties.CHANGE_SNAPSHOT_KEEP_MINUTES_DEFAULT)) * 60 * 1000;
 
         Set<String> hiveLocation = new HashSet<>();
-        if (HiveTableUtil.isHive(arcticTable)) {
+        if (TableTypeUtil.isHive(arcticTable)) {
           hiveLocation = HiveLocationUtils.getHiveLocation(arcticTable);
         }
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/HiveLocationUtils.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/HiveLocationUtils.java
@@ -19,7 +19,7 @@
 package com.netease.arctic.ams.server.utils;
 
 import com.netease.arctic.hive.table.SupportHive;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -35,7 +35,7 @@ public class HiveLocationUtils {
 
   public static Set<String> getHiveLocation(ArcticTable table) {
     Set<String> hiveLocations = new HashSet<>();
-    if (HiveTableUtil.isHive(table)) {
+    if (TableTypeUtil.isHive(table)) {
       if (table.spec().isUnpartitioned()) {
         try {
           Table hiveTable = ((SupportHive) table).getHMSClient().run(client ->

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestExpiredFileCleanSupportHive.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestExpiredFileCleanSupportHive.java
@@ -19,10 +19,9 @@
 package com.netease.arctic.ams.server.optimize;
 
 import com.netease.arctic.ams.server.service.impl.TableExpireService;
-import com.netease.arctic.ams.server.utils.HiveLocationUtils;
 import com.netease.arctic.hive.io.writer.AdaptHiveGenericTaskWriterBuilder;
 import com.netease.arctic.hive.table.HiveLocationKind;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.FileUtil;
@@ -66,7 +65,7 @@ public class TestExpiredFileCleanSupportHive extends TestSupportHiveBase {
     }
 
     Set<String> hiveLocation = new HashSet<>();
-    if (HiveTableUtil.isHive(testUnPartitionKeyedHiveTable)) {
+    if (TableTypeUtil.isHive(testUnPartitionKeyedHiveTable)) {
       hiveLocation.add(FileUtil.getFileDir(hiveFiles.get(0).path().toString()));
     }
     TableExpireService.expireSnapshots(testUnPartitionKeyedHiveTable.baseTable(), System.currentTimeMillis(), hiveLocation);

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -22,7 +22,7 @@ import com.netease.arctic.hive.io.writer.AdaptHiveOperateToTableRelation;
 import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
 import com.netease.arctic.hive.table.HiveLocationKind;
 import com.netease.arctic.hive.table.SupportHive;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.io.writer.CommonOutputFileFactory;
 import com.netease.arctic.io.writer.OutputFileFactory;
 import com.netease.arctic.io.writer.SortedPosDeleteWriter;
@@ -143,7 +143,7 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
             encryptionManager, partitionId, taskId, transactionId) :
         new CommonOutputFileFactory(baseLocation, table.spec(), fileFormat, table.io(),
             encryptionManager, partitionId, taskId, transactionId);
-    FileAppenderFactory<RowData> appenderFactory = HiveTableUtil.isHive(table) ?
+    FileAppenderFactory<RowData> appenderFactory = TableTypeUtil.isHive(table) ?
         new AdaptHiveFlinkAppenderFactory(schema, flinkSchema, table.properties(), table.spec()) :
         new FlinkAppenderFactory(
             schema, flinkSchema, table.properties(), table.spec());

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -22,7 +22,7 @@ import com.netease.arctic.hive.io.writer.AdaptHiveOperateToTableRelation;
 import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
 import com.netease.arctic.hive.table.HiveLocationKind;
 import com.netease.arctic.hive.table.SupportHive;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.io.writer.CommonOutputFileFactory;
 import com.netease.arctic.io.writer.OutputFileFactory;
 import com.netease.arctic.io.writer.SortedPosDeleteWriter;
@@ -143,7 +143,7 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
             encryptionManager, partitionId, taskId, transactionId) :
         new CommonOutputFileFactory(baseLocation, table.spec(), fileFormat, table.io(),
             encryptionManager, partitionId, taskId, transactionId);
-    FileAppenderFactory<RowData> appenderFactory = HiveTableUtil.isHive(table) ?
+    FileAppenderFactory<RowData> appenderFactory = TableTypeUtil.isHive(table) ?
         new AdaptHiveFlinkAppenderFactory(schema, flinkSchema, table.properties(), table.spec()) :
         new FlinkAppenderFactory(
             schema, flinkSchema, table.properties(), table.spec());

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -22,7 +22,7 @@ import com.netease.arctic.hive.io.writer.AdaptHiveOperateToTableRelation;
 import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
 import com.netease.arctic.hive.table.HiveLocationKind;
 import com.netease.arctic.hive.table.SupportHive;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.io.writer.CommonOutputFileFactory;
 import com.netease.arctic.io.writer.OutputFileFactory;
 import com.netease.arctic.io.writer.SortedPosDeleteWriter;
@@ -143,7 +143,7 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
             encryptionManager, partitionId, taskId, transactionId) :
         new CommonOutputFileFactory(baseLocation, table.spec(), fileFormat, table.io(),
             encryptionManager, partitionId, taskId, transactionId);
-    FileAppenderFactory<RowData> appenderFactory = HiveTableUtil.isHive(table) ?
+    FileAppenderFactory<RowData> appenderFactory = TableTypeUtil.isHive(table) ?
         new AdaptHiveFlinkAppenderFactory(schema, flinkSchema, table.properties(), table.spec()) :
         new FlinkAppenderFactory(
             schema, flinkSchema, table.properties(), table.spec());

--- a/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveGenericTaskWriterBuilder.java
+++ b/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveGenericTaskWriterBuilder.java
@@ -21,7 +21,7 @@ package com.netease.arctic.hive.io.writer;
 import com.netease.arctic.data.ChangeAction;
 import com.netease.arctic.hive.table.HiveLocationKind;
 import com.netease.arctic.hive.table.SupportHive;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.io.writer.CommonOutputFileFactory;
 import com.netease.arctic.io.writer.GenericBaseTaskWriter;
 import com.netease.arctic.io.writer.GenericChangeTaskWriter;
@@ -163,7 +163,7 @@ public class AdaptHiveGenericTaskWriterBuilder implements TaskWriterBuilder<Reco
             encryptionManager, partitionId, taskId, transactionId) :
         new CommonOutputFileFactory(baseLocation, table.spec(), fileFormat, table.io(),
             encryptionManager, partitionId, taskId, transactionId);
-    FileAppenderFactory<Record> appenderFactory = HiveTableUtil.isHive(table) ?
+    FileAppenderFactory<Record> appenderFactory = TableTypeUtil.isHive(table) ?
         new AdaptHiveGenericAppenderFactory(schema, table.spec()) :
         new GenericAppenderFactory(schema, table.spec());
     return new GenericBaseTaskWriter(fileFormat, appenderFactory,
@@ -186,7 +186,7 @@ public class AdaptHiveGenericTaskWriterBuilder implements TaskWriterBuilder<Reco
     long mask = PropertyUtil.propertyAsLong(table.properties(), TableProperties.CHANGE_FILE_INDEX_HASH_BUCKET,
         TableProperties.CHANGE_FILE_INDEX_HASH_BUCKET_DEFAULT) - 1;
     Schema changeWriteSchema = SchemaUtil.changeWriteSchema(table.changeTable().schema());
-    FileAppenderFactory<Record> appenderFactory = HiveTableUtil.isHive(table) ?
+    FileAppenderFactory<Record> appenderFactory = TableTypeUtil.isHive(table) ?
         new AdaptHiveGenericAppenderFactory(changeWriteSchema, table.spec()) :
         new GenericAppenderFactory(changeWriteSchema, table.spec());
     return new GenericChangeTaskWriter(fileFormat,

--- a/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveOperateToTableRelation.java
+++ b/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveOperateToTableRelation.java
@@ -19,7 +19,7 @@
 package com.netease.arctic.hive.io.writer;
 
 import com.netease.arctic.hive.table.HiveLocationKind;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.BaseLocationKind;
 import com.netease.arctic.table.ChangeLocationKind;
@@ -34,7 +34,7 @@ public class AdaptHiveOperateToTableRelation implements OperateToTableRelation {
   public LocationKind getLocationKindsFromOperateKind(
       ArcticTable arcticTable, WriteOperationKind writeOperationKind) {
     if (arcticTable.isKeyedTable()) {
-      if (HiveTableUtil.isHive(arcticTable)) {
+      if (TableTypeUtil.isHive(arcticTable)) {
         switch (writeOperationKind) {
           case APPEND:
             return ChangeLocationKind.INSTANT;
@@ -57,7 +57,7 @@ public class AdaptHiveOperateToTableRelation implements OperateToTableRelation {
         }
       }
     } else {
-      if (HiveTableUtil.isHive(arcticTable)) {
+      if (TableTypeUtil.isHive(arcticTable)) {
         switch (writeOperationKind) {
           case APPEND:
           case MAJOR_OPTIMIZE:

--- a/hive/src/main/java/com/netease/arctic/hive/utils/HiveTableUtil.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/HiveTableUtil.java
@@ -46,10 +46,6 @@ public class HiveTableUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveTableUtil.class);
 
-  public static boolean isHive(ArcticTable arcticTable) {
-    return arcticTable instanceof SupportHive;
-  }
-
   public static org.apache.hadoop.hive.metastore.api.Table loadHmsTable(
       HMSClient hiveClient, TableIdentifier tableIdentifier) {
     try {

--- a/hive/src/main/java/com/netease/arctic/hive/utils/TableTypeUtil.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/TableTypeUtil.java
@@ -1,0 +1,10 @@
+package com.netease.arctic.hive.utils;
+
+import com.netease.arctic.hive.table.SupportHive;
+import com.netease.arctic.table.ArcticTable;
+
+public class TableTypeUtil {
+  public static boolean isHive(ArcticTable arcticTable) {
+    return arcticTable instanceof SupportHive;
+  }
+}

--- a/trino/src/main/java/com/netease/arctic/trino/unkeyed/IcebergMetadata.java
+++ b/trino/src/main/java/com/netease/arctic/trino/unkeyed/IcebergMetadata.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.netease.arctic.hive.utils.HiveTableUtil;
+import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
@@ -290,7 +290,7 @@ public class IcebergMetadata
 
     Map<String, String> tableProperties = table.properties();
     String nameMappingJson = tableProperties.get(TableProperties.DEFAULT_NAME_MAPPING);
-    if (HiveTableUtil.isHive((ArcticTable) table)) {
+    if (TableTypeUtil.isHive((ArcticTable) table)) {
       return new AdaptHiveIcebergTableHandle(
           tableName.getSchemaName(),
           name.getTableName(),


### PR DESCRIPTION
close #323 

## Why are the changes needed?
Hive-exec is necessary for hive adaptive table, however, it can be optional for native Arctic table.

## Brief change log
  - *Seperate TableTypeUtil from HiveUtil*
  - *The flink 1.12 and 1.14, 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
