### PR TITLE
[ARCTIC-380][Hive]Change hive table schema filed name to lowercase when creating table

### DIFF
--- a/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
@@ -35,6 +35,7 @@ import com.netease.arctic.io.ArcticFileIO;
 import com.netease.arctic.io.ArcticHadoopFileIO;
 import com.netease.arctic.table.BaseKeyedTable;
 import com.netease.arctic.table.ChangeTable;
+import com.netease.arctic.table.PrimaryKeySpec;
 import com.netease.arctic.table.TableBuilder;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
@@ -42,8 +43,11 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.IcebergSchemaUtil;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.mapping.MappingUtil;
@@ -186,18 +190,44 @@ public class ArcticHiveCatalog extends BaseArcticCatalog {
   class ArcticHiveTableBuilder extends BaseArcticTableBuilder {
 
     public ArcticHiveTableBuilder(TableIdentifier identifier, Schema schema) {
-      super(identifier, schema);
+      super(identifier, HiveSchemaUtil.changeFieldNameToLowercase(schema));
     }
 
     boolean allowExistedHiveTable = false;
 
     @Override
+    public TableBuilder withPartitionSpec(PartitionSpec partitionSpec) {
+      return super.withPartitionSpec(IcebergSchemaUtil.copyPartitionSpec(partitionSpec, schema));
+    }
+
+    @Override
+    public TableBuilder withSortOrder(SortOrder sortOrder) {
+      return super.withSortOrder(IcebergSchemaUtil.copySortOrderSpec(sortOrder, schema));
+    }
+
+    @Override
+    public TableBuilder withPrimaryKeySpec(PrimaryKeySpec primaryKeySpec) {
+      PrimaryKeySpec.Builder builder = PrimaryKeySpec.builderFor(schema);
+      primaryKeySpec.fields().forEach(primaryKeyField -> builder.addColumn(primaryKeyField.fieldName().toLowerCase(
+          Locale.ROOT)));
+      return super.withPrimaryKeySpec(builder.build());
+    }
+
+    @Override
     public TableBuilder withProperty(String key, String value) {
       if (key.equals(HiveTableProperties.ALLOW_HIVE_TABLE_EXISTED) && value.equals("true")) {
         allowExistedHiveTable = true;
+      } else if (key.equals(TableProperties.TABLE_EVENT_TIME_FIELD)) {
+        super.withProperty(key, value.toLowerCase(Locale.ROOT));
       } else {
-        this.properties.put(key, value);
+        super.withProperty(key, value);
       }
+      return this;
+    }
+
+    @Override
+    public TableBuilder withProperties(Map<String, String> properties) {
+      properties.forEach(this::withProperty);
       return this;
     }
 

--- a/hive/src/main/java/com/netease/arctic/hive/utils/ChangeFieldName.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/ChangeFieldName.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.hive.utils;
+
+import com.google.common.collect.Sets;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Supplier;
+
+class ChangeFieldName extends TypeUtil.CustomOrderSchemaVisitor<Type> {
+
+  enum ChangeType {
+    TO_UPPERCASE, TO_LOWERCASE
+  }
+
+  private final ChangeType changeType;
+  private final Set<String> fieldNameSet = Sets.newHashSet();
+
+  /**
+   * Change the filed name of a schema, change to uppercase or lowercase.
+   *
+   * @param changeType TO_UPPERCASE or TO_LOWERCASE
+   */
+  ChangeFieldName(ChangeType changeType) {
+    this.changeType = changeType;
+  }
+
+  private String changeName(String name) {
+    switch (changeType) {
+      case TO_UPPERCASE:
+        return name.toUpperCase(Locale.ROOT);
+      case TO_LOWERCASE:
+        return name.toLowerCase(Locale.ROOT);
+      default:
+        throw new UnsupportedOperationException("Unsupported change type: " + changeType);
+    }
+  }
+
+  @Override
+  public Type schema(Schema schema, Supplier<Type> future) {
+    return future.get();
+  }
+
+  @Override
+  public Type struct(Types.StructType struct, Iterable<Type> futures) {
+    List<Types.NestedField> fields = struct.fields();
+    int length = struct.fields().size();
+
+    List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(length);
+    Iterator<Type> types = futures.iterator();
+    for (int i = 0; i < length; i += 1) {
+      Types.NestedField field = fields.get(i);
+      Type type = types.next();
+      if (field.isOptional()) {
+        newFields.add(Types.NestedField.optional(field.fieldId(), changeName(field.name()), type, field.doc()));
+      } else {
+        newFields.add(Types.NestedField.required(field.fieldId(), changeName(field.name()), type, field.doc()));
+      }
+      if (fieldNameSet.contains(newFields.get(i).name())) {
+        throw new IllegalArgumentException("Multiple fields' name will be changed to " + newFields.get(i).name());
+      }
+      fieldNameSet.add(newFields.get(i).name());
+    }
+
+    return Types.StructType.of(newFields);
+  }
+
+  @Override
+  public Type field(Types.NestedField field, Supplier<Type> future) {
+    return future.get();
+  }
+
+  @Override
+  public Type list(Types.ListType list, Supplier<Type> future) {
+    return list;
+  }
+
+  @Override
+  public Type map(Types.MapType map, Supplier<Type> keyFuture, Supplier<Type> valueFuture) {
+    return map;
+  }
+
+  @Override
+  public Type primitive(Type.PrimitiveType primitive) {
+    return primitive;
+  }
+}

--- a/hive/src/main/java/com/netease/arctic/hive/utils/HiveSchemaUtil.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/HiveSchemaUtil.java
@@ -100,4 +100,16 @@ public class HiveSchemaUtil {
     });
     return new Schema(columnsWithPk);
   }
