### PR TITLE
[Spark] Add prefix to spark 2.3 catalog url properties

### DIFF
--- a/spark/v2.3/spark/src/main/java/com/netease/arctic/spark/util/ArcticSparkUtil.java
+++ b/spark/v2.3/spark/src/main/java/com/netease/arctic/spark/util/ArcticSparkUtil.java
@@ -40,13 +40,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ArcticSparkUtil {
-  public static final String CATALOG_URL = "arctic.catalog.url";
+  public static final String CATALOG_URL = "spark.sql.arctic.catalog.url";
   public static final String SQL_DELEGATE_HIVE_TABLE = "spark.arctic.sql.delegate.enable";
 
   public static String catalogUrl(RuntimeConfig conf) {
     String catalogUrl = conf.get(CATALOG_URL, "");
     if (StringUtils.isBlank(catalogUrl)) {
-      throw new IllegalArgumentException("arctic.catalog.url is blank");
+      throw new IllegalArgumentException("spark.sql.arctic.catalog.url is blank");
     }
     return catalogUrl;
   }

--- a/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -144,9 +144,9 @@ public class SparkTestContext extends ExternalResource {
     catalogName = arctic_hive.getCatalogName();
     ams.handler().createCatalog(arctic_hive);
 
-    configs.put("arctic.catalog." + catalogName, ArcticCatalog.class.getName());
-    configs.put("arctic.catalog.type", "hive");
-    configs.put("arctic.catalog.url" , amsUrl + "/" + catalogName);
+    configs.put("spark.sql.arctic.catalog." + catalogName, ArcticCatalog.class.getName());
+    configs.put("spark.sql.arctic.catalog.type", "hive");
+    configs.put("spark.sql.arctic.catalog.url" , amsUrl + "/" + catalogName);
     return configs;
   }
 


### PR DESCRIPTION

## Why are the changes needed?

Spark 2.3 catalog property need "spark" prefix to take effect in spark-sql client.

## Brief change log

  - *Add 'spark.sql' prefix to catalog url*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
