### PR TITLE
[ARCTIC-172][Flink] Fix Flink read nothing in streaming mode when table has data in base, but not change

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -26,6 +26,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  */
 public class ArcticEnumeratorOffset {
   public static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
+
+  /**
+   * use Long.MIN_VALUE to indicate the earliest offset
+   */
+  public static final long EARLIEST_SNAPSHOT_ID = Long.MIN_VALUE;
   private Long changeSnapshotId;
   private Long snapshotTimestampMs;
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -114,7 +114,8 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
         FILE_SCAN_STARTUP_MODE_LATEST.equalsIgnoreCase(scanContext.scanStartupMode())) {
       keyedTable.refresh();
       Snapshot snapshot = keyedTable.changeTable().currentSnapshot();
-      enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshot.snapshotId(), null));
+      long snapshotId = snapshot == null ? Long.MIN_VALUE : snapshot.snapshotId();
+      enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshotId, null));
       LOG.info("{} is {}, the current snapshot id of the change table {}  is {}.",
           FILE_SCAN_STARTUP_MODE.key(), FILE_SCAN_STARTUP_MODE_LATEST, keyedTable.id(), snapshot.snapshotId());
     }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+import static com.netease.arctic.flink.read.hybrid.enumerator.ArcticEnumeratorOffset.EARLIEST_SNAPSHOT_ID;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.FILE_SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.FILE_SCAN_STARTUP_MODE_LATEST;
 import static com.netease.arctic.flink.util.ArcticUtils.loadArcticTable;
@@ -114,7 +115,7 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
         FILE_SCAN_STARTUP_MODE_LATEST.equalsIgnoreCase(scanContext.scanStartupMode())) {
       keyedTable.refresh();
       Snapshot snapshot = keyedTable.changeTable().currentSnapshot();
-      long snapshotId = snapshot == null ? Long.MIN_VALUE : snapshot.snapshotId();
+      long snapshotId = snapshot == null ? EARLIEST_SNAPSHOT_ID : snapshot.snapshotId();
       enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshotId, null));
       LOG.info("{} is {}, the current snapshot id of the change table {}  is {}.",
           FILE_SCAN_STARTUP_MODE.key(), FILE_SCAN_STARTUP_MODE_LATEST, keyedTable.id(), snapshot.snapshotId());

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImpl.java
@@ -22,6 +22,7 @@ import com.netease.arctic.flink.read.FlinkSplitPlanner;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.table.KeyedTable;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableScan;
@@ -73,10 +74,13 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
     Snapshot changeSnapshot = table.changeTable().currentSnapshot();
     if (changeSnapshot != null && changeSnapshot.snapshotId() != fromChangeSnapshotId) {
       long snapshotId = changeSnapshot.snapshotId();
-      TableScan tableScan = table.changeTable().newScan().appendsBetween(fromChangeSnapshotId, snapshotId);
+      TableScan tableScan = table.changeTable().newScan();
+
+      if (fromChangeSnapshotId != Long.MIN_VALUE) {
+        tableScan = tableScan.appendsBetween(fromChangeSnapshotId, snapshotId);
+      }
 
       List<ArcticSplit> arcticChangeSplit = planChangeTable(tableScan, splitCount);
-
       return new ContinuousEnumerationResult(
           arcticChangeSplit,
           lastPosition,
@@ -87,17 +91,24 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
 
   private ContinuousEnumerationResult discoverInitialSplits() {
     Snapshot changeSnapshot = table.changeTable().currentSnapshot();
+    List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, splitCount);
+
     if (changeSnapshot != null) {
       long changeStartSnapshotId = table.changeTable().currentSnapshot().snapshotId();
-      List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, splitCount);
-
       return new ContinuousEnumerationResult(
           arcticSplits,
           null,
           ArcticEnumeratorOffset.of(changeStartSnapshotId, null));
     } else {
       LOG.info("There have no change snapshot, table {}.", table);
+
+      if (CollectionUtils.isEmpty(arcticSplits)) {
+        return ContinuousEnumerationResult.EMPTY;
+      }
+      return new ContinuousEnumerationResult(
+          arcticSplits,
+          null,
+          ArcticEnumeratorOffset.of(Long.MIN_VALUE, null));
     }
-    return ContinuousEnumerationResult.EMPTY;
   }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImpl.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.netease.arctic.flink.read.FlinkSplitPlanner.planChangeTable;