+
+  /**
+   * Change the filed name in schema to lowercase.
+   *
+   * @param schema The original schema to change
+   * @return An new schema with lowercase field name
+   */
+  public static Schema changeFieldNameToLowercase(Schema schema) {
+    Types.StructType struct = TypeUtil.visit(schema.asStruct(),
+        new ChangeFieldName(ChangeFieldName.ChangeType.TO_LOWERCASE)).asStructType();
+    return new Schema(struct.fields());
+  }
 }

--- a/hive/src/main/java/org/apache/iceberg/IcebergSchemaUtil.java
+++ b/hive/src/main/java/org/apache/iceberg/IcebergSchemaUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg;
+
+public class IcebergSchemaUtil {
+
+  /**
+   * Copy an new partition spec depend on an new schema, new schema should contain the same fields partition spec need.
+   *
+   * @param partitionSpec partition spec to be copied
+   * @param copySchema schema new partition spec depend on
+   * @return the new partition spec
+   */
+  public static PartitionSpec copyPartitionSpec(PartitionSpec partitionSpec, Schema copySchema) {
+    PartitionSpec.Builder builder = PartitionSpec.builderFor(copySchema);
+    partitionSpec.fields().forEach(partitionField -> {
+      builder.add(partitionField.sourceId(), partitionField.name(), partitionField.transform().toString());
+    });
+    return builder.build();
+  }
+
+  /**
+   * Copy an new sort order spec depend on an new schema, new schema should contain the same fields sort order spec
+   * need.
+   *
+   * @param sortOrder sort order spec to be copied
+   * @param copySchema schema new partition spec depend on
+   * @return the new partition spec
+   */
+  public static SortOrder copySortOrderSpec(SortOrder sortOrder, Schema copySchema) {
+    SortOrder.Builder builder = SortOrder.builderFor(copySchema);
+    sortOrder.fields().forEach(sortField -> {
+      builder.addSortField(
+          sortField.transform().toString(),
+          sortField.sourceId(),
+          sortField.direction(),
+          sortField.nullOrder());
+    });
+    return builder.build();
+  }
+}

