### PR TITLE
[ARCTIC-436][AMS]:OptimizerMonitor check optimizer status logic error

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeExecuteService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeExecuteService.java
@@ -116,7 +116,7 @@ public class OptimizeExecuteService {
       List<com.netease.arctic.ams.server.model.Optimizer> optimizers =
           ServiceContainer.getOptimizerService().getOptimizers();
       optimizers.forEach(optimizer -> {
-        if ((optimizer.getUpdateTime().getTime() - currentTime) > OPTIMIZER_JOB_TIMEOUT) {
+        if ((currentTime - optimizer.getUpdateTime().getTime()) > OPTIMIZER_JOB_TIMEOUT) {
           ServiceContainer.getOptimizerService()
               .updateOptimizerStatus(optimizer.getJobId(), TableTaskStatus.FAILED);
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
fix #436 
When the Optimizer job stops, the dashboard still displays the job status as running

## Brief change log

change OptimizerMonitor.monitorStatus() logic

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