+import static com.netease.arctic.flink.read.hybrid.enumerator.ArcticEnumeratorOffset.EARLIEST_SNAPSHOT_ID;
 import static com.netease.arctic.flink.util.ArcticUtils.loadArcticTable;
 
 /**
@@ -93,22 +94,15 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
     Snapshot changeSnapshot = table.changeTable().currentSnapshot();
     List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, splitCount);
 
-    if (changeSnapshot != null) {
-      long changeStartSnapshotId = table.changeTable().currentSnapshot().snapshotId();
-      return new ContinuousEnumerationResult(
-          arcticSplits,
-          null,
-          ArcticEnumeratorOffset.of(changeStartSnapshotId, null));
-    } else {
-      LOG.info("There have no change snapshot, table {}.", table);
-
-      if (CollectionUtils.isEmpty(arcticSplits)) {
-        return ContinuousEnumerationResult.EMPTY;
-      }
-      return new ContinuousEnumerationResult(
-          arcticSplits,
-          null,
-          ArcticEnumeratorOffset.of(Long.MIN_VALUE, null));
+    long changeStartSnapshotId = changeSnapshot != null ? changeSnapshot.snapshotId() : EARLIEST_SNAPSHOT_ID;
+    if (changeSnapshot == null && CollectionUtils.isEmpty(arcticSplits)) {
+      LOG.info("There have no change snapshot, and no base splits in table: {}.", table);
+      return ContinuousEnumerationResult.EMPTY;
     }
+
+    return new ContinuousEnumerationResult(
+        arcticSplits,
+        null,
+        ArcticEnumeratorOffset.of(changeStartSnapshotId, null));
   }
 }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -26,7 +26,9 @@ import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
 import com.netease.arctic.flink.read.source.ArcticScanContext;
 import com.netease.arctic.flink.read.source.DataIterator;
 import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.write.FlinkSink;
+import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
@@ -61,6 +63,7 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
@@ -77,6 +80,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -273,6 +277,55 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
 
     assertArrayEquals(excepts2(), actualResult);
     jobClient.cancel();
+  }
+
+  @Test
+  public void testArcticContinuousSourceWithEmptyChangeInInit() throws Exception {
+    TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_empty_change");
+    KeyedTable table = testCatalog
+        .newTableBuilder(tableId, TABLE_SCHEMA)
+        .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+        .withPartitionSpec(SPEC)
+        .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+        .create().asKeyedTable();
+
+    TaskWriter<RowData> taskWriter = createTaskWriter(true);
+    List<RowData> baseData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+    }};
+    for (RowData record : baseData) {
+      taskWriter.write(record);
+    }
+    commit(table, taskWriter.complete(), true);
+
+    ArcticSource<RowData> arcticSource = initArcticSource(true, FILE_SCAN_STARTUP_MODE_EARLIEST, tableId);
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    // enable checkpoint
+    env.enableCheckpointing(1000);
+    ClientAndIterator<RowData> clientAndIterator = executeAndCollectWithClient(env, arcticSource);
+
+    JobClient jobClient = clientAndIterator.client;
+
+    List<RowData> actualResult = collectRecordsFromUnboundedStream(clientAndIterator, baseData.size());
+
+    Assert.assertEquals(new HashSet<>(baseData), new HashSet<>(actualResult));
+
+    LOG.info("begin write update_before update_after data and commit new snapshot to change table.");
+    writeUpdate(updateRecords(), table);
+    writeUpdate(updateRecords(), table);
+
+    actualResult = collectRecordsFromUnboundedStream(clientAndIterator, excepts2().length * 2);
+
+    Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+    jobClient.cancel();
+
   }
 
   @Test
@@ -528,6 +581,23 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         false);
   }
 
+  private ArcticSource<RowData> initArcticSource(boolean isStreaming, String scanStartupMode,
+                                                 TableIdentifier tableIdentifier) {
+    ArcticTableLoader tableLoader = ArcticTableLoader.of(tableIdentifier, catalogBuilder);
+    ArcticScanContext arcticScanContext = initArcticScanContext(isStreaming, scanStartupMode);
+    ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
+    ReaderFunction<RowData> rowDataReaderFunction = initRowDataReadFunction(table.asKeyedTable());
+    TypeInformation<RowData> typeInformation = InternalTypeInfo.of(FlinkSchemaUtil.convert(table.schema()));
+
+    return new ArcticSource<>(
+        tableLoader,
+        arcticScanContext,
+        rowDataReaderFunction,
+        typeInformation,
+        table.name(),
+        false);
+  }
+
   private ArcticSource<RowData> initArcticDimSource(boolean isStreaming) {
     ArcticTableLoader tableLoader = initLoader();
     ArcticScanContext arcticScanContext = initArcticScanContext(isStreaming, FILE_SCAN_STARTUP_MODE_EARLIEST);
@@ -547,14 +617,18 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
   }
 
   private RowDataReaderFunction initRowDataReadFunction() {
+    return initRowDataReadFunction(testKeyedTable);
+  }
+
+  private RowDataReaderFunction initRowDataReadFunction(KeyedTable keyedTable) {
     return new RowDataReaderFunction(
         new Configuration(),
-        testKeyedTable.schema(),
-        testKeyedTable.schema(),
-        testKeyedTable.primaryKeySpec(),
+        keyedTable.schema(),
+        keyedTable.schema(),
+        keyedTable.primaryKeySpec(),
         null,
         true,
-        testKeyedTable.io()
+        keyedTable.io()
     );
   }
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -322,10 +322,9 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     writeUpdate(updateRecords(), table);
 
     actualResult = collectRecordsFromUnboundedStream(clientAndIterator, excepts2().length * 2);
-
-    Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
     jobClient.cancel();
 
+    Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
   }
 
   @Test

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
@@ -26,6 +26,8 @@ import com.netease.arctic.flink.read.hybrid.split.ChangelogSplit;
 import com.netease.arctic.flink.read.source.DataIterator;
 import com.netease.arctic.scan.ArcticFileScanTask;
 import com.netease.arctic.scan.BaseArcticFileScanTask;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -139,15 +141,17 @@ public class RowDataReaderFunctionTest extends ContinuousSplitPlannerImplTest {
   }
 
   protected void writeUpdate(List<RowData> input) throws IOException {
-    //write change update
-    {
-      TaskWriter<RowData> taskWriter = createTaskWriter(false);
+    writeUpdate(input, testKeyedTable);
+  }
 
-      for (RowData record : input) {
-        taskWriter.write(record);
-      }
-      commit(testKeyedTable, taskWriter.complete(), false);
+  protected void writeUpdate(List<RowData> input, KeyedTable table) throws IOException {
+    //write change update
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(table, ROW_TYPE, TRANSACTION_ID.getAndIncrement(), false);
+
+    for (RowData record : input) {
+      taskWriter.write(record);
     }
+    commit(table, taskWriter.complete(), false);
   }
 
   protected List<RowData> updateRecords() {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -26,6 +26,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  */
 public class ArcticEnumeratorOffset {
   public static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
+
+  /**
+   * use Long.MIN_VALUE to indicate the earliest offset
+   */
+  public static final long EARLIEST_SNAPSHOT_ID = Long.MIN_VALUE;
   private Long changeSnapshotId;
   private Long snapshotTimestampMs;
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+import static com.netease.arctic.flink.read.hybrid.enumerator.ArcticEnumeratorOffset.EARLIEST_SNAPSHOT_ID;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.FILE_SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.FILE_SCAN_STARTUP_MODE_LATEST;
 import static com.netease.arctic.flink.util.ArcticUtils.loadArcticTable;
@@ -113,7 +114,7 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
         FILE_SCAN_STARTUP_MODE_LATEST.equalsIgnoreCase(scanContext.scanStartupMode())) {
       keyedTable.refresh();
       Snapshot snapshot = keyedTable.changeTable().currentSnapshot();
-      long snapshotId = snapshot == null ? Long.MIN_VALUE : snapshot.snapshotId();
+      long snapshotId = snapshot == null ? EARLIEST_SNAPSHOT_ID : snapshot.snapshotId();
       enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshotId, null));
       LOG.info("{} is {}, the current snapshot id of the change table {}  is {}.",
           FILE_SCAN_STARTUP_MODE.key(), FILE_SCAN_STARTUP_MODE_LATEST, keyedTable.id(), snapshot.snapshotId());

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -113,7 +113,8 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
         FILE_SCAN_STARTUP_MODE_LATEST.equalsIgnoreCase(scanContext.scanStartupMode())) {
       keyedTable.refresh();
       Snapshot snapshot = keyedTable.changeTable().currentSnapshot();
-      enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshot.snapshotId(), null));
+      long snapshotId = snapshot == null ? Long.MIN_VALUE : snapshot.snapshotId();
+      enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshotId, null));
       LOG.info("{} is {}, the current snapshot id of the change table {}  is {}.",
           FILE_SCAN_STARTUP_MODE.key(), FILE_SCAN_STARTUP_MODE_LATEST, keyedTable.id(), snapshot.snapshotId());
     }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