--- a/hive/src/test/java/com/netease/arctic/hive/utils/HiveSchemaUtilTest.java
+++ b/hive/src/test/java/com/netease/arctic/hive/utils/HiveSchemaUtilTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.hive.utils;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HiveSchemaUtilTest {
+
+
+  @Test
+  public void testChangeFieldNameToLowercase() {
+
+    Schema schema = new Schema(
+        Types.NestedField.optional(1, "Col1", Types.IntegerType.get()),
+        Types.NestedField.optional(2, "COL2", Types.LongType.get()),
+        Types.NestedField.optional(3, "COL3", Types.ListType.ofOptional(4, Types.StringType.get())),
+        Types.NestedField.optional(5, "COL4", Types.MapType.ofOptional(6, 7, Types.StringType.get(),
+            Types.StringType.get())),
+        Types.NestedField.optional(8, "COL5", Types.StructType.of(
+            Types.NestedField.optional(9, "COL6", Types.StringType.get()),
+            Types.NestedField.optional(10, "COL7", Types.TimestampType.withoutZone())))
+    );
+
+    Schema changedSchema = new Schema(
+        Types.NestedField.optional(1, "col1", Types.IntegerType.get()),
+        Types.NestedField.optional(2, "col2", Types.LongType.get()),
+        Types.NestedField.optional(3, "col3", Types.ListType.ofOptional(4, Types.StringType.get())),
+        Types.NestedField.optional(5, "col4", Types.MapType.ofOptional(6, 7, Types.StringType.get(),
+            Types.StringType.get())),
+        Types.NestedField.optional(8, "col5", Types.StructType.of(
+            Types.NestedField.optional(9, "col6", Types.StringType.get()),
+            Types.NestedField.optional(10, "col7", Types.TimestampType.withoutZone())))
+    );
+
+    Assert.assertEquals(changedSchema.asStruct(), HiveSchemaUtil.changeFieldNameToLowercase(schema).asStruct());
+  }
+
+}

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestCreateTableDDL.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestCreateTableDDL.java
@@ -512,6 +512,103 @@ public class TestCreateTableDDL extends SparkTestBase {
     });
   }
 
