### PR TITLE
[ARCTIC-314][AMS] Clear optimize tasks when commit failed and support pos-delete in unkeyed table

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.OverwriteFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.util.StructLikeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,8 @@ public class BaseOptimizeCommit {
   protected final Map<String, TableTaskHistory> commitTableTaskHistory = new HashMap<>();
   protected final Map<String, OptimizeType> partitionOptimizeType = new HashMap<>();
 
-  public BaseOptimizeCommit(ArcticTable arcticTable, Map<String, List<OptimizeTaskItem>> optimizeTasksToCommit) {
+  public BaseOptimizeCommit(ArcticTable arcticTable,
+                            Map<String, List<OptimizeTaskItem>> optimizeTasksToCommit) {
     this.arcticTable = arcticTable;
     this.optimizeTasksToCommit = optimizeTasksToCommit;
   }
@@ -75,11 +77,11 @@ public class BaseOptimizeCommit {
     return commitTableTaskHistory;
   }
 
-  public long commit(TableOptimizeRuntime tableOptimizeRuntime) throws Exception {
+  public boolean commit(long baseSnapshotId) throws Exception {
     try {
       if (optimizeTasksToCommit.isEmpty()) {
         LOG.info("{} get no tasks to commit", arcticTable.id());
-        return 0;
+        return true;
       }
       LOG.info("{} get tasks to commit for partitions {}", arcticTable.id(),
           optimizeTasksToCommit.keySet());
@@ -142,128 +144,25 @@ public class BaseOptimizeCommit {
         }
       }
 
-      UnkeyedTable baseArcticTable;
-      if (arcticTable.isKeyedTable()) {
-        baseArcticTable = arcticTable.asKeyedTable().baseTable();
-      } else {
-        baseArcticTable = arcticTable.asUnkeyedTable();
-      }
-
+      StructLikeMap<Long> minTransactionIds = getMinTransactionId(minorAddFiles);
       // commit minor optimize content
-      if (CollectionUtils.isNotEmpty(minorAddFiles) || CollectionUtils.isNotEmpty(minorDeleteFiles)) {
-        OverwriteBaseFiles overwriteBaseFiles = new OverwriteBaseFiles(arcticTable.asKeyedTable());
-        overwriteBaseFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
-        AtomicInteger addedPosDeleteFile = new AtomicInteger(0);
-        minorAddFiles.forEach(contentFile -> {
-          if (contentFile.content() == FileContent.DATA) {
-            overwriteBaseFiles.addFile((DataFile) contentFile);
-          } else {
-            overwriteBaseFiles.addFile((DeleteFile) contentFile);
-            addedPosDeleteFile.incrementAndGet();
-          }
-        });
-        AtomicInteger deletedPosDeleteFile = new AtomicInteger(0);
-        Set<DeleteFile> deletedPosDeleteFiles = new HashSet<>();
-        minorDeleteFiles.forEach(contentFile -> {
-          if (contentFile.content() == FileContent.DATA) {
-            overwriteBaseFiles.deleteFile((DataFile) contentFile);
-          } else {
-            deletedPosDeleteFiles.add((DeleteFile) contentFile);
-          }
-        });
-
-        if (spec.isUnpartitioned()) {
-          overwriteBaseFiles.withMaxTransactionId(TablePropertyUtil.EMPTY_STRUCT,
-              maxTransactionIds.get(TablePropertyUtil.EMPTY_STRUCT));
-        } else {
-          maxTransactionIds.forEach(overwriteBaseFiles::withMaxTransactionId);
-        }
-        overwriteBaseFiles.commit();
-
-        if (CollectionUtils.isNotEmpty(deletedPosDeleteFiles)) {
-          RewriteFiles rewriteFiles = baseArcticTable.newRewrite();
-          rewriteFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
-          rewriteFiles.rewriteFiles(Collections.emptySet(), deletedPosDeleteFiles,
-              Collections.emptySet(), Collections.emptySet());
-          try {
-            rewriteFiles.commit();
-          } catch (ValidationException e) {
-            LOG.warn("Iceberg RewriteFiles commit failed, but ignore", e);
-          }
-        }
-
-        LOG.info("{} minor optimize committed, delete {} files [{} posDelete files], " +
-                "add {} new files [{} posDelete files]",
-            arcticTable.id(), minorDeleteFiles.size(), deletedPosDeleteFile.get(), minorAddFiles.size(),
-            addedPosDeleteFile.get());
-      } else {
-        LOG.info("{} skip minor optimize commit", arcticTable.id());
-      }
+      minorCommit(arcticTable, minorAddFiles, minorDeleteFiles, maxTransactionIds, minTransactionIds);
 
       // commit major optimize content
-      if (CollectionUtils.isNotEmpty(majorAddFiles) || CollectionUtils.isNotEmpty(majorDeleteFiles)) {
-        Set<DataFile> addDataFiles = majorAddFiles.stream().map(contentFile -> {
-          if (contentFile.content() == FileContent.DATA) {
-            return (DataFile) contentFile;
-          }
+      majorCommit(arcticTable, majorAddFiles, majorDeleteFiles, baseSnapshotId);
 
-          return null;
-        }).filter(Objects::nonNull).collect(Collectors.toSet());
-        Set<DeleteFile> addDeleteFiles = majorAddFiles.stream().map(contentFile -> {
-          if (contentFile.content() == FileContent.POSITION_DELETES) {
-            return (DeleteFile) contentFile;
-          }
-
-          return null;
-        }).filter(Objects::nonNull).collect(Collectors.toSet());
-
-        Set<DataFile> deleteDataFiles = majorDeleteFiles.stream().map(contentFile -> {
-          if (contentFile.content() == FileContent.DATA) {
-            return (DataFile) contentFile;
-          }
-
-          return null;
-        }).filter(Objects::nonNull).collect(Collectors.toSet());
-        Set<DeleteFile> deleteDeleteFiles = majorDeleteFiles.stream().map(contentFile -> {
-          if (contentFile.content() == FileContent.POSITION_DELETES) {
-            return (DeleteFile) contentFile;
-          }
-
-          return null;
-        }).filter(Objects::nonNull).collect(Collectors.toSet());
-
-        if (!addDeleteFiles.isEmpty()) {
-          throw new IllegalArgumentException("for major optimize, can't add delete files " + addDeleteFiles);
-        }
-
-        // overwrite DataFiles
-        OverwriteFiles overwriteFiles = baseArcticTable.newOverwrite();
-        overwriteFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
-        deleteDataFiles.forEach(overwriteFiles::deleteFile);
-        addDataFiles.forEach(overwriteFiles::addFile);
-        overwriteFiles.commit();
-
-        // remove DeleteFiles
-        if (CollectionUtils.isNotEmpty(deleteDeleteFiles)) {
-          RewriteFiles rewriteFiles = baseArcticTable.newRewrite()
-              .validateFromSnapshot(baseArcticTable.currentSnapshot().snapshotId());
-          rewriteFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
-          rewriteFiles.rewriteFiles(Collections.emptySet(), deleteDeleteFiles, Collections.emptySet(), addDeleteFiles);
-          try {
-            rewriteFiles.commit();
-          } catch (ValidationException e) {
-            LOG.warn("Iceberg RewriteFiles commit failed, but ignore", e);
-          }
-        }
-
-        LOG.info("{} major optimize committed, delete {} files [{} posDelete files], " +
-                "add {} new files [{} posDelete files]",
-            arcticTable.id(), majorDeleteFiles.size(), deleteDeleteFiles.size(), majorAddFiles.size(),
-            addDeleteFiles.size());
+      return true;
+    } catch (ValidationException e) {
+      String missFileMessage = "Missing required files to delete";
+      String foundNewDeleteMessage = "found new delete for replaced data file";
+      if (e.getMessage().contains(missFileMessage) ||
+          e.getMessage().contains(foundNewDeleteMessage)) {
+        LOG.warn("Optimize commit table {} failed, give up commit.", arcticTable.id(), e);
+        return false;
       } else {
-        LOG.info("{} skip major optimize commit", arcticTable.id());
+        LOG.error("unexpected commit error " + arcticTable.id(), e);
+        throw new Exception("unexpected commit error ", e);
       }
-      return System.currentTimeMillis();
     } catch (Throwable t) {
       LOG.error("unexpected commit error " + arcticTable.id(), t);
       throw new Exception("unexpected commit error ", t);
@@ -272,6 +171,162 @@ public class BaseOptimizeCommit {
 
   public Map<String, OptimizeType> getPartitionOptimizeType() {
     return partitionOptimizeType;
+  }
+
+  private void minorCommit(ArcticTable arcticTable,
+                           Set<ContentFile<?>> minorAddFiles,
+                           Set<ContentFile<?>> minorDeleteFiles,
+                           StructLikeMap<Long> maxTransactionIds,
+                           StructLikeMap<Long> minTransactionIds) {
+    UnkeyedTable baseArcticTable;
+    if (arcticTable.isKeyedTable()) {
+      baseArcticTable = arcticTable.asKeyedTable().baseTable();
+    } else {
+      baseArcticTable = arcticTable.asUnkeyedTable();
+    }
+
+    if (CollectionUtils.isNotEmpty(minorAddFiles) || CollectionUtils.isNotEmpty(minorDeleteFiles)) {
+      OverwriteBaseFiles overwriteBaseFiles = new OverwriteBaseFiles(arcticTable.asKeyedTable());
+      overwriteBaseFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
+      overwriteBaseFiles.validateNoConflictingAppends(Expressions.alwaysFalse());
+      AtomicInteger addedPosDeleteFile = new AtomicInteger(0);
+      StructLikeMap<Long> oldPartitionMaxIds =
+          TablePropertyUtil.getPartitionMaxTransactionId(arcticTable.asKeyedTable());
+      minorAddFiles.forEach(contentFile -> {
+        // if partition min transactionId isn't bigger than max transactionId in partitionProperty,
+        // the partition files is expired
+        Long oldTransactionId = oldPartitionMaxIds.getOrDefault(contentFile.partition(), -1L);
+        Long newMinTransactionId = minTransactionIds.getOrDefault(contentFile.partition(), Long.MAX_VALUE);
+        if (oldTransactionId >= newMinTransactionId) {
+          maxTransactionIds.remove(contentFile.partition());
+          return;
+        }
+
+        if (contentFile.content() == FileContent.DATA) {
+          overwriteBaseFiles.addFile((DataFile) contentFile);
+        } else {
+          overwriteBaseFiles.addFile((DeleteFile) contentFile);
+          addedPosDeleteFile.incrementAndGet();
+        }
+      });
+      AtomicInteger deletedPosDeleteFile = new AtomicInteger(0);
+      Set<DeleteFile> deletedPosDeleteFiles = new HashSet<>();
+      minorDeleteFiles.forEach(contentFile -> {
+        if (contentFile.content() == FileContent.DATA) {
+          overwriteBaseFiles.deleteFile((DataFile) contentFile);
+        } else {
+          deletedPosDeleteFiles.add((DeleteFile) contentFile);
+        }
+      });
+
+      if (arcticTable.spec().isUnpartitioned()) {
+        if (maxTransactionIds.get(TablePropertyUtil.EMPTY_STRUCT) != null) {
+          overwriteBaseFiles.withMaxTransactionId(TablePropertyUtil.EMPTY_STRUCT,
+              maxTransactionIds.get(TablePropertyUtil.EMPTY_STRUCT));
+        }
+      } else {
+        maxTransactionIds.forEach(overwriteBaseFiles::withMaxTransactionId);
+      }
+      overwriteBaseFiles.commit();
+
+      if (CollectionUtils.isNotEmpty(deletedPosDeleteFiles)) {
+        RewriteFiles rewriteFiles = baseArcticTable.newRewrite();
+        rewriteFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
+        rewriteFiles.rewriteFiles(Collections.emptySet(), deletedPosDeleteFiles,
+            Collections.emptySet(), Collections.emptySet());
+        try {
+          rewriteFiles.commit();
+        } catch (ValidationException e) {
+          LOG.warn("Iceberg RewriteFiles commit failed, but ignore", e);
+        }
+      }
+
+      LOG.info("{} minor optimize committed, delete {} files [{} posDelete files], " +
+              "add {} new files [{} posDelete files]",
+          arcticTable.id(), minorDeleteFiles.size(), deletedPosDeleteFile.get(), minorAddFiles.size(),
+          addedPosDeleteFile.get());
+    } else {
+      LOG.info("{} skip minor optimize commit", arcticTable.id());
+    }
+  }
+
+  private void majorCommit(ArcticTable arcticTable,
+                           Set<ContentFile<?>> majorAddFiles,
+                           Set<ContentFile<?>> majorDeleteFiles,
+                           long baseSnapshotId) {
+    UnkeyedTable baseArcticTable;
+    if (arcticTable.isKeyedTable()) {
+      baseArcticTable = arcticTable.asKeyedTable().baseTable();
+    } else {
+      baseArcticTable = arcticTable.asUnkeyedTable();
+    }
+
+    if (CollectionUtils.isNotEmpty(majorAddFiles) || CollectionUtils.isNotEmpty(majorDeleteFiles)) {
+      Set<DataFile> addDataFiles = majorAddFiles.stream().map(contentFile -> {
+        if (contentFile.content() == FileContent.DATA) {
+          return (DataFile) contentFile;
+        }
+
+        return null;
+      }).filter(Objects::nonNull).collect(Collectors.toSet());
+      Set<DeleteFile> addDeleteFiles = majorAddFiles.stream().map(contentFile -> {
+        if (contentFile.content() == FileContent.POSITION_DELETES) {
+          return (DeleteFile) contentFile;
+        }
+
+        return null;
+      }).filter(Objects::nonNull).collect(Collectors.toSet());
+
+      Set<DataFile> deleteDataFiles = majorDeleteFiles.stream().map(contentFile -> {
+        if (contentFile.content() == FileContent.DATA) {
+          return (DataFile) contentFile;
+        }
+
+        return null;
+      }).filter(Objects::nonNull).collect(Collectors.toSet());
+      Set<DeleteFile> deleteDeleteFiles = majorDeleteFiles.stream().map(contentFile -> {
+        if (contentFile.content() == FileContent.POSITION_DELETES) {
+          return (DeleteFile) contentFile;
+        }
+
+        return null;
+      }).filter(Objects::nonNull).collect(Collectors.toSet());
+
+      if (!addDeleteFiles.isEmpty()) {
+        throw new IllegalArgumentException("for major optimize, can't add delete files " + addDeleteFiles);
+      }
+
+      // overwrite DataFiles
+      OverwriteFiles overwriteFiles = baseArcticTable.newOverwrite();
+      overwriteFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
+      overwriteFiles.validateNoConflictingAppends(Expressions.alwaysFalse());
+      deleteDataFiles.forEach(overwriteFiles::deleteFile);
+      addDataFiles.forEach(overwriteFiles::addFile);
+      if (baseSnapshotId != TableOptimizeRuntime.INVALID_SNAPSHOT_ID) {
+        overwriteFiles.validateFromSnapshot(baseSnapshotId);
+      }
+      overwriteFiles.commit();
+
+      // remove DeleteFiles
+      if (CollectionUtils.isNotEmpty(deleteDeleteFiles)) {
+        RewriteFiles rewriteFiles = baseArcticTable.newRewrite()
+            .validateFromSnapshot(baseArcticTable.currentSnapshot().snapshotId());
+        rewriteFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
+        rewriteFiles.rewriteFiles(Collections.emptySet(), deleteDeleteFiles, Collections.emptySet(), addDeleteFiles);
+        try {
+          rewriteFiles.commit();
+        } catch (ValidationException e) {
+          LOG.warn("Iceberg RewriteFiles commit failed, but ignore", e);
+        }
+      }
+
+      LOG.info("{} major optimize committed, delete {} files [{} posDelete files], " +
+              "add {} new files [{} posDelete files]",
+          arcticTable.id(), majorDeleteFiles.size(), deleteDeleteFiles.size(), majorAddFiles.size(),
+          addDeleteFiles.size());
+    } else {
+      LOG.info("{} skip major optimize commit", arcticTable.id());
+    }
   }
 
   private static Set<ContentFile<?>> selectDeletedFiles(BaseOptimizeTask optimizeTask,
@@ -311,6 +366,23 @@ public class BaseOptimizeCommit {
     if (optimizeTask.getTaskId().getType() == OptimizeType.FullMajor) {
       result.addAll(optimizeTask.getPosDeleteFiles().stream()
           .map(SerializationUtil::toInternalTableFile).collect(Collectors.toSet()));
+    }
+
+    return result;
+  }
+
+  private StructLikeMap<Long> getMinTransactionId(Set<ContentFile<?>> minorAddFiles) {
+    StructLikeMap<Long> result = StructLikeMap.create(arcticTable.spec().partitionType());
+
+    for (ContentFile<?> minorAddFile : minorAddFiles) {
+      DefaultKeyedFile.FileMeta fileMeta = DefaultKeyedFile.parseMetaFromFileName(minorAddFile.path().toString());
+      if (fileMeta.transactionId() != 0) {
+        long minTransactionId = fileMeta.transactionId();
+        if (result.get(minorAddFile.partition()) != null) {
+          minTransactionId = Math.min(minTransactionId, result.get(minorAddFile.partition()));
+        }
+        result.put(minorAddFile.partition(), minTransactionId);
+      }
     }
 
     return result;

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
@@ -153,7 +153,8 @@ public class FullOptimizePlan extends BaseOptimizePlan {
   private List<BaseOptimizeTask> collectUnKeyedTableTasks(String partition, List<DataFile> fileList) {
     List<BaseOptimizeTask> collector = new ArrayList<>();
 
-    if (needOptimize(Collections.emptyList(), fileList)) {
+    List<DeleteFile> posDeleteFiles = partitionPosDeleteFiles.getOrDefault(partition, Collections.emptyList());
+    if (needOptimize(posDeleteFiles, fileList)) {
       String group = UUID.randomUUID().toString();
       long createTime = System.currentTimeMillis();
       TaskConfig taskPartitionConfig = new TaskConfig(partition,

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
@@ -170,7 +170,7 @@ public class FullOptimizePlan extends BaseOptimizePlan {
       for (List<DataFile> files : packed) {
         if (CollectionUtils.isNotEmpty(files)) {
           collector.add(buildOptimizeTask(null,
-              Collections.emptyList(), Collections.emptyList(), files, Collections.emptyList(), taskPartitionConfig));
+              Collections.emptyList(), Collections.emptyList(), files, posDeleteFiles, taskPartitionConfig));
         }
       }
     }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/MajorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/MajorOptimizePlan.java
@@ -111,6 +111,7 @@ public class MajorOptimizePlan extends BaseOptimizePlan {
       result = collectUnKeyedTableTasks(partition, fileList);
       // init files
       partitionNeedMajorOptimizeFiles.put(partition, Collections.emptyList());
+      partitionPosDeleteFiles.put(partition, Collections.emptyList());
       partitionFileTree.get(partition).initFiles();
     } else {
       FileTree treeRoot = partitionFileTree.get(partition);
@@ -237,8 +238,9 @@ public class MajorOptimizePlan extends BaseOptimizePlan {
         .pack(fileList, DataFile::fileSizeInBytes);
     for (List<DataFile> files : packed) {
       if (CollectionUtils.isNotEmpty(files)) {
+        List<DeleteFile> posDeleteFiles = partitionPosDeleteFiles.getOrDefault(partition, Collections.emptyList());
         collector.add(buildOptimizeTask(null,
-            Collections.emptyList(), Collections.emptyList(), files, Collections.emptyList(), taskPartitionConfig));
+            Collections.emptyList(), Collections.emptyList(), files, posDeleteFiles, taskPartitionConfig));
       }
     }
     return collector;

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeTaskItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeTaskItem.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.ams.server.optimize;
 
+import com.google.common.base.Preconditions;
 import com.netease.arctic.ams.api.ErrorMessage;
 import com.netease.arctic.ams.api.JobId;
 import com.netease.arctic.ams.api.OptimizeStatus;
@@ -84,6 +85,8 @@ public class OptimizeTaskItem extends IJDBCService {
   public void onPending() {
     lock.lock();
     try {
+      Preconditions.checkArgument(optimizeRuntime.getStatus() != OptimizeStatus.Prepared,
+          "task prepared, can't on pending");
       BaseOptimizeTaskRuntime newRuntime = optimizeRuntime.clone();
       if (newRuntime.getStatus() == OptimizeStatus.Failed) {
         newRuntime.setRetry(newRuntime.getRetry() + 1);
@@ -100,6 +103,8 @@ public class OptimizeTaskItem extends IJDBCService {
   public TableTaskHistory onExecuting(JobId jobId, String attemptId) {
     lock.lock();
     try {
+      Preconditions.checkArgument(optimizeRuntime.getStatus() != OptimizeStatus.Prepared,
+          "task prepared, can't on executing");
       BaseOptimizeTaskRuntime newRuntime = optimizeRuntime.clone();
       long currentTime = System.currentTimeMillis();
       newRuntime.setAttemptId(attemptId);
@@ -139,6 +144,8 @@ public class OptimizeTaskItem extends IJDBCService {
     long reportTime = System.currentTimeMillis();
     lock.lock();
     try {
+      Preconditions.checkArgument(optimizeRuntime.getStatus() != OptimizeStatus.Prepared,
+          "task prepared, can't on failed");
       BaseOptimizeTaskRuntime newRuntime = optimizeRuntime.clone();
       newRuntime.setErrorMessage(errorMessage);
       newRuntime.setStatus(OptimizeStatus.Failed);
@@ -157,6 +164,8 @@ public class OptimizeTaskItem extends IJDBCService {
     long reportTime = System.currentTimeMillis();
     lock.lock();
     try {
+      Preconditions.checkArgument(optimizeRuntime.getStatus() != OptimizeStatus.Prepared,
+          "task prepared, can't on prepared");
       BaseOptimizeTaskRuntime newRuntime = optimizeRuntime.clone();
       if (newRuntime.getExecuteTime() == BaseOptimizeTaskRuntime.INVALID_TIME) {
         newRuntime.setExecuteTime(preparedTime);

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeTaskItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeTaskItem.java
@@ -69,6 +69,10 @@ public class OptimizeTaskItem extends IJDBCService {
     return optimizeRuntime;
   }
 
+  public void setOptimizeRuntime(BaseOptimizeTaskRuntime optimizeRuntime) {
+    this.optimizeRuntime = optimizeRuntime;
+  }
+
   public TableIdentifier getTableIdentifier() {
     return new TableIdentifier(optimizeTask.getTableIdentifier());
   }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveCommit.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import com.netease.arctic.ams.api.OptimizeType;
 import com.netease.arctic.ams.server.model.BaseOptimizeTask;
 import com.netease.arctic.ams.server.model.BaseOptimizeTaskRuntime;
-import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.data.DefaultKeyedFile;
 import com.netease.arctic.hive.HMSClient;
 import com.netease.arctic.hive.table.SupportHive;
@@ -45,7 +44,7 @@ public class SupportHiveCommit extends BaseOptimizeCommit {
   }
 
   @Override
-  public long commit(TableOptimizeRuntime tableOptimizeRuntime) throws Exception {
+  public boolean commit(long baseSnapshotId) throws Exception {
     LOG.info("{} get tasks to support hive commit for partitions {}", arcticTable.id(),
         optimizeTasksToCommit.keySet());
     HMSClient hiveClient = ((SupportHive) arcticTable).getHMSClient();
@@ -113,7 +112,7 @@ public class SupportHiveCommit extends BaseOptimizeCommit {
       }
     });
 
-    return super.commit(tableOptimizeRuntime);
+    return super.commit(baseSnapshotId);
   }
 
   protected boolean isPartitionMajorOptimizeSupportHive(String partition, List<OptimizeTaskItem> optimizeTaskItems) {

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizeCommit.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizeCommit.java
@@ -99,7 +99,7 @@ public class TestMajorOptimizeCommit extends TestBaseOptimizeBase {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     BaseOptimizeCommit optimizeCommit = new BaseOptimizeCommit(testKeyedTable, partitionTasks);
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testKeyedTable.baseTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     Set<String> newDeleteFilesPath = new HashSet<>();

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
@@ -23,10 +23,17 @@ import com.netease.arctic.ams.api.OptimizeType;
 import com.netease.arctic.ams.server.model.BaseOptimizeTask;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.ams.server.util.DataFileInfoUtils;
+import com.netease.arctic.hive.io.writer.AdaptHiveGenericTaskWriterBuilder;
+import com.netease.arctic.io.writer.SortedPosDeleteWriter;
+import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.table.UnkeyedTable;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.data.AdaptHiveGenericAppenderFactory;
 import org.apache.iceberg.data.GenericRecord;
@@ -45,6 +52,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
@@ -88,7 +96,7 @@ public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
 
   @Test
   public void testUnKeyedTableMajorOptimize() {
-    insertUnKeyedTableDataFiles();
+    insertUnKeyedTableDataFiles(testTable);
 
     MajorOptimizePlan majorOptimizePlan = new MajorOptimizePlan(testTable,
         new TableOptimizeRuntime(testTable.id()), baseDataFilesInfo, posDeleteFilesInfo,
@@ -108,7 +116,7 @@ public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
     testTable.updateProperties()
         .set(TableProperties.FULL_OPTIMIZE_TRIGGER_MAX_INTERVAL, "86400000")
         .commit();
-    insertUnKeyedTableDataFiles();
+    insertUnKeyedTableDataFiles(testTable);
 
     FullOptimizePlan fullOptimizePlan = new FullOptimizePlan(testTable,
         new TableOptimizeRuntime(testTable.id()), baseDataFilesInfo, posDeleteFilesInfo,
@@ -119,6 +127,43 @@ public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
     Assert.assertEquals(2, tasks.size());
     Assert.assertEquals(5, tasks.get(0).getBaseFileCnt());
     Assert.assertEquals(0, tasks.get(0).getPosDeleteFiles().size());
+    Assert.assertEquals(0, tasks.get(0).getInsertFileCnt());
+    Assert.assertEquals(0, tasks.get(0).getDeleteFileCnt());
+  }
+
+  @Test
+  public void testUnKeyedTableMajorOptimizeWithPosDelete() throws Exception {
+    insertUnKeyedTablePosDeleteFiles(testTable);
+
+    MajorOptimizePlan majorOptimizePlan = new MajorOptimizePlan(testTable,
+        new TableOptimizeRuntime(testTable.id()), baseDataFilesInfo, posDeleteFilesInfo,
+        new HashMap<>(), 1, System.currentTimeMillis(), snapshotId -> true);
+    List<BaseOptimizeTask> tasks = majorOptimizePlan.plan();
+
+    Assert.assertEquals(OptimizeType.Major, tasks.get(0).getTaskId().getType());
+    Assert.assertEquals(2, tasks.size());
+    Assert.assertEquals(5, tasks.get(0).getBaseFileCnt());
+    Assert.assertEquals(1, tasks.get(0).getPosDeleteFiles().size());
+    Assert.assertEquals(0, tasks.get(0).getInsertFileCnt());
+    Assert.assertEquals(0, tasks.get(0).getDeleteFileCnt());
+  }
+
+  @Test
+  public void testUnKeyedTableFullOptimizeWithPosDelete() throws Exception {
+    testTable.updateProperties()
+        .set(TableProperties.FULL_OPTIMIZE_TRIGGER_MAX_INTERVAL, "86400000")
+        .commit();
+    insertUnKeyedTablePosDeleteFiles(testTable);
+
+    FullOptimizePlan fullOptimizePlan = new FullOptimizePlan(testTable,
+        new TableOptimizeRuntime(testTable.id()), baseDataFilesInfo, posDeleteFilesInfo,
+        new HashMap<>(), 1, System.currentTimeMillis(), snapshotId -> true);
+    List<BaseOptimizeTask> tasks = fullOptimizePlan.plan();
+
+    Assert.assertEquals(OptimizeType.FullMajor, tasks.get(0).getTaskId().getType());
+    Assert.assertEquals(2, tasks.size());
+    Assert.assertEquals(5, tasks.get(0).getBaseFileCnt());
+    Assert.assertEquals(1, tasks.get(0).getPosDeleteFiles().size());
     Assert.assertEquals(0, tasks.get(0).getInsertFileCnt());
     Assert.assertEquals(0, tasks.get(0).getDeleteFileCnt());
   }
@@ -161,18 +206,51 @@ public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
     Assert.assertEquals(0, tasks.get(0).getDeleteFileCnt());
   }
 
-  private void insertUnKeyedTableDataFiles() {
+  private List<DataFile> insertUnKeyedTableDataFiles(ArcticTable arcticTable) {
     List<DataFile> dataFiles = insertUnKeyedTableDataFile(FILE_A.partition(), LocalDateTime.of(2022, 1, 1, 12, 0, 0), 5);
     dataFiles.addAll(insertUnKeyedTableDataFile(FILE_B.partition(), LocalDateTime.of(2022, 1, 2, 12, 0, 0), 5));
 
-    AppendFiles appendFiles = testTable.newAppend();
+    AppendFiles appendFiles = arcticTable.asUnkeyedTable().newAppend();
     dataFiles.forEach(appendFiles::appendFile);
     appendFiles.commit();
 
     long commitTime = System.currentTimeMillis();
     baseDataFilesInfo = dataFiles.stream()
-        .map(dataFile -> DataFileInfoUtils.convertToDatafileInfo(dataFile, commitTime, testTable))
+        .map(dataFile -> DataFileInfoUtils.convertToDatafileInfo(dataFile, commitTime, arcticTable))
         .collect(Collectors.toList());
+
+    return dataFiles;
+  }
+
+  private void insertUnKeyedTablePosDeleteFiles(ArcticTable arcticTable) throws Exception {
+    List<DataFile> dataFiles = insertUnKeyedTableDataFiles(arcticTable);
+
+    Map<StructLike, List<DataFile>> dataFilesPartitionMap =
+        new HashMap<>(dataFiles.stream().collect(Collectors.groupingBy(ContentFile::partition)));
+    List<DeleteFile> deleteFiles = new ArrayList<>();
+    for (Map.Entry<StructLike, List<DataFile>> dataFilePartitionMap : dataFilesPartitionMap.entrySet()) {
+      StructLike partition = dataFilePartitionMap.getKey();
+      List<DataFile> partitionFiles = dataFilePartitionMap.getValue();
+      SortedPosDeleteWriter<Record> posDeleteWriter = AdaptHiveGenericTaskWriterBuilder.builderFor(arcticTable)
+          .withTransactionId(0)
+          .buildBasePosDeleteWriter(0, 0, partition);
+      for (DataFile partitionFile : partitionFiles) {
+        // write pos delete
+        posDeleteWriter.delete(partitionFile.path(), 0);
+      }
+      deleteFiles.addAll(posDeleteWriter.complete());
+    }
+
+    UnkeyedTable baseTable = arcticTable.isKeyedTable() ?
+        arcticTable.asKeyedTable().baseTable() : arcticTable.asUnkeyedTable();
+    RowDelta rowDelta = baseTable.newRowDelta();
+    deleteFiles.forEach(rowDelta::addDeletes);
+    rowDelta.commit();
+
+    long commitTime = System.currentTimeMillis();
+    posDeleteFilesInfo.addAll(deleteFiles.stream()
+        .map(deleteFile -> DataFileInfoUtils.convertToDatafileInfo(deleteFile, commitTime, arcticTable))
+        .collect(Collectors.toList()));
   }
 
   private List<DataFile> insertUnKeyedTableDataFile(StructLike partitionData, LocalDateTime opTime, int count) {

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMinorOptimizeCommit.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMinorOptimizeCommit.java
@@ -117,7 +117,7 @@ public class TestMinorOptimizeCommit extends TestMinorOptimizePlan {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     BaseOptimizeCommit optimizeCommit = new BaseOptimizeCommit(testKeyedTable, partitionTasks);
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testKeyedTable.baseTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     Set<String> newDeleteFilesPath = new HashSet<>();
@@ -181,7 +181,7 @@ public class TestMinorOptimizeCommit extends TestMinorOptimizePlan {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     BaseOptimizeCommit optimizeCommit = new BaseOptimizeCommit(testNoPartitionTable, partitionTasks);
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testNoPartitionTable.baseTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     Set<String> newDeleteFilesPath = new HashSet<>();

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestSupportHiveMajorOptimizeCommit.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestSupportHiveMajorOptimizeCommit.java
@@ -81,7 +81,7 @@ public class TestSupportHiveMajorOptimizeCommit extends TestSupportHiveBase {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     SupportHiveCommit optimizeCommit = new SupportHiveCommit(testKeyedHiveTable, partitionTasks, taskItem -> {});
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testKeyedHiveTable.baseTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     Set<String> newDeleteFilesPath = new HashSet<>();
@@ -132,7 +132,7 @@ public class TestSupportHiveMajorOptimizeCommit extends TestSupportHiveBase {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     SupportHiveCommit optimizeCommit = new SupportHiveCommit(testKeyedHiveTable, partitionTasks, taskItem -> {});
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testKeyedHiveTable.baseTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     testKeyedHiveTable.baseTable().newScan().planFiles()
@@ -181,7 +181,7 @@ public class TestSupportHiveMajorOptimizeCommit extends TestSupportHiveBase {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     SupportHiveCommit optimizeCommit = new SupportHiveCommit(testKeyedHiveTable, partitionTasks, taskItem -> {});
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testKeyedHiveTable.baseTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     testKeyedHiveTable.baseTable().newScan().planFiles()
@@ -228,7 +228,7 @@ public class TestSupportHiveMajorOptimizeCommit extends TestSupportHiveBase {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     SupportHiveCommit optimizeCommit = new SupportHiveCommit(testHiveTable, partitionTasks, taskItem -> {});
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testHiveTable.asUnkeyedTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     testHiveTable.asUnkeyedTable().newScan().planFiles()
@@ -278,7 +278,7 @@ public class TestSupportHiveMajorOptimizeCommit extends TestSupportHiveBase {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     SupportHiveCommit optimizeCommit = new SupportHiveCommit(testHiveTable, partitionTasks, taskItem -> {});
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testHiveTable.asUnkeyedTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     testHiveTable.asUnkeyedTable().newScan().planFiles()
@@ -325,7 +325,7 @@ public class TestSupportHiveMajorOptimizeCommit extends TestSupportHiveBase {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     SupportHiveCommit optimizeCommit = new SupportHiveCommit(testUnPartitionKeyedHiveTable, partitionTasks, taskItem -> {});
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testUnPartitionKeyedHiveTable.baseTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     testUnPartitionKeyedHiveTable.baseTable().newScan().planFiles()
@@ -374,7 +374,7 @@ public class TestSupportHiveMajorOptimizeCommit extends TestSupportHiveBase {
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
     SupportHiveCommit optimizeCommit = new SupportHiveCommit(testUnPartitionKeyedHiveTable, partitionTasks, taskItem -> {});
-    optimizeCommit.commit(tableOptimizeRuntime);
+    optimizeCommit.commit(testUnPartitionKeyedHiveTable.baseTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     testUnPartitionKeyedHiveTable.baseTable().newScan().planFiles()

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/util/DataFileInfoUtils.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/util/DataFileInfoUtils.java
@@ -25,8 +25,6 @@ import com.netease.arctic.data.DataTreeNode;
 import com.netease.arctic.data.DefaultKeyedFile;
 import com.netease.arctic.data.PrimaryKeyedFile;
 import com.netease.arctic.table.ArcticTable;
-import com.netease.arctic.table.KeyedTable;
-import com.netease.arctic.utils.FileUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.PartitionField;
@@ -58,12 +56,12 @@ public class DataFileInfoUtils {
     return dataFileInfo;
   }
 
-  public static DataFileInfo convertToDatafileInfo(DeleteFile deleteFile, long commitTime, KeyedTable keyedTable) {
+  public static DataFileInfo convertToDatafileInfo(DeleteFile deleteFile, long commitTime, ArcticTable arcticTable) {
     DataFileInfo dataFileInfo = new DataFileInfo();
     dataFileInfo.setSize(deleteFile.fileSizeInBytes());
     dataFileInfo.setPath(deleteFile.path().toString());
-    dataFileInfo.setPartition(partitionToPath(partitionFields(keyedTable.spec(), deleteFile.partition())));
-    dataFileInfo.setSpecId(keyedTable.spec().specId());
+    dataFileInfo.setPartition(partitionToPath(partitionFields(arcticTable.spec(), deleteFile.partition())));
+    dataFileInfo.setSpecId(arcticTable.spec().specId());
     dataFileInfo.setRecordCount(deleteFile.recordCount());
     dataFileInfo.setType(DataFileType.POS_DELETE_FILE.name());
     DataTreeNode node = DefaultKeyedFile.parseMetaFromFileName(deleteFile.path().toString()).node();

--- a/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveGenericTaskWriterBuilder.java
+++ b/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveGenericTaskWriterBuilder.java
@@ -59,7 +59,7 @@ import java.util.Locale;
  */
 public class AdaptHiveGenericTaskWriterBuilder implements TaskWriterBuilder<Record> {
 
-  private ArcticTable table;
+  private final ArcticTable table;
 
   private Long transactionId;
   private int partitionId = 0;
@@ -110,16 +110,13 @@ public class AdaptHiveGenericTaskWriterBuilder implements TaskWriterBuilder<Reco
   }
 
   public SortedPosDeleteWriter<Record> buildBasePosDeleteWriter(long mask, long index, StructLike partitionKey) {
-    if (table.isUnkeyedTable()) {
-      throw new IllegalArgumentException("UnKeyed table UnSupport position delete");
-    }
-    KeyedTable table = (KeyedTable) this.table;
+    UnkeyedTable baseTable = this.table.isKeyedTable() ? table.asKeyedTable().baseTable() : table.asUnkeyedTable();
     Preconditions.checkNotNull(transactionId);
-    FileFormat fileFormat = FileFormat.valueOf((table.properties().getOrDefault(
+    FileFormat fileFormat = FileFormat.valueOf((baseTable.properties().getOrDefault(
         TableProperties.BASE_FILE_FORMAT,
         TableProperties.BASE_FILE_FORMAT_DEFAULT).toUpperCase(Locale.ENGLISH)));
     GenericAppenderFactory appenderFactory =
-        new GenericAppenderFactory(table.baseTable().schema(), table.spec());
+        new GenericAppenderFactory(baseTable.schema(), baseTable.spec());
     appenderFactory.set(
         org.apache.iceberg.TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + MetadataColumns.DELETE_FILE_PATH.name(),
         MetricsModes.Full.get().toString());
@@ -127,8 +124,8 @@ public class AdaptHiveGenericTaskWriterBuilder implements TaskWriterBuilder<Reco
         org.apache.iceberg.TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + MetadataColumns.DELETE_FILE_POS.name(),
         MetricsModes.Full.get().toString());
     return new SortedPosDeleteWriter<>(appenderFactory,
-        new CommonOutputFileFactory(table.baseLocation(), table.spec(), fileFormat, table.io(),
-            table.baseTable().encryption(), partitionId, taskId, transactionId),
+        new CommonOutputFileFactory(baseTable.location(), baseTable.spec(), fileFormat, baseTable.io(),
+            baseTable.encryption(), partitionId, taskId, transactionId),
         fileFormat, mask, index, partitionKey);
   }
 

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MajorExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MajorExecutor.java
@@ -43,6 +43,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.IdentityPartitionConverters;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterator;
@@ -155,7 +156,8 @@ public class MajorExecutor extends BaseExecutor<DataFile> {
 
     AdaptHiveGenericArcticDataReader arcticDataReader =
         new AdaptHiveGenericArcticDataReader(table.io(), table.schema(), requiredSchema, primaryKeySpec,
-            null, false, IdentityPartitionConverters::convertConstant, sourceNodes, false);
+            table.properties().get(TableProperties.DEFAULT_NAME_MAPPING), false,
+            IdentityPartitionConverters::convertConstant, sourceNodes, false);
 
     List<ArcticFileScanTask> fileScanTasks = dataFiles.stream()
         .map(file -> {

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MinorExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MinorExecutor.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.IdentityPartitionConverters;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterable;
@@ -181,7 +182,8 @@ public class MinorExecutor extends BaseExecutor<DeleteFile> {
     }
     AdaptHiveGenericArcticDataReader arcticDataReader =
         new AdaptHiveGenericArcticDataReader(table.io(), table.schema(), requiredSchema,
-            primaryKeySpec, null, false, IdentityPartitionConverters::convertConstant, sourceNodes, false);
+            primaryKeySpec, table.properties().get(TableProperties.DEFAULT_NAME_MAPPING),
+            false, IdentityPartitionConverters::convertConstant, sourceNodes, false);
 
     KeyedTableScanTask keyedTableScanTask = new NodeFileScanTask(fileScanTasks);
     return arcticDataReader.readDeletedData(keyedTableScanTask);


### PR DESCRIPTION
## Why are the changes needed?
1.fix #314 
2.optimize support pos-delete in unKeyedTable
3.add name-mapping for support hive reader in optimize

## Brief change log

  - add check when minor optimize commit, if partition has files transactionId less than base.max-transaction-id, will give up this partition commit
  - if throw ValidationException(Missing required files to delete or found new delete for replaced data file), will give up this commit, because files in base have changed
  - major optimize for unKeyed table support pos-delete files
  - add name-mapping for support hive reader in optimize

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request