@@ -26,6 +26,7 @@ import com.netease.arctic.flink.read.hybrid.split.ChangelogSplit;
 import com.netease.arctic.flink.read.source.DataIterator;
 import com.netease.arctic.scan.ArcticFileScanTask;
 import com.netease.arctic.scan.BaseArcticFileScanTask;
+import com.netease.arctic.table.KeyedTable;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -139,15 +140,17 @@ public class RowDataReaderFunctionTest extends ContinuousSplitPlannerImplTest {
   }
 
   protected void writeUpdate(List<RowData> input) throws IOException {
-    //write change update
-    {
-      TaskWriter<RowData> taskWriter = createTaskWriter(false);
+    writeUpdate(input, testKeyedTable);
+  }
 
-      for (RowData record : input) {
-        taskWriter.write(record);
-      }
-      commit(testKeyedTable, taskWriter.complete(), false);
+  protected void writeUpdate(List<RowData> input, KeyedTable table) throws IOException {
+    //write change update
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(table, ROW_TYPE, TRANSACTION_ID.getAndIncrement(), false);
+
+    for (RowData record : input) {
+      taskWriter.write(record);
     }
+    commit(table, taskWriter.complete(), false);
   }
 
   protected List<RowData> updateRecords() {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -26,6 +26,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  */
 public class ArcticEnumeratorOffset {
   public static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
+
+  /**
+   * use Long.MIN_VALUE to indicate the earliest offset
+   */
+  public static final long EARLIEST_SNAPSHOT_ID = Long.MIN_VALUE;
   private Long changeSnapshotId;
   private Long snapshotTimestampMs;
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -114,7 +114,8 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
         FILE_SCAN_STARTUP_MODE_LATEST.equalsIgnoreCase(scanContext.scanStartupMode())) {
       keyedTable.refresh();
       Snapshot snapshot = keyedTable.changeTable().currentSnapshot();
-      enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshot.snapshotId(), null));
+      long snapshotId = snapshot == null ? Long.MIN_VALUE : snapshot.snapshotId();
+      enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshotId, null));
       LOG.info("{} is {}, the current snapshot id of the change table {}  is {}.",
           FILE_SCAN_STARTUP_MODE.key(), FILE_SCAN_STARTUP_MODE_LATEST, keyedTable.id(), snapshot.snapshotId());
     }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+import static com.netease.arctic.flink.read.hybrid.enumerator.ArcticEnumeratorOffset.EARLIEST_SNAPSHOT_ID;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.FILE_SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.FILE_SCAN_STARTUP_MODE_LATEST;
 import static com.netease.arctic.flink.util.ArcticUtils.loadArcticTable;
