### PR TITLE
[ARCTIC-422] [FLINK] check ENABLE_LOG_STORE property before building LogReader

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -62,6 +62,8 @@ import java.util.Set;
 
 import static com.netease.arctic.flink.catalog.descriptors.ArcticCatalogValidator.METASTORE_URL;
 import static com.netease.arctic.flink.catalog.descriptors.ArcticCatalogValidator.METASTORE_URL_OPTION;
+import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
+import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS_PREFIX;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FORMAT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.PROPS_BOOTSTRAP_SERVERS;
@@ -148,6 +150,9 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         break;
       case ArcticValidator.ARCTIC_READ_LOG:
       default:
+        Preconditions.checkArgument(PropertyUtil.propertyAsBoolean(arcticTable.properties(),
+                ENABLE_LOG_STORE, ENABLE_LOG_STORE_DEFAULT),
+            String.format("Read log should enable %s at first", ENABLE_LOG_STORE));
         arcticDynamicSource = createLogSource(arcticTable, context);
     }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -118,8 +118,9 @@ public class ArcticUtils {
     boolean streamEnable = PropertyUtil.propertyAsBoolean(properties, TableProperties.ENABLE_LOG_STORE,
         TableProperties.ENABLE_LOG_STORE_DEFAULT);
     if (!streamEnable) {
-      throw new ValidationException(
-          "emit to kafka was set, but no kafka config be found, please set kafka config first");
+      throw new ValidationException(String.format(
+          "emit to kafka was set, but no kafka config be found, please set kafka config first. Then enable %s",
+          TableProperties.ENABLE_LOG_STORE));
     }
 
     String version = properties.getOrDefault(LOG_STORE_DATA_VERSION, LOG_STORE_DATA_VERSION_DEFAULT);

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -67,6 +67,8 @@ import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getSource
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getSourceTopics;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getStartupOptions;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.validateTableSourceOptions;
+import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
+import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FIELDS_PREFIX;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FORMAT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
@@ -149,6 +151,9 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         break;
       case ArcticValidator.ARCTIC_READ_LOG:
       default:
+        Preconditions.checkArgument(PropertyUtil.propertyAsBoolean(arcticTable.properties(),
+                ENABLE_LOG_STORE, ENABLE_LOG_STORE_DEFAULT),
+            String.format("Read log should enable %s at first", ENABLE_LOG_STORE));
         arcticDynamicSource = createLogSource(arcticTable, context);
     }
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -118,8 +118,9 @@ public class ArcticUtils {
     boolean streamEnable = PropertyUtil.propertyAsBoolean(properties, TableProperties.ENABLE_LOG_STORE,
         TableProperties.ENABLE_LOG_STORE_DEFAULT);
     if (!streamEnable) {
-      throw new ValidationException(
-          "emit to kafka was set, but no kafka config be found, please set kafka config first");
+      throw new ValidationException(String.format(
+          "emit to kafka was set, but no kafka config be found, please set kafka config first. Then enable %s",
+          TableProperties.ENABLE_LOG_STORE));
     }
 
     String version = properties.getOrDefault(LOG_STORE_DATA_VERSION, LOG_STORE_DATA_VERSION_DEFAULT);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -67,6 +67,8 @@ import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getSource
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getSourceTopics;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getStartupOptions;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.validateTableSourceOptions;
+import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
+import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FIELDS_PREFIX;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FORMAT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
@@ -149,6 +151,9 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         break;
       case ArcticValidator.ARCTIC_READ_LOG:
       default:
+        Preconditions.checkArgument(PropertyUtil.propertyAsBoolean(arcticTable.properties(),
+                ENABLE_LOG_STORE, ENABLE_LOG_STORE_DEFAULT),
+            String.format("Read log should enable %s at first", ENABLE_LOG_STORE));
         arcticDynamicSource = createLogSource(arcticTable, context);
     }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -118,8 +118,9 @@ public class ArcticUtils {
     boolean streamEnable = PropertyUtil.propertyAsBoolean(properties, TableProperties.ENABLE_LOG_STORE,
         TableProperties.ENABLE_LOG_STORE_DEFAULT);
     if (!streamEnable) {
-      throw new ValidationException(
-          "emit to kafka was set, but no kafka config be found, please set kafka config first");
+      throw new ValidationException(String.format(
+          "emit to kafka was set, but no kafka config be found, please set kafka config first. Then enable %s",
+          TableProperties.ENABLE_LOG_STORE));
     }
 
     String version = properties.getOrDefault(LOG_STORE_DATA_VERSION, LOG_STORE_DATA_VERSION_DEFAULT);


### PR DESCRIPTION
Fix #422 

## Why are the changes needed?
Without ENABLE_LOG_STORE property validation, it may lead to exceptions for lacking of some required properties. It will confuse users in trouble shooting.

## Brief change log

  - *Add ENABLE_LOG_STORE  validation before building LogReader*
  - *The flink 1.12 and 1.14, 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
