### PR TITLE
[ARCTIC-430][AMS]Record baseSnapshotId for unKeyed table

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableQuotaInfo.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableQuotaInfo.java
@@ -60,7 +60,7 @@ public class TableQuotaInfo implements Comparable<TableQuotaInfo> {
 
   @Override
   public int compareTo(@NotNull TableQuotaInfo o) {
-    if (!quota.equals(o.getQuota())) {
+    if (quota.compareTo(o.getQuota()) != 0) {
       return quota.compareTo(o.getQuota());
     }
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
@@ -311,7 +311,8 @@ public class BaseOptimizeCommit {
         RewriteFiles removeDeleteFiles = baseArcticTable.newRewrite()
             .validateFromSnapshot(baseArcticTable.currentSnapshot().snapshotId());
         removeDeleteFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
-        removeDeleteFiles.rewriteFiles(Collections.emptySet(), deleteDeleteFiles, Collections.emptySet(), addDeleteFiles);
+        removeDeleteFiles
+            .rewriteFiles(Collections.emptySet(), deleteDeleteFiles, Collections.emptySet(), addDeleteFiles);
         try {
           removeDeleteFiles.commit();
         } catch (ValidationException e) {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizePlan.java
@@ -301,7 +301,7 @@ public abstract class BaseOptimizePlan {
       this.currentBaseSnapshotId = UnKeyedTableUtil.getSnapshotId(arcticTable.asKeyedTable().baseTable());
       this.currentChangeSnapshotId = UnKeyedTableUtil.getSnapshotId(arcticTable.asKeyedTable().changeTable());
     } else {
-      this.currentChangeSnapshotId = UnKeyedTableUtil.getSnapshotId(arcticTable.asUnkeyedTable());
+      this.currentBaseSnapshotId = UnKeyedTableUtil.getSnapshotId(arcticTable.asUnkeyedTable());
     }
 
     return tableChanged();


### PR DESCRIPTION
## Why are the changes needed?
fix #430 
fix #431 
flink increment pull will failed if major commit use OverwriteFils because iceberg don't support this operation increment pull

## Brief change log

  - *record currentBaseSnapshotId rather than currentChangeSnapshotId for unKeyed table in BaseOptimizePlan class*
  - *modify equals condition for compareTo method in TableQuotaInfo class*
  - *modify overwrite dataFiles to rewrite dataFiles in major commit*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
