### PR TITLE
[ARCTIC-363][Flink] separate topic from producerConfig

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Properties;
 
-import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -66,6 +65,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
   private transient Long ckpComplete;
   private final Schema schema;
   private final Properties producerConfig;
+  private final String topic;
   private final ShuffleHelper helper;
   protected final LogMsgFactory<RowData> factory;
   protected LogMsgFactory.Producer<RowData> producer;
@@ -94,7 +94,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
       ShuffleHelper helper) {
     this.schema = schema;
     this.producerConfig = checkNotNull(producerConfig);
-    this.producerConfig.put(LOG_STORE_MESSAGE_TOPIC, checkNotNull(topic));
+    this.topic = checkNotNull(topic);
     this.factory = factory;
     this.fieldGetterFactory = fieldGetterFactory;
     this.jobIdentify = jobId;
@@ -136,6 +136,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
                 fieldGetterFactory,
                 factory,
                 producerConfig,
+                topic,
                 helper));
     int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
 
@@ -173,6 +174,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
     producer =
         factory.createProducer(
             producerConfig,
+            topic,
             logDataJsonSerialization,
             helper);
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
@@ -82,6 +82,7 @@ public class GlobalFlipCommitter {
     private final LogDataJsonSerialization<RowData> logDataJsonSerialization;
     private final LogMsgFactory<RowData> factory;
     private final Properties producerConfig;
+    private final String topic;
     private final ShuffleHelper helper;
     private transient LogMsgFactory.Producer<RowData> producer;
 
@@ -91,6 +92,7 @@ public class GlobalFlipCommitter {
         LogData.FieldGetterFactory<RowData> fieldGetterFactory,
         LogMsgFactory<RowData> factory,
         Properties producerConfig,
+        String topic,
         ShuffleHelper helper) {
       this.numberOfTasks = numberOfTasks;
       this.factory = checkNotNull(factory);
@@ -99,6 +101,7 @@ public class GlobalFlipCommitter {
           checkNotNull(fieldGetterFactory)
       );
       this.producerConfig = producerConfig;
+      this.topic = topic;
       this.helper = helper;
     }
 
@@ -148,6 +151,7 @@ public class GlobalFlipCommitter {
         producer =
             factory.createProducer(
                 producerConfig,
+                topic,
                 logDataJsonSerialization,
                 helper);
         producer.open();

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
@@ -34,6 +34,7 @@ public interface LogMsgFactory<T> extends Serializable {
 
   Producer<T> createProducer(
       Properties producerConfig,
+      String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
       ShuffleHelper helper);
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
@@ -22,7 +22,6 @@ import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.write.hidden.ArcticLogPartitioner;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
 import com.netease.arctic.log.LogDataJsonSerialization;
-import com.netease.arctic.table.TableProperties;
 
 import java.util.Properties;
 
@@ -37,9 +36,9 @@ public class HiddenKafkaFactory<T> implements LogMsgFactory<T> {
   @Override
   public Producer<T> createProducer(
       Properties producerConfig,
+      String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
       ShuffleHelper helper) {
-    final String topic = producerConfig.getProperty(TableProperties.LOG_STORE_MESSAGE_TOPIC);
     checkNotNull(topic);
     return new HiddenKafkaProducer<>(
         producerConfig,

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducerTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducerTest.java
@@ -40,7 +40,6 @@ import java.util.UUID;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate.getProperties;
 import static com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate.getPropertiesWithByteArray;
-import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -107,10 +106,10 @@ public class HiddenKafkaProducerTest extends BaseLogTest {
         checkNotNull(fieldGetterFactory));
 
     Properties properties = getPropertiesWithByteArray(kafkaTestBase.getProperties());
-    properties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     LogMsgFactory.Producer<RowData> producer =
         new HiddenKafkaFactory<RowData>().createProducer(
             properties,
+            topic,
             logDataJsonSerialization,
             null);
     producer.open();

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Properties;
 
-import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -66,6 +65,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
   private transient Long ckpComplete;
   private final Schema schema;
   private final Properties producerConfig;
+  private final String topic;
   private final ShuffleHelper helper;
   protected final LogMsgFactory<RowData> factory;
   protected LogMsgFactory.Producer<RowData> producer;
@@ -94,7 +94,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
       ShuffleHelper helper) {
     this.schema = schema;
     this.producerConfig = checkNotNull(producerConfig);
-    this.producerConfig.put(LOG_STORE_MESSAGE_TOPIC, checkNotNull(topic));
+    this.topic = checkNotNull(topic);
     this.factory = factory;
     this.fieldGetterFactory = fieldGetterFactory;
     this.jobIdentify = jobId;
@@ -136,6 +136,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
                 fieldGetterFactory,
                 factory,
                 producerConfig,
+                topic,
                 helper));
     int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
 
@@ -173,6 +174,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
     producer =
         factory.createProducer(
             producerConfig,
+            topic,
             logDataJsonSerialization,
             helper);
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
@@ -82,6 +82,7 @@ public class GlobalFlipCommitter {
     private final LogDataJsonSerialization<RowData> logDataJsonSerialization;
     private final LogMsgFactory<RowData> factory;
     private final Properties producerConfig;
+    private final String topic;
     private final ShuffleHelper helper;
     private transient LogMsgFactory.Producer<RowData> producer;
 
@@ -91,6 +92,7 @@ public class GlobalFlipCommitter {
         LogData.FieldGetterFactory<RowData> fieldGetterFactory,
         LogMsgFactory<RowData> factory,
         Properties producerConfig,
+        String topic,
         ShuffleHelper helper) {
       this.numberOfTasks = numberOfTasks;
       this.factory = checkNotNull(factory);
@@ -99,6 +101,7 @@ public class GlobalFlipCommitter {
           checkNotNull(fieldGetterFactory)
       );
       this.producerConfig = producerConfig;
+      this.topic = topic;
       this.helper = helper;
     }
 
@@ -148,6 +151,7 @@ public class GlobalFlipCommitter {
         producer =
             factory.createProducer(
                 producerConfig,
+                topic,
                 logDataJsonSerialization,
                 helper);
         producer.open();

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
@@ -34,6 +34,7 @@ public interface LogMsgFactory<T> extends Serializable {
 
   Producer<T> createProducer(
       Properties producerConfig,
+      String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
       ShuffleHelper helper);
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
@@ -37,9 +37,9 @@ public class HiddenKafkaFactory<T> implements LogMsgFactory<T> {
   @Override
   public Producer<T> createProducer(
       Properties producerConfig,
+      String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
       ShuffleHelper helper) {
-    final String topic = producerConfig.getProperty(TableProperties.LOG_STORE_MESSAGE_TOPIC);
     checkNotNull(topic);
     return new HiddenKafkaProducer<>(
         producerConfig,

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducerTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducerTest.java
@@ -23,11 +23,6 @@ import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
-
-import java.time.Duration;
-import java.util.Properties;
-import java.util.UUID;
-
 import org.apache.flink.streaming.connectors.kafka.internals.FlinkKafkaInternalProducer;
 import org.apache.flink.table.data.RowData;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -38,9 +33,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.util.Properties;
+import java.util.UUID;
+
 import static com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate.getProperties;
 import static com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate.getPropertiesWithByteArray;
-import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -108,10 +106,10 @@ public class HiddenKafkaProducerTest extends BaseLogTest {
         checkNotNull(fieldGetterFactory));
 
     Properties properties = getPropertiesWithByteArray(kafkaTestBase.getProperties());
-    properties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     LogMsgFactory.Producer<RowData> producer =
         new HiddenKafkaFactory<RowData>().createProducer(
             properties,
+            topic,
             logDataJsonSerialization,
             null);
     producer.open();

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Properties;
 
-import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -66,6 +65,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
   private transient Long ckpComplete;
   private final Schema schema;
   private final Properties producerConfig;
+  private final String topic;
   private final ShuffleHelper helper;
   protected final LogMsgFactory<RowData> factory;
   protected LogMsgFactory.Producer<RowData> producer;
@@ -94,7 +94,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
       ShuffleHelper helper) {
     this.schema = schema;
     this.producerConfig = checkNotNull(producerConfig);
-    this.producerConfig.put(LOG_STORE_MESSAGE_TOPIC, checkNotNull(topic));
+    this.topic = checkNotNull(topic);
     this.factory = factory;
     this.fieldGetterFactory = fieldGetterFactory;
     this.jobIdentify = jobId;
@@ -136,6 +136,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
                 fieldGetterFactory,
                 factory,
                 producerConfig,
+                topic,
                 helper));
     int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
 
@@ -173,6 +174,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
     producer =
         factory.createProducer(
             producerConfig,
+            topic,
             logDataJsonSerialization,
             helper);
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
@@ -82,6 +82,7 @@ public class GlobalFlipCommitter {
     private final LogDataJsonSerialization<RowData> logDataJsonSerialization;
     private final LogMsgFactory<RowData> factory;
     private final Properties producerConfig;
+    private final String topic;
     private final ShuffleHelper helper;
     private transient LogMsgFactory.Producer<RowData> producer;
 
@@ -91,6 +92,7 @@ public class GlobalFlipCommitter {
         LogData.FieldGetterFactory<RowData> fieldGetterFactory,
         LogMsgFactory<RowData> factory,
         Properties producerConfig,
+        String topic,
         ShuffleHelper helper) {
       this.numberOfTasks = numberOfTasks;
       this.factory = checkNotNull(factory);
@@ -99,6 +101,7 @@ public class GlobalFlipCommitter {
           checkNotNull(fieldGetterFactory)
       );
       this.producerConfig = producerConfig;
+      this.topic = topic;
       this.helper = helper;
     }
 
@@ -148,6 +151,7 @@ public class GlobalFlipCommitter {
         producer =
             factory.createProducer(
                 producerConfig,
+                topic,
                 logDataJsonSerialization,
                 helper);
         producer.open();

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
@@ -34,6 +34,7 @@ public interface LogMsgFactory<T> extends Serializable {
 
   Producer<T> createProducer(
       Properties producerConfig,
+      String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
       ShuffleHelper helper);
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
@@ -22,7 +22,6 @@ import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.write.hidden.ArcticLogPartitioner;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
 import com.netease.arctic.log.LogDataJsonSerialization;
-import com.netease.arctic.table.TableProperties;
 
 import java.util.Properties;
 
@@ -37,9 +36,9 @@ public class HiddenKafkaFactory<T> implements LogMsgFactory<T> {
   @Override
   public Producer<T> createProducer(
       Properties producerConfig,
+      String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
       ShuffleHelper helper) {
-    final String topic = producerConfig.getProperty(TableProperties.LOG_STORE_MESSAGE_TOPIC);
     checkNotNull(topic);
     return new HiddenKafkaProducer<>(
         producerConfig,

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducerTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducerTest.java
@@ -23,11 +23,6 @@ import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
-
-import java.time.Duration;
-import java.util.Properties;
-import java.util.UUID;
-
 import org.apache.flink.streaming.connectors.kafka.internals.FlinkKafkaInternalProducer;
 import org.apache.flink.table.data.RowData;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -38,9 +33,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.util.Properties;
+import java.util.UUID;
+
 import static com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate.getProperties;
 import static com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate.getPropertiesWithByteArray;
-import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -108,10 +106,10 @@ public class HiddenKafkaProducerTest extends BaseLogTest {
         checkNotNull(fieldGetterFactory));
 
     Properties properties = getPropertiesWithByteArray(kafkaTestBase.getProperties());
-    properties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     LogMsgFactory.Producer<RowData> producer =
         new HiddenKafkaFactory<RowData>().createProducer(
             properties,
+            topic,
             logDataJsonSerialization,
             null);
     producer.open();


### PR DESCRIPTION
Resolve #363 

## Why are the changes needed?
LOG_STORE_MESSAGE_TOPIC has been put into producerConfig in AbstractHiddenLogWriter.java. This custom properties may lead to TransactionalIdAuthorizationException in SASL.

And putting the invalid properties into kafka producer config is also ugly.

## Brief change log

  - *separate topic from producerConfig*
  - *The flink 1.12 and 1.14, 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