+  @Test
+  public void testCreateUppercaseTable() throws TException {
+    // hive style
+    TableIdentifier identifierA = TableIdentifier.of(catalogNameHive, database, tableA);
+
+    sql("create table {0}.{1} ( \n" +
+        " ID int , \n" +
+        " NAME string , \n " +
+        " primary key (ID) \n" +
+        ") using arctic \n" +
+        " partitioned by (TS string, DT string) \n" +
+        " tblproperties ( \n" +
+        " ''props.test1'' = ''val1'', \n" +
+        " ''props.test2'' = ''val2'', \n" +
+        " ''table.event-time-field'' = ''NAME'') ", database, tableA);
+    assertTableExist(identifierA);
+    ArcticTable keyedTableA = loadTable(identifierA);
+    Types.StructType expectedSchema = Types.StructType.of(
+        Types.NestedField.required(1, "id", Types.IntegerType.get()),
+        Types.NestedField.optional(2, "name", Types.StringType.get()),
+        Types.NestedField.optional(3, "ts", Types.StringType.get()),
+        Types.NestedField.optional(4, "dt", Types.StringType.get()));
+    Assert.assertEquals("Schema should match expected",
+        expectedSchema, keyedTableA.schema().asStruct());
+    sql("desc table {0}.{1}", database, tableA);
+    assertPartitionResult(rows, Lists.newArrayList("ts", "dt"));
+
+    Assert.assertArrayEquals("Primary should match expected",
+        new List[]{Collections.singletonList("id")},
+        new List[]{keyedTableA.asKeyedTable().primaryKeySpec().fieldNames()});
+    Assert.assertTrue(keyedTableA.properties().containsKey("props.test1"));
+    Assert.assertEquals("val1", keyedTableA.properties().get("props.test1"));
+    Assert.assertTrue(keyedTableA.properties().containsKey("props.test2"));
+    Assert.assertEquals("val2", keyedTableA.properties().get("props.test2"));
+    Assert.assertTrue(keyedTableA.properties().containsKey("table.event-time-field"));
+    Assert.assertEquals("name", keyedTableA.properties().get("table.event-time-field"));
+
+    sql("use spark_catalog");
+    Table hiveTableA = hms.getClient().getTable(database, tableA);
+    Assert.assertNotNull(hiveTableA);
+    rows = sql("desc table {0}.{1}", database, tableA);
+    assertHiveDesc(rows,
+        Lists.newArrayList("id", "name", "ts", "dt"),
+        Lists.newArrayList("ts", "dt"));
+
+    sql("use " + catalogNameHive);
+    sql("drop table {0}.{1}", database, tableA);
+    assertTableNotExist(identifierA);
+
+    // column reference style
+    TableIdentifier identifierB = TableIdentifier.of(catalogNameHive, database, tableB);
+    sql("create table {0}.{1} ( \n" +
+        " id int , \n" +
+        " name string , \n" +
+        " ts string ,\n " +
+        " dt string ,\n " +
+        " primary key (id) \n" +
+        ") using arctic \n" +
+        " partitioned by (ts, dt) \n" +
+        " tblproperties ( \n" +
+        " ''props.test1'' = ''val1'', \n" +
+        " ''props.test2'' = ''val2'' ) ", database, tableB);
+
+    ArcticTable keyedTableB = loadTable(identifierB);
+    Types.StructType expectedSchemaB = Types.StructType.of(
+        Types.NestedField.required(1, "id", Types.IntegerType.get()),
+        Types.NestedField.optional(2, "name", Types.StringType.get()),
+        Types.NestedField.optional(3, "ts", Types.StringType.get()),
+        Types.NestedField.optional(4, "dt", Types.StringType.get()));
+    Assert.assertEquals("Schema should match expected",
+        expectedSchemaB, keyedTableB.schema().asStruct());
+
+    sql("desc table {0}.{1}", database, tableB);
+    assertPartitionResult(rows, Lists.newArrayList("ts", "dt"));
+
+    Assert.assertArrayEquals("Primary should match expected",
+        new List[]{Collections.singletonList("id")},
+        new List[]{keyedTableB.asKeyedTable().primaryKeySpec().fieldNames()});
+
+    Assert.assertTrue(keyedTableB.properties().containsKey("props.test1"));
+    Assert.assertEquals("val1", keyedTableB.properties().get("props.test1"));
+    Assert.assertTrue(keyedTableB.properties().containsKey("props.test2"));
+    Assert.assertEquals("val2", keyedTableB.properties().get("props.test2"));
+
+    sql("use spark_catalog");
+    Table hiveTableB = hms.getClient().getTable(database, tableB);
+    Assert.assertNotNull(hiveTableB);
+    rows = sql("desc table {0}.{1}", database, tableB);
+    assertHiveDesc(rows,
+        Lists.newArrayList("id", "name", "ts", "dt"),
+        Lists.newArrayList("ts", "dt"));
+
+    sql("use " + catalogNameHive);
+    sql("drop table {0}.{1}", database, tableB);
+    assertTableNotExist(identifierB);
+  }
+
   private String rowToSqlValues(List<Object[]> rows) {
     List<String> rowValues = rows.stream().map(row -> {
       List<String> columns = Arrays.stream(row).map(value -> {

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
@@ -42,6 +42,12 @@ public class TestKeyedTableDml extends SparkTestBase {
       " data string, primary key(id)) \n" +
       " using arctic ";
 
+  protected String createUppercaseTableTemplate = "create table {0}.{1}( \n" +
+      " ID int, \n" +
+      " NAME string, \n" +
+      " DATA string, primary key(ID))\n" +
+      " using arctic partitioned by (DATA) " ;
+
   @Before
   public void prepare() {
     sql("use " + catalogNameHive);
@@ -189,5 +195,17 @@ public class TestKeyedTableDml extends SparkTestBase {
     Assert.assertEquals(2, rows.size());
     Assert.assertEquals(1, rows.get(0)[0]);
     Assert.assertEquals(2, rows.get(1)[0]);
+  }
+
+  @Test
+  public void testCreateTableUppercase() {
+    sql(createUppercaseTableTemplate, database, "uppercase_table");
+    sql("insert into " + database + "." + "uppercase_table" +
+        " values (1, 'aaa', 'abcd' ) , " +
+        "(2, 'bbb', 'bbcd'), " +
+        "(3, 'ccc', 'cbcd') ");
+    rows = sql("select id, name, data from {0}.{1} ", database, "uppercase_table");
+    Assert.assertEquals(3, rows.size());
+    sql("drop table if exists " + database + "." + "uppercase_table");
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Resolve #380 .

As Hive table support lowercase field name only, we should change table schema field name to lowercase when creating hive table.

## Brief change log

  - *Add ChangeFieldName converter for iceberg schema*
  - *Change table field name to lowercase when creating hive table.*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
