### PR TITLE
[SPARK]Change the Spark update from outer join to select + project

### DIFF
--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
@@ -199,6 +199,9 @@ public class TestKeyedTableDml extends SparkTestBase {
 
     rows = sql("select * from {0}.{1} where id = 1", database, notUpsertTable);
     Assert.assertEquals("dddd", rows.get(0)[1]);
+
+    rows = sql("select * from {0}.{1}.{2}.change where id = 1 and name = ''dddd''", catalogNameHive, database, notUpsertTable);
+    Assert.assertEquals(2, rows.size());
   }
 
   @Test

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
@@ -188,6 +188,20 @@ public class TestKeyedTableDml extends SparkTestBase {
   }
 
   @Test
+  public void testUpdateUnUpsertTable() {
+    sql("insert into " + database + "." + notUpsertTable +
+            " values (1, 'aaa', 'abcd' ) , " +
+            "(2, 'bbb', 'bbcd'), " +
+            "(3, 'ccc', 'cbcd') ");
+    rows = sql("select * from {0}.{1} ", database, notUpsertTable);
+    Assert.assertEquals(6, rows.size());
+    sql("update {0}.{1} as t set name = ''dddd'' where id = 1", database, notUpsertTable);
+
+    rows = sql("select * from {0}.{1} where id = 1", database, notUpsertTable);
+    Assert.assertEquals("dddd", rows.get(0)[1]);
+  }
+
+  @Test
   public void testDelete() {
     sql("delete from {0}.{1} where id = 3", database, notUpsertTable);
     rows = sql("select id, name from {0}.{1} order by id", database, notUpsertTable);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In the Spark update plan, the final query was originally constructed as a outer join, now the Query will be constructed as a select + project
 


## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request


