### PR TITLE
[Arctic-329] fix mysql/ams-init.sql for optimize_task_history

### DIFF
--- a/ams/ams-server/src/main/resources/sql/mysql/ams-init.sql
+++ b/ams/ams-server/src/main/resources/sql/mysql/ams-init.sql
@@ -237,7 +237,6 @@ CREATE TABLE `optimize_task_history`
     `cost_time`       bigint(20) DEFAULT NULL COMMENT 'Task cost time',
     `queue_id`        int(11) DEFAULT NULL COMMENT 'Task queue id',
     `task_group_id`   varchar(40) DEFAULT NULL COMMENT 'Task group id',
-    PRIMARY KEY (`task_history_id`,`task_group_id`),
     KEY               `task_group_id_index` (`task_history_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'History of each optimize task';
 

--- a/ams/ams-server/src/main/resources/sql/mysql/upgrade-0.3.0-to-0.3.1.sql
+++ b/ams/ams-server/src/main/resources/sql/mysql/upgrade-0.3.0-to-0.3.1.sql
@@ -26,3 +26,6 @@ ALTER TABLE `table_metadata` ADD COLUMN `cur_schema_id` int(11) NOT NULL DEFAULT
 ALTER TABLE `table_transaction_meta` modify COLUMN `table_identifier` varchar(384) NOT NULL;
 ALTER TABLE `optimize_file` MODIFY COLUMN `optimize_type` varchar(10) NOT NULL COMMENT 'Optimize type: Major, Minor, FullMajor';
 ALTER TABLE `optimize_table_runtime` ADD COLUMN `latest_full_optimize_time` MEDIUMTEXT NULL COMMENT 'Latest Full Optimize time for all partitions';
+ALTER TABLE `optimize_task_history` MODIFY COLUMN `task_history_id` varchar(40) NOT NULL COMMENT 'Task history id' first, MODIFY COLUMN 
+`task_group_id` varchar(40) NOT NULL COMMENT 'Task group id' after `task_history_id`;
+ALTER TABLE `optimize_task_history` ADD PRIMARY KEY (`task_history_id`,`task_group_id`);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #329

## Brief change log

  - move optimize_task_history upgrade sql to src/main/resources/sql/mysql/upgrade-0.3.0-to-0.3.1.sql

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/103108928/188579083-e58224aa-250d-4c44-bf17-8e0a958f80e1.png">
<img width="951" alt="image" src="https://user-images.githubusercontent.com/103108928/188579133-65b42962-90db-47ec-b5d3-584a4226a314.png">


- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