@@ -114,7 +115,7 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
         FILE_SCAN_STARTUP_MODE_LATEST.equalsIgnoreCase(scanContext.scanStartupMode())) {
       keyedTable.refresh();
       Snapshot snapshot = keyedTable.changeTable().currentSnapshot();
-      long snapshotId = snapshot == null ? Long.MIN_VALUE : snapshot.snapshotId();
+      long snapshotId = snapshot == null ? EARLIEST_SNAPSHOT_ID : snapshot.snapshotId();
       enumeratorPosition.set(ArcticEnumeratorOffset.of(snapshotId, null));
       LOG.info("{} is {}, the current snapshot id of the change table {}  is {}.",
           FILE_SCAN_STARTUP_MODE.key(), FILE_SCAN_STARTUP_MODE_LATEST, keyedTable.id(), snapshot.snapshotId());

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
@@ -26,6 +26,7 @@ import com.netease.arctic.flink.read.hybrid.split.ChangelogSplit;
 import com.netease.arctic.flink.read.source.DataIterator;
 import com.netease.arctic.scan.ArcticFileScanTask;
 import com.netease.arctic.scan.BaseArcticFileScanTask;
+import com.netease.arctic.table.KeyedTable;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -139,15 +140,17 @@ public class RowDataReaderFunctionTest extends ContinuousSplitPlannerImplTest {
   }
 
   protected void writeUpdate(List<RowData> input) throws IOException {
-    //write change update
-    {
-      TaskWriter<RowData> taskWriter = createTaskWriter(false);
+    writeUpdate(input, testKeyedTable);
+  }
 
-      for (RowData record : input) {
-        taskWriter.write(record);
-      }
-      commit(testKeyedTable, taskWriter.complete(), false);
+  protected void writeUpdate(List<RowData> input, KeyedTable table) throws IOException {
+    //write change update
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(table, ROW_TYPE, TRANSACTION_ID.getAndIncrement(), false);
+
+    for (RowData record : input) {
+      taskWriter.write(record);
     }
+    commit(table, taskWriter.complete(), false);
   }
 
   protected List<RowData> updateRecords() {


### PR DESCRIPTION
Fix #172 

## Why are the changes needed?
If arctic's file-store only have data in base-table, but nothing in change-table, arctic source will reading nothing in ContinuousSplitPlannerImpl#discoverInitialSplits because changeSnapshot in change-table is null.
The data in base-table can be insert overwrite through Spark.

We should fix it.

## Brief change log
  - *The flink 1.12 and 1.14, 1.15 versions are affected.*
  - *Plan split if there is no snapshot in change-store, only some in base-store.*

## How was this patch tested?
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
