### PR TITLE
[ARCTIC-402][HIVE]Incorrect table information is obtained when multiple Hive Catalogs exist

### DIFF
--- a/ams/ams-server/pom.xml
+++ b/ams/ams-server/pom.xml
@@ -560,6 +560,8 @@
                             <outputDirectory>
                                 ${project.build.directory}/arctic-ams-server-dependency/lib
                             </outputDirectory>
+                            <includeScope>compile</includeScope>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/hive/src/main/java/com/netease/arctic/hive/ArcticHiveClientPool.java
+++ b/hive/src/main/java/com/netease/arctic/hive/ArcticHiveClientPool.java
@@ -111,19 +111,4 @@ public class ArcticHiveClientPool extends ClientPoolImpl<HiveMetaStoreClient, TE
   protected void close(HiveMetaStoreClient client) {
     client.close();
   }
-
-  // @Override
-  // protected HiveMetaStoreClient newClient() {
-  //   return metaStore.doAs(() -> super.newClient());
-  // }
-  //
-  // @Override
-  // protected HiveMetaStoreClient reconnect(HiveMetaStoreClient client) {
-  //   try {
-  //     return metaStore.doAs(() -> super.reconnect(client));
-  //   } catch (Exception e) {
-  //     LOG.error("hive metastore client reconnected failed", e);
-  //     throw e;
-  //   }
-  // }
 }

--- a/hive/src/main/java/com/netease/arctic/hive/CachedHiveClientPool.java
+++ b/hive/src/main/java/com/netease/arctic/hive/CachedHiveClientPool.java
@@ -54,7 +54,6 @@ public class CachedHiveClientPool implements HMSClient, Serializable {
   }
 
   private ArcticHiveClientPool clientPool() {
-    tableMetaStore.getHiveSiteLocation().ifPresent(HiveConf::setHiveSiteLocation);
     return clientPoolCache.get(tableMetaStore, k -> new ArcticHiveClientPool(tableMetaStore, clientPoolSize));
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
resolve #402

## Brief change log

Reconstructed `ArcticHiveClientPool` class to replace `HiveClientPool` from Iceberg, And in the init method to increase this:`HiveConf. AddResource (tableMetaStore. GetHiveSiteLocation (). OrElse (null));`

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

Configure multiple Hive catalogs and obtain table information through AMS, and use multiple threads to call the listDatabases method of different catalogs at the same time

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
