### PR TITLE
[ARCTIC-360][AMS] Refine table optimize_task_history from partition level to task level

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/TaskHistoryMapper.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/TaskHistoryMapper.java
@@ -35,7 +35,7 @@ public interface TaskHistoryMapper {
   String TABLE_NAME = "optimize_task_history";
 
   @Select("select catalog_name, db_name, table_name, task_group_id, task_history_id," +
-      "start_time, end_time, cost_time, queue_id from " + TABLE_NAME + " where " +
+      "task_trace_id, task_attempt_id, start_time, end_time, cost_time, queue_id from " + TABLE_NAME + " where " +
       "catalog_name = #{tableIdentifier.catalog} and db_name = #{tableIdentifier.database} " +
       "and table_name = #{tableIdentifier.tableName} and task_history_id = #{historyId}")
   @Results({
@@ -44,6 +44,8 @@ public interface TaskHistoryMapper {
       @Result(column = "table_name", property = "tableIdentifier.tableName"),
       @Result(column = "task_group_id", property = "taskGroupId"),
       @Result(column = "task_history_id", property = "taskHistoryId"),
+      @Result(column = "task_trace_id", property = "taskTraceId"),
+      @Result(column = "task_attempt_id", property = "taskAttemptId"),
       @Result(column = "start_time", property = "startTime",
           typeHandler = Long2TsConvertor.class),
       @Result(column = "end_time", property = "endTime",
@@ -55,12 +57,14 @@ public interface TaskHistoryMapper {
                                            @Param("historyId") String historyId);
 
   @Insert("insert into " + TABLE_NAME + "(catalog_name, db_name, table_name, task_group_id, " +
-      "task_history_id, start_time, end_time, cost_time, queue_id) values ( " +
+      "task_history_id, task_trace_id, task_attempt_id, start_time, end_time, cost_time, queue_id) values ( " +
       "#{taskHistory.tableIdentifier.catalog}, " +
       "#{taskHistory.tableIdentifier.database}, " +
       "#{taskHistory.tableIdentifier.tableName}, " +
       "#{taskHistory.taskGroupId}, " +
       "#{taskHistory.taskHistoryId}, " +
+      "#{taskHistory.taskTraceId}, " +
+      "#{taskHistory.taskAttemptId}, " +
       "#{taskHistory.startTime, " +
       "typeHandler=com.netease.arctic.ams.server.mybatis.Long2TsConvertor}," +
       "#{taskHistory.endTime, " +
@@ -76,15 +80,11 @@ public interface TaskHistoryMapper {
       "typeHandler=com.netease.arctic.ams.server.mybatis.Long2TsConvertor}, " +
       "cost_time = #{taskHistory.costTime} " +
       "where " +
-      "catalog_name = #{taskHistory.tableIdentifier.catalog} and " +
-      "db_name = #{taskHistory.tableIdentifier.database} and " +
-      "table_name = #{taskHistory.tableIdentifier.tableName} and " +
-      "task_history_id = #{taskHistory.taskHistoryId} and " +
-      "task_group_id = #{taskHistory.taskGroupId}")
+      "task_attempt_id = #{taskHistory.taskAttemptId}")
   void updateTaskHistory(@Param("taskHistory") TableTaskHistory taskHistory);
 
   @Select("select catalog_name, db_name, table_name, task_group_id, task_history_id," +
-      "start_time, end_time, cost_time, queue_id from " + TABLE_NAME + " where " +
+      "task_trace_id, task_attempt_id, start_time, end_time, cost_time, queue_id from " + TABLE_NAME + " where " +
       "queue_id = #{queueId} " +
       "and start_time < #{endTime, typeHandler=com.netease.arctic.ams.server.mybatis.Long2TsConvertor} " +
       "and (end_time > #{startTime, typeHandler=com.netease.arctic.ams.server.mybatis.Long2TsConvertor} " +
@@ -95,6 +95,8 @@ public interface TaskHistoryMapper {
       @Result(column = "table_name", property = "tableIdentifier.tableName"),
       @Result(column = "task_group_id", property = "taskGroupId"),
       @Result(column = "task_history_id", property = "taskHistoryId"),
+      @Result(column = "task_trace_id", property = "taskTraceId"),
+      @Result(column = "task_attempt_id", property = "taskAttemptId"),
       @Result(column = "start_time", property = "startTime",
           typeHandler = Long2TsConvertor.class),
       @Result(column = "end_time", property = "endTime",
@@ -107,7 +109,7 @@ public interface TaskHistoryMapper {
                                                            @Param("endTime") long endTime);
 
   @Select("select catalog_name, db_name, table_name, task_group_id, task_history_id," +
-      "start_time, end_time, cost_time, queue_id from " + TABLE_NAME + " where " +
+      "task_trace_id, task_attempt_id, start_time, end_time, cost_time, queue_id from " + TABLE_NAME + " where " +
       "start_time < #{endTime, typeHandler=com.netease.arctic.ams.server.mybatis.Long2TsConvertor} " +
       "and (end_time > #{startTime, typeHandler=com.netease.arctic.ams.server.mybatis.Long2TsConvertor} " +
       "or end_time is null)")
@@ -117,6 +119,8 @@ public interface TaskHistoryMapper {
       @Result(column = "table_name", property = "tableIdentifier.tableName"),
       @Result(column = "task_group_id", property = "taskGroupId"),
       @Result(column = "task_history_id", property = "taskHistoryId"),
+      @Result(column = "task_trace_id", property = "taskTraceId"),
+      @Result(column = "task_attempt_id", property = "taskAttemptId"),
       @Result(column = "start_time", property = "startTime",
           typeHandler = Long2TsConvertor.class),
       @Result(column = "end_time", property = "endTime",
@@ -128,7 +132,7 @@ public interface TaskHistoryMapper {
                                                  @Param("endTime") long endTime);
 
   @Select("select catalog_name, db_name, table_name, task_group_id, task_history_id," +
-      "start_time, end_time, cost_time, queue_id from " + TABLE_NAME + " where " +
+      "task_trace_id, task_attempt_id, start_time, end_time, cost_time, queue_id from " + TABLE_NAME + " where " +
       "catalog_name = #{tableIdentifier.catalog} and " +
       "db_name = #{tableIdentifier.database} and " +
       "table_name = #{tableIdentifier.tableName} " +
@@ -141,6 +145,8 @@ public interface TaskHistoryMapper {
       @Result(column = "table_name", property = "tableIdentifier.tableName"),
       @Result(column = "task_group_id", property = "taskGroupId"),
       @Result(column = "task_history_id", property = "taskHistoryId"),
+      @Result(column = "task_trace_id", property = "taskTraceId"),
+      @Result(column = "task_attempt_id", property = "taskAttemptId"),
       @Result(column = "start_time", property = "startTime",
           typeHandler = Long2TsConvertor.class),
       @Result(column = "end_time", property = "endTime",
@@ -162,5 +168,10 @@ public interface TaskHistoryMapper {
       "and table_name = #{tableIdentifier.tableName} and task_history_id = #{historyId}")
   void deleteTaskHistoryWithHistoryId(@Param("tableIdentifier") TableIdentifier tableIdentifier,
                                       @Param("historyId") String historyId);
-  
+
+  @Delete("delete from " + TABLE_NAME + " where " +
+      "catalog_name = #{tableIdentifier.catalog} and db_name = #{tableIdentifier.database} " +
+      "and table_name = #{tableIdentifier.tableName} and task_history_id != #{latestTaskHistoryId} " +
+      "and end_time < #{expireTime, typeHandler=com.netease.arctic.ams.server.mybatis.Long2TsConvertor}")
+  void expireTaskHistory(TableIdentifier identifier, String latestTaskHistoryId, long expireTime);
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableTaskHistory.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableTaskHistory.java
@@ -24,6 +24,8 @@ public class TableTaskHistory {
   private TableIdentifier tableIdentifier;
   private String taskGroupId;
   private String taskHistoryId;
+  private String taskTraceId;
+  private String taskAttemptId;
   private long startTime;
   private long endTime;
   private long costTime;
@@ -51,6 +53,22 @@ public class TableTaskHistory {
 
   public void setTaskHistoryId(String taskHistoryId) {
     this.taskHistoryId = taskHistoryId;
+  }
+
+  public String getTaskTraceId() {
+    return taskTraceId;
+  }
+
+  public void setTaskTraceId(String taskTraceId) {
+    this.taskTraceId = taskTraceId;
+  }
+
+  public String getTaskAttemptId() {
+    return taskAttemptId;
+  }
+
+  public void setTaskAttemptId(String taskAttemptId) {
+    this.taskAttemptId = taskAttemptId;
   }
 
   public long getStartTime() {
@@ -95,6 +113,8 @@ public class TableTaskHistory {
         ", endTime=" + endTime +
         ", costTime=" + costTime +
         ", queueId=" + queueId +
+        ", taskTraceId=" + taskTraceId +
+        ", taskAttemptId=" + taskAttemptId +
         '}';
   }
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
@@ -95,6 +95,10 @@ public class BaseOptimizeCommit {
       StructLikeMap<Long> maxTransactionIds = StructLikeMap.create(spec.partitionType());
       for (Map.Entry<String, List<OptimizeTaskItem>> entry : optimizeTasksToCommit.entrySet()) {
         for (OptimizeTaskItem task : entry.getValue()) {
+          if (!checkFileCount(task)) {
+            LOG.error("table {} file count not match", arcticTable.id());
+            throw new IllegalArgumentException("file count not match, can't commit");
+          }
           // tasks in partition
           if (task.getOptimizeTask().getTaskId().getType() == OptimizeType.Minor) {
             task.getOptimizeRuntime().getTargetFiles().stream()
@@ -171,6 +175,29 @@ public class BaseOptimizeCommit {
 
   public Map<String, OptimizeType> getPartitionOptimizeType() {
     return partitionOptimizeType;
+  }
+
+  private boolean checkFileCount(OptimizeTaskItem task) {
+    int baseFileCount = task.getOptimizeTask().getBaseFiles().size();
+    int insertFileCount = task.getOptimizeTask().getInsertFiles().size();
+    int deleteFileCount = task.getOptimizeTask().getDeleteFiles().size();
+    int posDeleteFileCount = task.getOptimizeTask().getPosDeleteFiles().size();
+    int targetFileCount = task.getOptimizeRuntime().getTargetFiles().size();
+
+    boolean result = baseFileCount == task.getOptimizeTask().getBaseFileCnt() &&
+        insertFileCount == task.getOptimizeTask().getInsertFileCnt() &&
+        deleteFileCount == task.getOptimizeTask().getDeleteFileCnt() &&
+        posDeleteFileCount == task.getOptimizeTask().getPosDeleteFileCnt() &&
+        targetFileCount == task.getOptimizeRuntime().getNewFileCnt();
+    if (!result) {
+      LOG.error("file count check failed. baseFileCount/baseFileCnt is {}/{}, " +
+              "insertFileCount/insertFileCnt is {}/{}, deleteFileCount/deleteFileCnt is {}/{}, " +
+              "posDeleteFileCount/posDeleteFileCnt is {}/{}, targetFileCount/newFileCnt is {}/{}",
+          baseFileCount, task.getOptimizeTask().getBaseFileCnt(), insertFileCount, task.getOptimizeTask().getInsertFileCnt(),
+          deleteFileCount, task.getOptimizeTask().getDeleteFileCnt(), posDeleteFileCount, task.getOptimizeTask().getPosDeleteFileCnt(),
+          targetFileCount, task.getOptimizeRuntime().getNewFileCnt());
+    }
+    return result;
   }
 
   private void minorCommit(ArcticTable arcticTable,

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeTaskItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeTaskItem.java
@@ -26,6 +26,7 @@ import com.netease.arctic.ams.api.OptimizeTaskId;
 import com.netease.arctic.ams.server.mapper.InternalTableFilesMapper;
 import com.netease.arctic.ams.server.mapper.OptimizeTaskRuntimesMapper;
 import com.netease.arctic.ams.server.mapper.OptimizeTasksMapper;
+import com.netease.arctic.ams.server.mapper.TaskHistoryMapper;
 import com.netease.arctic.ams.server.model.BaseOptimizeTask;
 import com.netease.arctic.ams.server.model.BaseOptimizeTaskRuntime;
 import com.netease.arctic.ams.server.model.TableTaskHistory;
@@ -116,7 +117,7 @@ public class OptimizeTaskItem extends IJDBCService {
       newRuntime.setErrorMessage(null);
       persistTaskRuntime(newRuntime, false);
       optimizeRuntime = newRuntime;
-      return constructTableTaskHistory(currentTime);
+      return constructNewTableTaskHistory(currentTime, attemptId);
     } catch (Throwable t) {
       onFailed(new ErrorMessage(System.currentTimeMillis(),
           "internal error, failed to set task status to Executing, set to Failed"), 0);
@@ -155,6 +156,8 @@ public class OptimizeTaskItem extends IJDBCService {
       newRuntime.setCostTime(costTime);
       persistTaskRuntime(newRuntime, false);
       optimizeRuntime = newRuntime;
+
+      updateTableTaskHistory();
     } finally {
       lock.unlock();
     }
@@ -179,6 +182,8 @@ public class OptimizeTaskItem extends IJDBCService {
       newRuntime.setCostTime(costTime);
       persistTaskRuntime(newRuntime, true);
       optimizeRuntime = newRuntime;
+
+      updateTableTaskHistory();
     } finally {
       lock.unlock();
     }
@@ -313,15 +318,42 @@ public class OptimizeTaskItem extends IJDBCService {
     }
   }
 
-  private TableTaskHistory constructTableTaskHistory(long currentTime) {
+  private TableTaskHistory constructNewTableTaskHistory(long currentTime, String attemptId) {
     TableTaskHistory tableTaskHistory = new TableTaskHistory();
     tableTaskHistory.setTableIdentifier(new TableIdentifier(optimizeTask.getTableIdentifier()));
     tableTaskHistory.setTaskGroupId(optimizeTask.getTaskGroup());
     tableTaskHistory.setTaskHistoryId(optimizeTask.getTaskHistoryId());
+    tableTaskHistory.setTaskTraceId(optimizeTask.getTaskId().getTraceId());
+    tableTaskHistory.setTaskAttemptId(attemptId);
     tableTaskHistory.setStartTime(currentTime);
     tableTaskHistory.setQueueId(optimizeTask.getQueueId());
 
     return tableTaskHistory;
+  }
+
+  private void updateTableTaskHistory() {
+    TableTaskHistory tableTaskHistory = new TableTaskHistory();
+    tableTaskHistory.setTableIdentifier(new TableIdentifier(optimizeTask.getTableIdentifier()));
+    tableTaskHistory.setTaskGroupId(optimizeTask.getTaskGroup());
+    tableTaskHistory.setTaskHistoryId(optimizeTask.getTaskHistoryId());
+    tableTaskHistory.setTaskTraceId(optimizeTask.getTaskId().getTraceId());
+    tableTaskHistory.setTaskAttemptId(optimizeRuntime.getAttemptId());
+    tableTaskHistory.setQueueId(optimizeTask.getQueueId());
+
+    tableTaskHistory.setStartTime(optimizeRuntime.getExecuteTime());
+    tableTaskHistory.setEndTime(optimizeRuntime.getReportTime());
+    tableTaskHistory.setCostTime(optimizeRuntime.getCostTime());
+
+    try (SqlSession sqlSession = getSqlSession(true)) {
+      TaskHistoryMapper taskHistoryMapper = getMapper(sqlSession, TaskHistoryMapper.class);
+      try {
+        taskHistoryMapper.updateTaskHistory(tableTaskHistory);
+      } catch (Exception e) {
+        LOG.error("failed to update task history, tableId is {}, attemptId is {}",
+            optimizeTask.getTableIdentifier(),
+            optimizeRuntime.getAttemptId());
+      }
+    }
   }
 
   public void persistOptimizeTask() {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
@@ -568,7 +568,6 @@ public class TableOptimizeItem extends IJDBCService {
     try (SqlSession sqlSession = getSqlSession(false)) {
       Map<String, List<OptimizeTaskItem>> tasks = optimizeCommit.getCommittedTasks();
       Map<String, OptimizeType> optimizeTypMap = optimizeCommit.getPartitionOptimizeType();
-      Map<String, TableTaskHistory> commitTableTaskHistory = optimizeCommit.getCommitTableTaskHistory();
 
       // commit
       OptimizeTasksMapper optimizeTasksMapper =
@@ -581,8 +580,6 @@ public class TableOptimizeItem extends IJDBCService {
           getMapper(sqlSession, TableOptimizeRuntimeMapper.class);
       OptimizeHistoryMapper optimizeHistoryMapper =
           getMapper(sqlSession, OptimizeHistoryMapper.class);
-      TaskHistoryMapper taskHistoryMapper =
-          getMapper(sqlSession, TaskHistoryMapper.class);
 
       try {
         tasks.values().stream().flatMap(Collection::stream)
@@ -621,13 +618,6 @@ public class TableOptimizeItem extends IJDBCService {
         optimizeHistoryMapper.insertOptimizeHistory(record);
       } catch (Throwable t) {
         LOG.warn("failed to persist optimize history after commit, ignore. " + getTableIdentifier(), t);
-        sqlSession.rollback(true);
-      }
-
-      try {
-        commitTableTaskHistory.forEach((key, value) -> taskHistoryMapper.updateTaskHistory(value));
-      } catch (Exception e) {
-        LOG.warn("failed to persist task history after commit, ignore. " + getTableIdentifier(), e);
         sqlSession.rollback(true);
       }
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/ITableTaskHistoryService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/ITableTaskHistoryService.java
@@ -41,4 +41,6 @@ public interface ITableTaskHistoryService {
   void deleteTaskHistory(TableIdentifier identifier);
 
   void deleteTaskHistoryWithHistoryId(TableIdentifier identifier, String taskHistoryId);
+
+  void expireTaskHistory(TableIdentifier identifier, String latestTaskHistoryId, long expireTime);
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
@@ -627,6 +627,11 @@ public class OptimizeQueueService extends IJDBCService {
           latestCostTime = latestCostTime + currentTime - latestTaskHistory.getStartTime();
         }
       }
+
+      if (currentTime - latestStartTime == 0) {
+        return BigDecimal.valueOf(Long.MAX_VALUE);
+      }
+
       BigDecimal currentQuota = new BigDecimal(latestCostTime)
           .divide(new BigDecimal(currentTime - latestStartTime),
               2,

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/RuntimeDataExpireService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/RuntimeDataExpireService.java
@@ -19,29 +19,56 @@
 package com.netease.arctic.ams.server.service.impl;
 
 import com.netease.arctic.ams.server.model.TableMetadata;
+import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
+import com.netease.arctic.ams.server.optimize.IOptimizeService;
 import com.netease.arctic.ams.server.service.IMetaService;
+import com.netease.arctic.ams.server.service.ITableTaskHistoryService;
 import com.netease.arctic.ams.server.service.ServiceContainer;
 import com.netease.arctic.table.TableIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 
 public class RuntimeDataExpireService {
+  private static final Logger LOG = LoggerFactory.getLogger(RuntimeDataExpireService.class);
+
   private final ArcticTransactionService transactionService;
   private final IMetaService metaService;
+  private final IOptimizeService optimizeService;
+  private final ITableTaskHistoryService tableTaskHistoryService;
 
   Long txDataExpireInterval = 24 * 60 * 60 * 1000L;
+  Long taskHistoryDataExpireInterval = 7 * 24 * 60 * 60 * 1000L;
 
   public RuntimeDataExpireService() {
     this.transactionService = ServiceContainer.getArcticTransactionService();
     this.metaService = ServiceContainer.getMetaService();
+    this.tableTaskHistoryService = ServiceContainer.getTableTaskHistoryService();
+    this.optimizeService = ServiceContainer.getOptimizeService();
   }
 
   public void doExpire() {
     List<TableMetadata> tableMetadata = metaService.listTables();
+    // expire and clear transaction table
     tableMetadata.forEach(meta -> {
       TableIdentifier identifier = meta.getTableIdentifier();
       transactionService.expire(
           identifier.buildTableIdentifier(),
           System.currentTimeMillis() - this.txDataExpireInterval);
+    });
+
+    // expire and clear table_task_history table
+    tableMetadata.forEach(meta -> {
+      TableIdentifier identifier = meta.getTableIdentifier();
+      try {
+        TableOptimizeRuntime tableOptimizeRuntime = optimizeService.getTableOptimizeItem(identifier).getTableOptimizeRuntime();
+        tableTaskHistoryService.expireTaskHistory(identifier,
+            tableOptimizeRuntime.getLatestTaskHistoryId(),
+            System.currentTimeMillis() - this.taskHistoryDataExpireInterval);
+      } catch (Exception e) {
+        LOG.error("failed to expire and clear table_task_history table", e);
+      }
     });
   }
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/TableTaskHistoryService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/TableTaskHistoryService.java
@@ -116,4 +116,14 @@ public class TableTaskHistoryService extends IJDBCService implements ITableTaskH
       taskHistoryMapper.deleteTaskHistoryWithHistoryId(identifier, taskHistoryId);
     }
   }
+
+  @Override
+  public void expireTaskHistory(TableIdentifier identifier, String latestTaskHistoryId, long expireTime) {
+    try (SqlSession sqlSession = getSqlSession(true)) {
+      TaskHistoryMapper taskHistoryMapper =
+          getMapper(sqlSession, TaskHistoryMapper.class);
+
+      taskHistoryMapper.expireTaskHistory(identifier, latestTaskHistoryId, expireTime);
+    }
+  }
 }

--- a/ams/ams-server/src/main/resources/sql/derby/ams-init.sql
+++ b/ams/ams-server/src/main/resources/sql/derby/ams-init.sql
@@ -222,12 +222,14 @@ CREATE TABLE optimize_task_history (
     db_name varchar(64) NOT NULL,
     table_name varchar(64) NOT NULL,
     task_history_id varchar(40) DEFAULT NULL,
+    task_trace_id varchar(40) DEFAULT NULL,
+    task_attempt_id varchar(40) DEFAULT NULL,
     start_time timestamp DEFAULT NULL,
     end_time timestamp DEFAULT NULL,
     cost_time bigint DEFAULT NULL,
     queue_id int DEFAULT NULL,
     task_group_id varchar(40) DEFAULT NULL,
-    UNIQUE (task_history_id, task_group_id)
+    PRIMARY KEY (task_attempt_id)
 );
 
 CREATE TABLE database_metadata (

--- a/ams/ams-server/src/main/resources/sql/mysql/0.3.2-init.sql
+++ b/ams/ams-server/src/main/resources/sql/mysql/0.3.2-init.sql
@@ -233,8 +233,10 @@ CREATE TABLE `optimize_table_runtime`
 
 CREATE TABLE `optimize_task_history`
 (
+    `task_attempt_id`   varchar(40) NOT NULL COMMENT 'Task attempt id',
     `task_history_id` varchar(40) NOT NULL COMMENT 'Task history id',
     `task_group_id`   varchar(40) NOT NULL COMMENT 'Task group id',
+    `task_trace_id`   varchar(40) NOT NULL COMMENT 'Task trace id',
     `catalog_name`    varchar(64) NOT NULL COMMENT 'Catalog name',
     `db_name`         varchar(64) NOT NULL COMMENT 'Database name',
     `table_name`      varchar(64) NOT NULL COMMENT 'Table name',
@@ -242,8 +244,11 @@ CREATE TABLE `optimize_task_history`
     `end_time`        datetime(3) DEFAULT NULL COMMENT 'Task end time',
     `cost_time`       bigint(20) DEFAULT NULL COMMENT 'Task cost time',
     `queue_id`        int(11) DEFAULT NULL COMMENT 'Task queue id',
-    PRIMARY KEY (`task_history_id`,`task_group_id`),
-    KEY               `task_group_id_index` (`task_history_id`)
+    PRIMARY KEY (`task_attempt_id`),
+    KEY `table_task_history_id_end_time_index` (`catalog_name`, `db_name`, `table_name`, `task_history_id`, `end_time`),
+    KEY `queue_id_time_index` (`queue_id`, `start_time`, `end_time`),
+    KEY `table_time_index` (`catalog_name`, `db_name`, `table_name`, `start_time`, `end_time`),
+    KEY `table_id_index` (`catalog_name`, `db_name`, `table_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'History of each optimize task';
 
 CREATE TABLE `table_transaction_meta`

--- a/ams/ams-server/src/main/resources/sql/mysql/upgrade-0.3.1-to-0.3.2.sql
+++ b/ams/ams-server/src/main/resources/sql/mysql/upgrade-0.3.1-to-0.3.2.sql
@@ -1,1 +1,22 @@
+DROP TABLE IF EXISTS `optimize_task_history`;
+CREATE TABLE `optimize_task_history`
+(
+    `task_attempt_id`   varchar(40) NOT NULL COMMENT 'Task attempt id',
+    `task_history_id` varchar(40) NOT NULL COMMENT 'Task history id',
+    `task_group_id`   varchar(40) NOT NULL COMMENT 'Task group id',
+    `task_trace_id`   varchar(40) NOT NULL COMMENT 'Task trace id',
+    `catalog_name`    varchar(64) NOT NULL COMMENT 'Catalog name',
+    `db_name`         varchar(64) NOT NULL COMMENT 'Database name',
+    `table_name`      varchar(64) NOT NULL COMMENT 'Table name',
+    `start_time`      datetime(3) DEFAULT NULL COMMENT 'Task start time',
+    `end_time`        datetime(3) DEFAULT NULL COMMENT 'Task end time',
+    `cost_time`       bigint(20) DEFAULT NULL COMMENT 'Task cost time',
+    `queue_id`        int(11) DEFAULT NULL COMMENT 'Task queue id',
+    PRIMARY KEY (`task_attempt_id`),
+    KEY `table_task_history_id_end_time_index` (`catalog_name`, `db_name`, `table_name`, `task_history_id`, `end_time`),
+    KEY `queue_id_time_index` (`queue_id`, `start_time`, `end_time`),
+    KEY `table_time_index` (`catalog_name`, `db_name`, `table_name`, `start_time`, `end_time`),
+    KEY `table_id_index` (`catalog_name`, `db_name`, `table_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'History of each optimize task';
+
 ALTER TABLE `optimize_task` drop COLUMN `is_delete_pos_delete`;


### PR DESCRIPTION
## Why are the changes needed?
fix #360, calculate quota is incorrect in some situation.

## Brief change log
  - *table optimize_task_history add column task_trace_id and attempt_id to mark a record match one task poll*
  - *new record will be produced when task polled(failed task polled with retry will also produce new record)*
  - *update record end_time and cost_time when task failed or prepared*
  - *add expire and clean logic for optimize_task_history table*
  - *add file count check when optimize commit*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
