### PR TITLE
[ARCTIC-459][FLINK] Fix the missing of the required fields after project pushdown

### DIFF
--- a/flink/v1.12/flink-runtime/pom.xml
+++ b/flink/v1.12/flink-runtime/pom.xml
@@ -86,7 +86,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
@@ -18,21 +18,38 @@
 
 package com.netease.arctic.flink;
 
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.PrimaryKeySpec;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.WatermarkSpec;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * An util that converts flink table schema.
  */
 public class FlinkSchemaUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FlinkSchemaUtil.class);
+
   /**
    * Convert a {@link RowType} to a {@link TableSchema}.
    *
@@ -120,5 +137,78 @@ public class FlinkSchemaUtil {
       fields[i] = tableColumn.getType().getLogicalType();
     }
     return RowType.of(fields);
+  }
+
+  /**
+   * Primary key and partition key are the required fields for shuffle.
+   * The required fields should be added even though project push-down
+   */
+  public static List<Types.NestedField> addPrimaryAndPartitionKey(
+      List<Types.NestedField> projectedColumns, ArcticTable table) {
+    List<String> primaryKeys = table.isUnkeyedTable() ? Collections.EMPTY_LIST
+        : table.asKeyedTable().primaryKeySpec().fields().stream()
+        .map(PrimaryKeySpec.PrimaryKeyField::fieldName).collect(Collectors.toList());
+
+    List<Types.NestedField> columns = new ArrayList<>(projectedColumns);
+    Set<String> projectedNames = new HashSet<>();
+    Set<Integer> projectedIds = new HashSet<>();
+
+    projectedColumns.forEach((c) -> {
+      projectedNames.add(c.name());
+      projectedIds.add(c.fieldId());
+    });
+
+    primaryKeys.forEach(pk -> {
+      if (!projectedNames.contains(pk)) {
+        columns.add(table.schema().findField(pk));
+      }
+    });
+
+    Set<Integer> partitionIds = table.spec().identitySourceIds();
+    partitionIds.forEach(partition -> {
+      if (!projectedIds.contains(partition)) {
+        columns.add(table.schema().findField(partition));
+      }
+    });
+    LOG.info("Projected Columns after addPrimaryAndPartitionKey, columns:{}", columns);
+    return columns;
+  }
+
+  /**
+   * Primary key and partition key are the required fields for shuffle.
+   * The required fields should be added even though project push-down
+   *
+   * @param builder
+   * @param table
+   * @param tableSchema
+   * @param projectedColumns
+   */
+  public static void addPrimaryAndPartitionKey(
+      TableSchema.Builder builder, ArcticTable table, TableSchema tableSchema, String[] projectedColumns) {
+    Set<String> projectedNames = Arrays.stream(projectedColumns).collect(Collectors.toSet());
+
+    if (table.isKeyedTable()) {
+      List<String> pks = table.asKeyedTable().primaryKeySpec().fieldNames();
+      pks.forEach(pk -> {
+        if (projectedNames.contains(pk)) {
+          return;
+        }
+        builder.field(pk, tableSchema.getFieldDataType(pk)
+            .orElseThrow(() -> new ValidationException("Arctic primary key should be declared in table")));
+      });
+    }
+
+    Set<String> partitionNames = Sets.newHashSet();
+    for (PartitionField field : table.spec().fields()) {
+      partitionNames.add(field.name());
+    }
+
+    partitionNames.forEach(p -> {
+      if (projectedNames.contains(p)) {
+        return;
+      }
+      builder.field(p, tableSchema.getFieldDataType(p)
+          .orElseThrow(() -> new ValidationException("Arctic partition key should be declared in table")));
+    });
   }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public class ShuffleSplitAssigner implements SplitAssigner {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleSplitAssigner.class);
 
-  private static final long POLL_TIMEOUT = 300;
+  private static final long POLL_TIMEOUT = 200;
   private final SplitEnumeratorContext<ArcticSplit> enumeratorContext;
 
   private int totalParallelism;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public class ShuffleSplitAssigner implements SplitAssigner {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleSplitAssigner.class);
 
-  private static final long POLL_TIMEOUT = 3;
+  private static final long POLL_TIMEOUT = 300;
   private final SplitEnumeratorContext<ArcticSplit> enumeratorContext;
 
   private int totalParallelism;
@@ -103,7 +103,7 @@ public class ShuffleSplitAssigner implements SplitAssigner {
 
       ArcticSplit arcticSplit = null;
       try {
-        arcticSplit = queue.poll(POLL_TIMEOUT, TimeUnit.SECONDS);
+        arcticSplit = queue.poll(POLL_TIMEOUT, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
         LOG.warn("interruptedException", e);
       }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -31,6 +31,8 @@ import org.apache.iceberg.types.Types;
 
 import java.io.Serializable;
 
+import static org.apache.iceberg.IcebergSchemaUtil.projectPartition;
+
 /**
  * This helper operates to one arctic table and the data of the table.
  */
@@ -50,7 +52,7 @@ public class ShuffleHelper implements Serializable {
     PartitionKey partitionKey = null;
 
     if (table.spec() != null && !CollectionUtil.isNullOrEmpty(table.spec().fields())) {
-      partitionKey = new PartitionKey(table.spec(), schema);
+      partitionKey = new PartitionKey(projectPartition(table.spec(), schema), schema);
     }
     schema = addFieldsNotInArctic(schema, rowType);
 
@@ -66,7 +68,8 @@ public class ShuffleHelper implements Serializable {
 
   /**
    * If using arctic table as build table, there will be an additional implicit field, valuing process time.
-   * @param schema The physical schema in Arctic table
+   *
+   * @param schema  The physical schema in Arctic table
    * @param rowType Flink RowData type.
    * @return the Arctic Schema with additional implicit field.
    */
@@ -126,7 +129,7 @@ public class ShuffleHelper implements Serializable {
   }
 
   public boolean isPartitionKeyExist() {
-    return partitionKey != null;
+    return partitionKey != null && partitionKey.size() > 0;
   }
 
   public int hashPartitionValue(RowData rowData) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -69,7 +69,7 @@ public class ShuffleHelper implements Serializable {
   /**
    * If using arctic table as build table, there will be an additional implicit field, valuing process time.
    *
-   * @param schema  The physical schema in Arctic table
+   * @param schema  The physical schema in Arctic table.
    * @param rowType Flink RowData type.
    * @return the Arctic Schema with additional implicit field.
    */

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -55,7 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
@@ -177,8 +177,9 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
   }
 
   private DataStream<RowData> distribute(DataStream<RowData> source, DistributionHashMode mode) {
+    ShuffleHelper helper = ShuffleHelper.build(arcticTable, readSchema, flinkSchemaRowType);
     if (mode == DistributionHashMode.AUTO) {
-      mode = DistributionHashMode.autoSelect(arcticTable.isKeyedTable(), !arcticTable.spec().isUnpartitioned());
+      mode = DistributionHashMode.autoSelect(arcticTable.isKeyedTable(), helper.isPartitionKeyExist());
     }
     LOG.info("source distribute mode in effect. {}", mode);
     switch (mode) {
@@ -187,23 +188,22 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       case PRIMARY_KEY:
         Preconditions.checkArgument(arcticTable.isKeyedTable(),
             "illegal shuffle policy " + mode.getDesc() + " for table without primary key");
-        return hash(source, DistributionHashMode.PRIMARY_KEY);
+        return hash(source, helper, DistributionHashMode.PRIMARY_KEY);
       case PARTITION_KEY:
         Preconditions.checkArgument(!arcticTable.spec().isUnpartitioned(),
             "illegal shuffle policy " + mode.getDesc() + " for table without partition key");
-        return hash(source, DistributionHashMode.PARTITION_KEY);
+        return hash(source, helper, DistributionHashMode.PARTITION_KEY);
       case PRIMARY_PARTITION_KEY:
         Preconditions.checkArgument(arcticTable.isKeyedTable() && !arcticTable.spec().isUnpartitioned(),
             "illegal shuffle policy " + mode.getDesc() +
                 " for table without primary key or partition key");
-        return hash(source, DistributionHashMode.PRIMARY_PARTITION_KEY);
+        return hash(source, helper, DistributionHashMode.PRIMARY_PARTITION_KEY);
       default:
         throw new RuntimeException("Unrecognized " + READ_DISTRIBUTION_HASH_MODE + ": " + mode);
     }
   }
 
-  public DataStream<RowData> hash(DataStream<RowData> source, DistributionHashMode hashMode) {
-    ShuffleHelper helper = ShuffleHelper.build(arcticTable, readSchema, flinkSchemaRowType);
+  public DataStream<RowData> hash(DataStream<RowData> source, ShuffleHelper helper, DistributionHashMode hashMode) {
     ReadShuffleRulePolicy shuffleRulePolicy = new ReadShuffleRulePolicy(helper, hashMode);
     return source.partitionCustom(shuffleRulePolicy.generatePartitioner(), shuffleRulePolicy.generateKeySelector());
   }
@@ -251,7 +251,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
         .mapToObj(columns::get)
         .collect(Collectors.toList());
 
-    readSchema = new Schema(addPrimaryAndPartitionKey(projectedColumns, arcticTable));
+    readSchema = new Schema(addPrimaryKey(projectedColumns, arcticTable));
     flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
@@ -246,7 +247,11 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       projectionFields[i] = projectedFields[i][0];
     }
     final List<Types.NestedField> columns = readSchema.columns();
-    readSchema = new Schema(Arrays.stream(projectionFields).mapToObj(columns::get).collect(Collectors.toList()));
+    List<Types.NestedField> projectedColumns = Arrays.stream(projectionFields)
+        .mapToObj(columns::get)
+        .collect(Collectors.toList());
+
+    readSchema = new Schema(addPrimaryAndPartitionKey(projectedColumns, arcticTable));
     flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -42,12 +42,15 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkFilters;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -56,6 +59,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TAB
 public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown,
     SupportsProjectionPushDown, SupportsLimitPushDown, SupportsWatermarkPushDown {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ArcticFileSource.class);
+  
   private int[] projectedFields;
   private long limit;
   private List<Expression> filters;
@@ -127,9 +132,16 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
     } else {
       String[] fullNames = tableSchema.getFieldNames();
       DataType[] fullTypes = tableSchema.getFieldDataTypes();
-      return TableSchema.builder().fields(
-          Arrays.stream(projectedFields).mapToObj(i -> fullNames[i]).toArray(String[]::new),
-          Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new)).build();
+
+      String[] projectedColumns = Arrays.stream(projectedFields).mapToObj(i -> fullNames[i]).toArray(String[]::new);
+      TableSchema.Builder builder = TableSchema.builder().fields(
+          projectedColumns,
+          Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
+
+      addPrimaryAndPartitionKey(builder, table, tableSchema, projectedColumns);
+      TableSchema ts = builder.build();
+      LOG.info("TableSchema builder after addPrimaryAndPartitionKey, schema:{}", ts);
+      return ts;
     }
   }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -50,7 +50,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -138,9 +138,9 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
           projectedColumns,
           Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
 
-      addPrimaryAndPartitionKey(builder, table, tableSchema, projectedColumns);
+      addPrimaryKey(builder, table, tableSchema, projectedColumns);
       TableSchema ts = builder.build();
-      LOG.info("TableSchema builder after addPrimaryAndPartitionKey, schema:{}", ts);
+      LOG.info("TableSchema builder after addPrimaryKey, schema:{}", ts);
       return ts;
     }
   }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -279,7 +279,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceWithEmptyChangeInInit() throws Exception {
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_empty_change");
     KeyedTable table = testCatalog

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -21,9 +21,9 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableResult;
@@ -120,7 +120,7 @@ public class TestJoin extends FlinkTestBase {
         actual.add(row);
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{"a", 1000004L, null, null});
@@ -203,7 +203,7 @@ public class TestJoin extends FlinkTestBase {
         actual.add(row);
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{"a", 1L, 123, "a"});

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -20,10 +20,10 @@ package com.netease.arctic.flink.table;
 
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.hive.HiveTableTestBase;
 import com.netease.arctic.table.TableProperties;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.ApiExpression;
 import org.apache.flink.table.api.DataTypes;
@@ -239,7 +239,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -292,7 +292,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -435,7 +435,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -494,6 +494,6 @@ public class TestKeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -21,10 +21,10 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.catalog.ArcticCatalog;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.hive.HiveTableTestBase;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.ApiExpression;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
@@ -274,7 +274,7 @@ public class TestUnkeyed extends FlinkTestBase {
         actual.add(iterator.next());
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
   }
 
@@ -331,7 +331,7 @@ public class TestUnkeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -384,7 +384,7 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -508,7 +508,7 @@ public class TestUnkeyed extends FlinkTestBase {
         actual.add(iterator.next());
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
     Assert.assertEquals(new HashSet<>(expected), actual);
   }
 
@@ -567,7 +567,7 @@ public class TestUnkeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -619,7 +619,7 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
 }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -20,9 +20,9 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableResult;
@@ -119,7 +119,7 @@ public class TestWatermark extends FlinkTestBase {
       Row row = iterator.next();
       actual.add(row);
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{true});
@@ -170,7 +170,7 @@ public class TestWatermark extends FlinkTestBase {
       Row row = iterator.next();
       actual.add(row);
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{true, LocalDateTime.parse("2022-06-17T10:08:11")});

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -1,0 +1,129 @@
+package com.netease.arctic.flink.table;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableIdentifier;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.io.TaskWriter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.netease.arctic.ams.api.MockArcticMetastoreServer.TEST_CATALOG_NAME;
+import static com.netease.arctic.table.TableProperties.LOCATION;
+
+public class TestWatermark extends FlinkTestBase {
+  public static final Logger LOG = LoggerFactory.getLogger(TestJoin.class);
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static final String DB = PK_TABLE_ID.getDatabase();
+  private static final String TABLE = "test_keyed";
+
+  public void before() throws Exception {
+    super.before();
+    super.config(TEST_CATALOG_NAME);
+  }
+
+  @After
+  public void after() {
+    sql("DROP TABLE IF EXISTS arcticCatalog." + DB + "." + TABLE);
+  }
+
+  @Test
+  public void testWatermark() throws Exception {
+    sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
+
+    sql("CREATE TABLE IF NOT EXISTS %s (" +
+            " id bigint, user_id int, name STRING, category string, op_time timestamp, is_true boolean" +
+            ", PRIMARY KEY (id, user_id) NOT ENFORCED) PARTITIONED BY(category, name) WITH %s",
+        table, toWithClause(tableProperties));
+
+    TableSchema flinkSchema = TableSchema.builder()
+        .field("id", DataTypes.BIGINT())
+        .field("user_id", DataTypes.INT())
+        .field("name", DataTypes.STRING())
+        .field("category", DataTypes.STRING())
+        .field("op_time", DataTypes.TIMESTAMP(3))
+        .field("is_true", DataTypes.BOOLEAN())
+        .build();
+    RowType rowType = (RowType) flinkSchema.toRowDataType().getLogicalType();
+    KeyedTable keyedTable = (KeyedTable) ArcticUtils.loadArcticTable(
+        ArcticTableLoader.of(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE), catalogBuilder));
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(keyedTable, rowType, 1, true);
+    List<RowData> baseData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 2L, 123, StringData.fromString("a"), StringData.fromString("a"),
+          TimestampData.fromLocalDateTime(LocalDateTime.now().minusMinutes(1)), true));
+    }};
+    for (RowData record : baseData) {
+      taskWriter.write(record);
+    }
+    commit(keyedTable, taskWriter.complete(), true);
+
+    sql("create table d (tt as cast(op_time as timestamp(3)), watermark for tt as tt) like %s", table);
+
+    TableResult result = exec("select is_true from d");
+
+    CommonTestUtils.waitUntilJobManagerIsInitialized(() -> result.getJobClient().get().getJobStatus().get());
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      Row row = iterator.next();
+      actual.add(row);
+    }
+    result.getJobClient().ifPresent(JobClient::cancel);
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{true});
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+  }
+
+}

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.util;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.execution.JobClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(TestUtil.class);
+
+  public static void cancelJob(JobClient jobClient) {
+    if (isJobTerminated(jobClient)) {
+      return;
+    }
+    try {
+      jobClient.cancel();
+    } catch (Exception e) {
+      LOG.warn("cancel job exception.", e);
+    }
+  }
+
+  public static boolean isJobTerminated(JobClient jobClient) {
+    try {
+      JobStatus status = jobClient.getJobStatus().get();
+      return status.isGloballyTerminalState();
+    } catch (Exception e) {
+      // TODO
+      //  This is sort of hack.
+      //  Currently different execution environment will have different behaviors
+      //  when fetching a finished job status.
+      //  For example, standalone session cluster will return a normal FINISHED,
+      //  while mini cluster will throw IllegalStateException,
+      //  and yarn per job will throw ApplicationNotFoundException.
+      //  We have to assume that job has finished in this case.
+      //  Change this when these behaviors are unified.
+      LOG.warn(
+          "Failed to get job status so we assume that the job has terminated. Some data might be lost.",
+          e);
+      return true;
+    }
+  }
+
+}

--- a/flink/v1.14/flink-runtime/pom.xml
+++ b/flink/v1.14/flink-runtime/pom.xml
@@ -85,7 +85,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
@@ -28,8 +28,6 @@ import org.apache.flink.table.api.WatermarkSpec;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
-import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,10 +138,10 @@ public class FlinkSchemaUtil {
   }
 
   /**
-   * Primary key and partition key are the required fields for shuffle.
-   * The required fields should be added even though project push-down
+   * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
+   * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
-  public static List<Types.NestedField> addPrimaryAndPartitionKey(
+  public static List<Types.NestedField> addPrimaryKey(
       List<Types.NestedField> projectedColumns, ArcticTable table) {
     List<String> primaryKeys = table.isUnkeyedTable() ? Collections.EMPTY_LIST
         : table.asKeyedTable().primaryKeySpec().fields().stream()
@@ -151,12 +149,8 @@ public class FlinkSchemaUtil {
 
     List<Types.NestedField> columns = new ArrayList<>(projectedColumns);
     Set<String> projectedNames = new HashSet<>();
-    Set<Integer> projectedIds = new HashSet<>();
 
-    projectedColumns.forEach((c) -> {
-      projectedNames.add(c.name());
-      projectedIds.add(c.fieldId());
-    });
+    projectedColumns.forEach(c -> projectedNames.add(c.name()));
 
     primaryKeys.forEach(pk -> {
       if (!projectedNames.contains(pk)) {
@@ -164,51 +158,30 @@ public class FlinkSchemaUtil {
       }
     });
 
-    Set<Integer> partitionIds = table.spec().identitySourceIds();
-    partitionIds.forEach(partition -> {
-      if (!projectedIds.contains(partition)) {
-        columns.add(table.schema().findField(partition));
-      }
-    });
-    LOG.info("Projected Columns after addPrimaryAndPartitionKey, columns:{}", columns);
+    LOG.info("Projected Columns after addPrimaryKey, columns:{}", columns);
     return columns;
   }
 
   /**
-   * Primary key and partition key are the required fields for shuffle.
-   * The required fields should be added even though project push-down
-   *
-   * @param builder
-   * @param table
-   * @param tableSchema
-   * @param projectedColumns
+   * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
+   * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
-  public static void addPrimaryAndPartitionKey(
+  public static void addPrimaryKey(
       TableSchema.Builder builder, ArcticTable table, TableSchema tableSchema, String[] projectedColumns) {
     Set<String> projectedNames = Arrays.stream(projectedColumns).collect(Collectors.toSet());
 
-    if (table.isKeyedTable()) {
-      List<String> pks = table.asKeyedTable().primaryKeySpec().fieldNames();
-      pks.forEach(pk -> {
-        if (projectedNames.contains(pk)) {
-          return;
-        }
-        builder.field(pk, tableSchema.getFieldDataType(pk)
-            .orElseThrow(() -> new ValidationException("Arctic primary key should be declared in table")));
-      });
+    if (!table.isKeyedTable()) {
+      return;
     }
 
-    Set<String> partitionNames = Sets.newHashSet();
-    for (PartitionField field : table.spec().fields()) {
-      partitionNames.add(field.name());
-    }
-
-    partitionNames.forEach(p -> {
-      if (projectedNames.contains(p)) {
+    List<String> pks = table.asKeyedTable().primaryKeySpec().fieldNames();
+    pks.forEach(pk -> {
+      if (projectedNames.contains(pk)) {
         return;
       }
-      builder.field(p, tableSchema.getFieldDataType(p)
-          .orElseThrow(() -> new ValidationException("Arctic partition key should be declared in table")));
+      builder.field(pk, tableSchema.getFieldDataType(pk)
+          .orElseThrow(() -> new ValidationException("Arctic primary key should be declared in table")));
     });
   }
+  
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public class ShuffleSplitAssigner implements SplitAssigner {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleSplitAssigner.class);
 
-  private static final long POLL_TIMEOUT = 300;
+  private static final long POLL_TIMEOUT = 200;
   private final SplitEnumeratorContext<ArcticSplit> enumeratorContext;
 
   private int totalParallelism;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public class ShuffleSplitAssigner implements SplitAssigner {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleSplitAssigner.class);
 
-  private static final long POLL_TIMEOUT = 3;
+  private static final long POLL_TIMEOUT = 300;
   private final SplitEnumeratorContext<ArcticSplit> enumeratorContext;
 
   private int totalParallelism;
@@ -103,7 +103,7 @@ public class ShuffleSplitAssigner implements SplitAssigner {
 
       ArcticSplit arcticSplit = null;
       try {
-        arcticSplit = queue.poll(POLL_TIMEOUT, TimeUnit.SECONDS);
+        arcticSplit = queue.poll(POLL_TIMEOUT, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
         LOG.warn("interruptedException", e);
       }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -69,7 +69,7 @@ public class ShuffleHelper implements Serializable {
   /**
    * If using arctic table as build table, there will be an additional implicit field, valuing process time.
    *
-   * @param schema  The physical schema in Arctic table
+   * @param schema  The physical schema in Arctic table.
    * @param rowType Flink RowData type.
    * @return the Arctic Schema with additional implicit field.
    */

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -31,6 +31,8 @@ import org.apache.iceberg.types.Types;
 
 import java.io.Serializable;
 
+import static org.apache.iceberg.IcebergSchemaUtil.projectPartition;
+
 /**
  * This helper operates to one arctic table and the data of the table.
  */
@@ -50,7 +52,7 @@ public class ShuffleHelper implements Serializable {
     PartitionKey partitionKey = null;
 
     if (table.spec() != null && !CollectionUtil.isNullOrEmpty(table.spec().fields())) {
-      partitionKey = new PartitionKey(table.spec(), schema);
+      partitionKey = new PartitionKey(projectPartition(table.spec(), schema), schema);
     }
     schema = addFieldsNotInArctic(schema, rowType);
 
@@ -127,7 +129,7 @@ public class ShuffleHelper implements Serializable {
   }
 
   public boolean isPartitionKeyExist() {
-    return partitionKey != null;
+    return partitionKey != null && partitionKey.size() > 0;
   }
 
   public int hashPartitionValue(RowData rowData) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -55,7 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
@@ -177,8 +177,9 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
   }
 
   private DataStream<RowData> distribute(DataStream<RowData> source, DistributionHashMode mode) {
+    ShuffleHelper helper = ShuffleHelper.build(arcticTable, readSchema, flinkSchemaRowType);
     if (mode == DistributionHashMode.AUTO) {
-      mode = DistributionHashMode.autoSelect(arcticTable.isKeyedTable(), !arcticTable.spec().isUnpartitioned());
+      mode = DistributionHashMode.autoSelect(arcticTable.isKeyedTable(), helper.isPartitionKeyExist());
     }
     LOG.info("source distribute mode in effect. {}", mode);
     switch (mode) {
@@ -187,23 +188,22 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       case PRIMARY_KEY:
         Preconditions.checkArgument(arcticTable.isKeyedTable(),
             "illegal shuffle policy " + mode.getDesc() + " for table without primary key");
-        return hash(source, DistributionHashMode.PRIMARY_KEY);
+        return hash(source, helper, DistributionHashMode.PRIMARY_KEY);
       case PARTITION_KEY:
         Preconditions.checkArgument(!arcticTable.spec().isUnpartitioned(),
             "illegal shuffle policy " + mode.getDesc() + " for table without partition key");
-        return hash(source, DistributionHashMode.PARTITION_KEY);
+        return hash(source, helper, DistributionHashMode.PARTITION_KEY);
       case PRIMARY_PARTITION_KEY:
         Preconditions.checkArgument(arcticTable.isKeyedTable() && !arcticTable.spec().isUnpartitioned(),
             "illegal shuffle policy " + mode.getDesc() +
                 " for table without primary key or partition key");
-        return hash(source, DistributionHashMode.PRIMARY_PARTITION_KEY);
+        return hash(source, helper, DistributionHashMode.PRIMARY_PARTITION_KEY);
       default:
         throw new RuntimeException("Unrecognized " + READ_DISTRIBUTION_HASH_MODE + ": " + mode);
     }
   }
 
-  public DataStream<RowData> hash(DataStream<RowData> source, DistributionHashMode hashMode) {
-    ShuffleHelper helper = ShuffleHelper.build(arcticTable, readSchema, flinkSchemaRowType);
+  public DataStream<RowData> hash(DataStream<RowData> source, ShuffleHelper helper, DistributionHashMode hashMode) {
     ReadShuffleRulePolicy shuffleRulePolicy = new ReadShuffleRulePolicy(helper, hashMode);
     return source.partitionCustom(shuffleRulePolicy.generatePartitioner(), shuffleRulePolicy.generateKeySelector());
   }
@@ -251,7 +251,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
         .mapToObj(columns::get)
         .collect(Collectors.toList());
 
-    readSchema = new Schema(addPrimaryAndPartitionKey(projectedColumns, arcticTable));
+    readSchema = new Schema(addPrimaryKey(projectedColumns, arcticTable));
     flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
@@ -246,7 +247,11 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       projectionFields[i] = projectedFields[i][0];
     }
     final List<Types.NestedField> columns = readSchema.columns();
-    readSchema = new Schema(Arrays.stream(projectionFields).mapToObj(columns::get).collect(Collectors.toList()));
+    List<Types.NestedField> projectedColumns = Arrays.stream(projectionFields)
+        .mapToObj(columns::get)
+        .collect(Collectors.toList());
+
+    readSchema = new Schema(addPrimaryAndPartitionKey(projectedColumns, arcticTable));
     flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -42,12 +42,15 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkFilters;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -56,6 +59,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TAB
 public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown,
     SupportsProjectionPushDown, SupportsLimitPushDown, SupportsWatermarkPushDown {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ArcticFileSource.class);
+  
   private int[] projectedFields;
   private long limit;
   private List<Expression> filters;
@@ -127,9 +132,16 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
     } else {
       String[] fullNames = tableSchema.getFieldNames();
       DataType[] fullTypes = tableSchema.getFieldDataTypes();
-      return TableSchema.builder().fields(
-          Arrays.stream(projectedFields).mapToObj(i -> fullNames[i]).toArray(String[]::new),
-          Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new)).build();
+
+      String[] projectedColumns = Arrays.stream(projectedFields).mapToObj(i -> fullNames[i]).toArray(String[]::new);
+      TableSchema.Builder builder = TableSchema.builder().fields(
+          projectedColumns,
+          Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
+
+      addPrimaryAndPartitionKey(builder, table, tableSchema, projectedColumns);
+      TableSchema ts = builder.build();
+      LOG.info("TableSchema builder after addPrimaryAndPartitionKey, schema:{}", ts);
+      return ts;
     }
   }
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -50,7 +50,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -60,7 +60,7 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
     SupportsProjectionPushDown, SupportsLimitPushDown, SupportsWatermarkPushDown {
 
   private static final Logger LOG = LoggerFactory.getLogger(ArcticFileSource.class);
-  
+
   private int[] projectedFields;
   private long limit;
   private List<Expression> filters;
@@ -138,9 +138,9 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
           projectedColumns,
           Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
 
-      addPrimaryAndPartitionKey(builder, table, tableSchema, projectedColumns);
+      addPrimaryKey(builder, table, tableSchema, projectedColumns);
       TableSchema ts = builder.build();
-      LOG.info("TableSchema builder after addPrimaryAndPartitionKey, schema:{}", ts);
+      LOG.info("TableSchema builder after addPrimaryKey, schema:{}", ts);
       return ts;
     }
   }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -279,7 +279,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceWithEmptyChangeInInit() throws Exception {
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_empty_change");
     KeyedTable table = testCatalog

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -21,11 +21,11 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 import org.apache.flink.table.api.DataTypes;
@@ -125,7 +125,7 @@ public class TestJoin extends FlinkTestBase {
         actual.add(row);
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{"a", 1000004L, null, null});
@@ -209,7 +209,7 @@ public class TestJoin extends FlinkTestBase {
         actual.add(row);
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{"a", 1L, 123, "a"});

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -20,10 +20,10 @@ package com.netease.arctic.flink.table;
 
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.hive.HiveTableTestBase;
 import com.netease.arctic.table.TableProperties;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.ApiExpression;
 import org.apache.flink.table.api.DataTypes;
@@ -243,7 +243,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -296,7 +296,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -439,7 +439,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -499,6 +499,6 @@ public class TestKeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -21,10 +21,10 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.catalog.ArcticCatalog;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.hive.HiveTableTestBase;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.ApiExpression;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
@@ -274,7 +274,7 @@ public class TestUnkeyed extends FlinkTestBase {
         actual.add(iterator.next());
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
   }
 
@@ -331,7 +331,7 @@ public class TestUnkeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -384,7 +384,7 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -508,7 +508,7 @@ public class TestUnkeyed extends FlinkTestBase {
         actual.add(iterator.next());
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
     Assert.assertEquals(new HashSet<>(expected), actual);
   }
 
@@ -567,7 +567,7 @@ public class TestUnkeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -619,7 +619,7 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
 }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -20,9 +20,9 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableResult;
@@ -119,7 +119,7 @@ public class TestWatermark extends FlinkTestBase {
       Row row = iterator.next();
       actual.add(row);
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{true});
@@ -170,7 +170,7 @@ public class TestWatermark extends FlinkTestBase {
       Row row = iterator.next();
       actual.add(row);
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{true, LocalDateTime.parse("2022-06-17T10:08:11")});

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -1,0 +1,129 @@
+package com.netease.arctic.flink.table;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableIdentifier;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.io.TaskWriter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.netease.arctic.ams.api.MockArcticMetastoreServer.TEST_CATALOG_NAME;
+import static com.netease.arctic.table.TableProperties.LOCATION;
+
+public class TestWatermark extends FlinkTestBase {
+  public static final Logger LOG = LoggerFactory.getLogger(TestJoin.class);
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static final String DB = PK_TABLE_ID.getDatabase();
+  private static final String TABLE = "test_keyed";
+
+  public void before() throws Exception {
+    super.before();
+    super.config(TEST_CATALOG_NAME);
+  }
+
+  @After
+  public void after() {
+    sql("DROP TABLE IF EXISTS arcticCatalog." + DB + "." + TABLE);
+  }
+
+  @Test
+  public void testWatermark() throws Exception {
+    sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
+
+    sql("CREATE TABLE IF NOT EXISTS %s (" +
+            " id bigint, user_id int, name STRING, category string, op_time timestamp, is_true boolean" +
+            ", PRIMARY KEY (id, user_id) NOT ENFORCED) PARTITIONED BY(category, name) WITH %s",
+        table, toWithClause(tableProperties));
+
+    TableSchema flinkSchema = TableSchema.builder()
+        .field("id", DataTypes.BIGINT())
+        .field("user_id", DataTypes.INT())
+        .field("name", DataTypes.STRING())
+        .field("category", DataTypes.STRING())
+        .field("op_time", DataTypes.TIMESTAMP(3))
+        .field("is_true", DataTypes.BOOLEAN())
+        .build();
+    RowType rowType = (RowType) flinkSchema.toRowDataType().getLogicalType();
+    KeyedTable keyedTable = (KeyedTable) ArcticUtils.loadArcticTable(
+        ArcticTableLoader.of(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE), catalogBuilder));
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(keyedTable, rowType, 1, true);
+    List<RowData> baseData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 2L, 123, StringData.fromString("a"), StringData.fromString("a"),
+          TimestampData.fromLocalDateTime(LocalDateTime.now().minusMinutes(1)), true));
+    }};
+    for (RowData record : baseData) {
+      taskWriter.write(record);
+    }
+    commit(keyedTable, taskWriter.complete(), true);
+
+    sql("create table d (tt as cast(op_time as timestamp(3)), watermark for tt as tt) like %s", table);
+
+    TableResult result = exec("select is_true from d");
+
+    CommonTestUtils.waitUntilJobManagerIsInitialized(() -> result.getJobClient().get().getJobStatus().get());
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      Row row = iterator.next();
+      actual.add(row);
+    }
+    result.getJobClient().ifPresent(JobClient::cancel);
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{true});
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+  }
+
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.util;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.execution.JobClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(TestUtil.class);
+
+  public static void cancelJob(JobClient jobClient) {
+    if (isJobTerminated(jobClient)) {
+      return;
+    }
+    try {
+      jobClient.cancel();
+    } catch (Exception e) {
+      LOG.warn("cancel job exception.", e);
+    }
+  }
+
+  public static boolean isJobTerminated(JobClient jobClient) {
+    try {
+      JobStatus status = jobClient.getJobStatus().get();
+      return status.isGloballyTerminalState();
+    } catch (Exception e) {
+      // TODO
+      //  This is sort of hack.
+      //  Currently different execution environment will have different behaviors
+      //  when fetching a finished job status.
+      //  For example, standalone session cluster will return a normal FINISHED,
+      //  while mini cluster will throw IllegalStateException,
+      //  and yarn per job will throw ApplicationNotFoundException.
+      //  We have to assume that job has finished in this case.
+      //  Change this when these behaviors are unified.
+      LOG.warn(
+          "Failed to get job status so we assume that the job has terminated. Some data might be lost.",
+          e);
+      return true;
+    }
+  }
+
+}

--- a/flink/v1.15/flink-runtime/pom.xml
+++ b/flink/v1.15/flink-runtime/pom.xml
@@ -85,7 +85,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
@@ -28,8 +28,6 @@ import org.apache.flink.table.api.WatermarkSpec;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
-import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,10 +138,10 @@ public class FlinkSchemaUtil {
   }
 
   /**
-   * Primary key and partition key are the required fields for shuffle.
-   * The required fields should be added even though project push-down
+   * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
+   * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
-  public static List<Types.NestedField> addPrimaryAndPartitionKey(
+  public static List<Types.NestedField> addPrimaryKey(
       List<Types.NestedField> projectedColumns, ArcticTable table) {
     List<String> primaryKeys = table.isUnkeyedTable() ? Collections.EMPTY_LIST
         : table.asKeyedTable().primaryKeySpec().fields().stream()
@@ -151,12 +149,8 @@ public class FlinkSchemaUtil {
 
     List<Types.NestedField> columns = new ArrayList<>(projectedColumns);
     Set<String> projectedNames = new HashSet<>();
-    Set<Integer> projectedIds = new HashSet<>();
 
-    projectedColumns.forEach((c) -> {
-      projectedNames.add(c.name());
-      projectedIds.add(c.fieldId());
-    });
+    projectedColumns.forEach(c -> projectedNames.add(c.name()));
 
     primaryKeys.forEach(pk -> {
       if (!projectedNames.contains(pk)) {
@@ -164,51 +158,30 @@ public class FlinkSchemaUtil {
       }
     });
 
-    Set<Integer> partitionIds = table.spec().identitySourceIds();
-    partitionIds.forEach(partition -> {
-      if (!projectedIds.contains(partition)) {
-        columns.add(table.schema().findField(partition));
-      }
-    });
-    LOG.info("Projected Columns after addPrimaryAndPartitionKey, columns:{}", columns);
+    LOG.info("Projected Columns after addPrimaryKey, columns:{}", columns);
     return columns;
   }
 
   /**
-   * Primary key and partition key are the required fields for shuffle.
-   * The required fields should be added even though project push-down
-   *
-   * @param builder
-   * @param table
-   * @param tableSchema
-   * @param projectedColumns
+   * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
+   * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
-  public static void addPrimaryAndPartitionKey(
+  public static void addPrimaryKey(
       TableSchema.Builder builder, ArcticTable table, TableSchema tableSchema, String[] projectedColumns) {
     Set<String> projectedNames = Arrays.stream(projectedColumns).collect(Collectors.toSet());
 
-    if (table.isKeyedTable()) {
-      List<String> pks = table.asKeyedTable().primaryKeySpec().fieldNames();
-      pks.forEach(pk -> {
-        if (projectedNames.contains(pk)) {
-          return;
-        }
-        builder.field(pk, tableSchema.getFieldDataType(pk)
-            .orElseThrow(() -> new ValidationException("Arctic primary key should be declared in table")));
-      });
+    if (!table.isKeyedTable()) {
+      return;
     }
 
-    Set<String> partitionNames = Sets.newHashSet();
-    for (PartitionField field : table.spec().fields()) {
-      partitionNames.add(field.name());
-    }
-
-    partitionNames.forEach(p -> {
-      if (projectedNames.contains(p)) {
+    List<String> pks = table.asKeyedTable().primaryKeySpec().fieldNames();
+    pks.forEach(pk -> {
+      if (projectedNames.contains(pk)) {
         return;
       }
-      builder.field(p, tableSchema.getFieldDataType(p)
-          .orElseThrow(() -> new ValidationException("Arctic partition key should be declared in table")));
+      builder.field(pk, tableSchema.getFieldDataType(pk)
+          .orElseThrow(() -> new ValidationException("Arctic primary key should be declared in table")));
     });
   }
+  
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public class ShuffleSplitAssigner implements SplitAssigner {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleSplitAssigner.class);
 
-  private static final long POLL_TIMEOUT = 300;
+  private static final long POLL_TIMEOUT = 200;
   private final SplitEnumeratorContext<ArcticSplit> enumeratorContext;
 
   private int totalParallelism;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public class ShuffleSplitAssigner implements SplitAssigner {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleSplitAssigner.class);
 
-  private static final long POLL_TIMEOUT = 3;
+  private static final long POLL_TIMEOUT = 300;
   private final SplitEnumeratorContext<ArcticSplit> enumeratorContext;
 
   private int totalParallelism;
@@ -103,7 +103,7 @@ public class ShuffleSplitAssigner implements SplitAssigner {
 
       ArcticSplit arcticSplit = null;
       try {
-        arcticSplit = queue.poll(POLL_TIMEOUT, TimeUnit.SECONDS);
+        arcticSplit = queue.poll(POLL_TIMEOUT, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
         LOG.warn("interruptedException", e);
       }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -69,7 +69,7 @@ public class ShuffleHelper implements Serializable {
   /**
    * If using arctic table as build table, there will be an additional implicit field, valuing process time.
    *
-   * @param schema  The physical schema in Arctic table
+   * @param schema  The physical schema in Arctic table.
    * @param rowType Flink RowData type.
    * @return the Arctic Schema with additional implicit field.
    */

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/ShuffleHelper.java
@@ -31,6 +31,8 @@ import org.apache.iceberg.types.Types;
 
 import java.io.Serializable;
 
+import static org.apache.iceberg.IcebergSchemaUtil.projectPartition;
+
 /**
  * This helper operates to one arctic table and the data of the table.
  */
@@ -50,7 +52,7 @@ public class ShuffleHelper implements Serializable {
     PartitionKey partitionKey = null;
 
     if (table.spec() != null && !CollectionUtil.isNullOrEmpty(table.spec().fields())) {
-      partitionKey = new PartitionKey(table.spec(), schema);
+      partitionKey = new PartitionKey(projectPartition(table.spec(), schema), schema);
     }
     schema = addFieldsNotInArctic(schema, rowType);
 
@@ -127,7 +129,7 @@ public class ShuffleHelper implements Serializable {
   }
 
   public boolean isPartitionKeyExist() {
-    return partitionKey != null;
+    return partitionKey != null && partitionKey.size() > 0;
   }
 
   public int hashPartitionValue(RowData rowData) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -56,7 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
@@ -181,8 +181,9 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
   }
 
   private DataStream<RowData> distribute(DataStream<RowData> source, DistributionHashMode mode) {
+    ShuffleHelper helper = ShuffleHelper.build(arcticTable, readSchema, flinkSchemaRowType);
     if (mode == DistributionHashMode.AUTO) {
-      mode = DistributionHashMode.autoSelect(arcticTable.isKeyedTable(), !arcticTable.spec().isUnpartitioned());
+      mode = DistributionHashMode.autoSelect(arcticTable.isKeyedTable(), helper.isPartitionKeyExist());
     }
     LOG.info("source distribute mode in effect. {}", mode);
     switch (mode) {
@@ -191,23 +192,22 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       case PRIMARY_KEY:
         Preconditions.checkArgument(arcticTable.isKeyedTable(),
             "illegal shuffle policy " + mode.getDesc() + " for table without primary key");
-        return hash(source, DistributionHashMode.PRIMARY_KEY);
+        return hash(source, helper, DistributionHashMode.PRIMARY_KEY);
       case PARTITION_KEY:
         Preconditions.checkArgument(!arcticTable.spec().isUnpartitioned(),
             "illegal shuffle policy " + mode.getDesc() + " for table without partition key");
-        return hash(source, DistributionHashMode.PARTITION_KEY);
+        return hash(source, helper, DistributionHashMode.PARTITION_KEY);
       case PRIMARY_PARTITION_KEY:
         Preconditions.checkArgument(arcticTable.isKeyedTable() && !arcticTable.spec().isUnpartitioned(),
             "illegal shuffle policy " + mode.getDesc() +
                 " for table without primary key or partition key");
-        return hash(source, DistributionHashMode.PRIMARY_PARTITION_KEY);
+        return hash(source, helper, DistributionHashMode.PRIMARY_PARTITION_KEY);
       default:
         throw new RuntimeException("Unrecognized " + READ_DISTRIBUTION_HASH_MODE + ": " + mode);
     }
   }
 
-  public DataStream<RowData> hash(DataStream<RowData> source, DistributionHashMode hashMode) {
-    ShuffleHelper helper = ShuffleHelper.build(arcticTable, readSchema, flinkSchemaRowType);
+  public DataStream<RowData> hash(DataStream<RowData> source, ShuffleHelper helper, DistributionHashMode hashMode) {
     ReadShuffleRulePolicy shuffleRulePolicy = new ReadShuffleRulePolicy(helper, hashMode);
     return source.partitionCustom(shuffleRulePolicy.generatePartitioner(), shuffleRulePolicy.generateKeySelector());
   }
@@ -255,7 +255,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
         .mapToObj(columns::get)
         .collect(Collectors.toList());
 
-    readSchema = new Schema(addPrimaryAndPartitionKey(projectedColumns, arcticTable));
+    readSchema = new Schema(addPrimaryKey(projectedColumns, arcticTable));
     flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
 import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
@@ -250,7 +251,11 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
       projectionFields[i] = projectedFields[i][0];
     }
     final List<Types.NestedField> columns = readSchema.columns();
-    readSchema = new Schema(Arrays.stream(projectionFields).mapToObj(columns::get).collect(Collectors.toList()));
+    List<Types.NestedField> projectedColumns = Arrays.stream(projectionFields)
+        .mapToObj(columns::get)
+        .collect(Collectors.toList());
+
+    readSchema = new Schema(addPrimaryAndPartitionKey(projectedColumns, arcticTable));
     flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -52,7 +51,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -62,7 +61,7 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
     SupportsProjectionPushDown, SupportsLimitPushDown, SupportsWatermarkPushDown {
 
   private static final Logger LOG = LoggerFactory.getLogger(ArcticFileSource.class);
-  
+
   private int[] projectedFields;
   private long limit;
   private List<Expression> filters;
@@ -141,9 +140,9 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
           projectedColumns,
           Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
 
-      addPrimaryAndPartitionKey(builder, table, tableSchema, projectedColumns);
+      addPrimaryKey(builder, table, tableSchema, projectedColumns);
       TableSchema ts = builder.build();
-      LOG.info("TableSchema builder after addPrimaryAndPartitionKey, schema:{}", ts);
+      LOG.info("TableSchema builder after addPrimaryKey, schema:{}", ts);
       return ts;
     }
   }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -44,12 +44,15 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkFilters;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryAndPartitionKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -58,6 +61,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TAB
 public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown,
     SupportsProjectionPushDown, SupportsLimitPushDown, SupportsWatermarkPushDown {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ArcticFileSource.class);
+  
   private int[] projectedFields;
   private long limit;
   private List<Expression> filters;
@@ -130,9 +135,16 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
     } else {
       String[] fullNames = tableSchema.getFieldNames();
       DataType[] fullTypes = tableSchema.getFieldDataTypes();
-      return TableSchema.builder().fields(
-          Arrays.stream(projectedFields).mapToObj(i -> fullNames[i]).toArray(String[]::new),
-          Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new)).build();
+
+      String[] projectedColumns = Arrays.stream(projectedFields).mapToObj(i -> fullNames[i]).toArray(String[]::new);
+      TableSchema.Builder builder = TableSchema.builder().fields(
+          projectedColumns,
+          Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
+
+      addPrimaryAndPartitionKey(builder, table, tableSchema, projectedColumns);
+      TableSchema ts = builder.build();
+      LOG.info("TableSchema builder after addPrimaryAndPartitionKey, schema:{}", ts);
+      return ts;
     }
   }
 

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -279,7 +279,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceWithEmptyChangeInInit() throws Exception {
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_empty_change");
     KeyedTable table = testCatalog

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -21,10 +21,10 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 import org.apache.flink.table.api.DataTypes;
@@ -122,7 +122,7 @@ public class TestJoin extends FlinkTestBase {
         actual.add(row);
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{"a", 1000004L, null, null});
@@ -205,7 +205,7 @@ public class TestJoin extends FlinkTestBase {
         actual.add(row);
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{"a", 1L, 123, "a"});

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -20,10 +20,10 @@ package com.netease.arctic.flink.table;
 
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.hive.HiveTableTestBase;
 import com.netease.arctic.table.TableProperties;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.ApiExpression;
 import org.apache.flink.table.api.DataTypes;
@@ -243,7 +243,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -296,7 +296,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -439,7 +439,7 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -499,6 +499,6 @@ public class TestKeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -21,10 +21,10 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.catalog.ArcticCatalog;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.hive.HiveTableTestBase;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.ApiExpression;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
@@ -274,7 +274,7 @@ public class TestUnkeyed extends FlinkTestBase {
         actual.add(iterator.next());
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
   }
 
@@ -331,7 +331,7 @@ public class TestUnkeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -384,7 +384,7 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -508,7 +508,7 @@ public class TestUnkeyed extends FlinkTestBase {
         actual.add(iterator.next());
       }
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
     Assert.assertEquals(new HashSet<>(expected), actual);
   }
 
@@ -567,7 +567,7 @@ public class TestUnkeyed extends FlinkTestBase {
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
 
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
   @Test
@@ -619,7 +619,7 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 
 }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -20,9 +20,9 @@ package com.netease.arctic.flink.table;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.flink.util.TestUtil;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableResult;
@@ -119,7 +119,7 @@ public class TestWatermark extends FlinkTestBase {
       Row row = iterator.next();
       actual.add(row);
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{true});
@@ -170,7 +170,7 @@ public class TestWatermark extends FlinkTestBase {
       Row row = iterator.next();
       actual.add(row);
     }
-    result.getJobClient().ifPresent(JobClient::cancel);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
 
     List<Object[]> expected = new LinkedList<>();
     expected.add(new Object[]{true, LocalDateTime.parse("2022-06-17T10:08:11")});

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -1,0 +1,129 @@
+package com.netease.arctic.flink.table;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableIdentifier;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.io.TaskWriter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.netease.arctic.ams.api.MockArcticMetastoreServer.TEST_CATALOG_NAME;
+import static com.netease.arctic.table.TableProperties.LOCATION;
+
+public class TestWatermark extends FlinkTestBase {
+  public static final Logger LOG = LoggerFactory.getLogger(TestJoin.class);
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static final String DB = PK_TABLE_ID.getDatabase();
+  private static final String TABLE = "test_keyed";
+
+  public void before() throws Exception {
+    super.before();
+    super.config(TEST_CATALOG_NAME);
+  }
+
+  @After
+  public void after() {
+    sql("DROP TABLE IF EXISTS arcticCatalog." + DB + "." + TABLE);
+  }
+
+  @Test
+  public void testWatermark() throws Exception {
+    sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
+
+    sql("CREATE TABLE IF NOT EXISTS %s (" +
+            " id bigint, user_id int, name STRING, category string, op_time timestamp, is_true boolean" +
+            ", PRIMARY KEY (id, user_id) NOT ENFORCED) PARTITIONED BY(category, name) WITH %s",
+        table, toWithClause(tableProperties));
+
+    TableSchema flinkSchema = TableSchema.builder()
+        .field("id", DataTypes.BIGINT())
+        .field("user_id", DataTypes.INT())
+        .field("name", DataTypes.STRING())
+        .field("category", DataTypes.STRING())
+        .field("op_time", DataTypes.TIMESTAMP(3))
+        .field("is_true", DataTypes.BOOLEAN())
+        .build();
+    RowType rowType = (RowType) flinkSchema.toRowDataType().getLogicalType();
+    KeyedTable keyedTable = (KeyedTable) ArcticUtils.loadArcticTable(
+        ArcticTableLoader.of(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE), catalogBuilder));
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(keyedTable, rowType, 1, true);
+    List<RowData> baseData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+          RowKind.INSERT, 2L, 123, StringData.fromString("a"), StringData.fromString("a"),
+          TimestampData.fromLocalDateTime(LocalDateTime.now().minusMinutes(1)), true));
+    }};
+    for (RowData record : baseData) {
+      taskWriter.write(record);
+    }
+    commit(keyedTable, taskWriter.complete(), true);
+
+    sql("create table d (tt as cast(op_time as timestamp(3)), watermark for tt as tt) like %s", table);
+
+    TableResult result = exec("select is_true from d");
+
+    CommonTestUtils.waitUntilJobManagerIsInitialized(() -> result.getJobClient().get().getJobStatus().get());
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      Row row = iterator.next();
+      actual.add(row);
+    }
+    result.getJobClient().ifPresent(JobClient::cancel);
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{true});
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+  }
+
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.util;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.execution.JobClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(TestUtil.class);
+
+  public static void cancelJob(JobClient jobClient) {
+    if (isJobTerminated(jobClient)) {
+      return;
+    }
+    try {
+      jobClient.cancel();
+    } catch (Exception e) {
+      LOG.warn("cancel job exception.", e);
+    }
+  }
+
+  public static boolean isJobTerminated(JobClient jobClient) {
+    try {
+      JobStatus status = jobClient.getJobStatus().get();
+      return status.isGloballyTerminalState();
+    } catch (Exception e) {
+      // TODO
+      //  This is sort of hack.
+      //  Currently different execution environment will have different behaviors
+      //  when fetching a finished job status.
+      //  For example, standalone session cluster will return a normal FINISHED,
+      //  while mini cluster will throw IllegalStateException,
+      //  and yarn per job will throw ApplicationNotFoundException.
+      //  We have to assume that job has finished in this case.
+      //  Change this when these behaviors are unified.
+      LOG.warn(
+          "Failed to get job status so we assume that the job has terminated. Some data might be lost.",
+          e);
+      return true;
+    }
+  }
+
+}

--- a/hive/src/main/java/org/apache/iceberg/IcebergSchemaUtil.java
+++ b/hive/src/main/java/org/apache/iceberg/IcebergSchemaUtil.java
@@ -54,4 +54,17 @@ public class IcebergSchemaUtil {
     });
     return builder.build();
   }
+
+  public static PartitionSpec projectPartition(PartitionSpec partitionSpec, Schema schema) {
+    PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
+
+    partitionSpec.fields().forEach(p -> {
+      if (schema.findField(p.sourceId()) == null) {
+        return;
+      }
+
+      builder.add(p.sourceId(), p.name(), p.transform().toString());
+    });
+    return builder.build();
+  }
 }


### PR DESCRIPTION
FIX #459 

## Why are the changes needed?
Project pushdown may lead to the missing of primary key, partition key. ShuffleHelper may lose the required info, and produce NPE.

This hotfix tends to read the required fields appended after the projected fields in the order of 'projected fields', 'primary keys', 'partition keys'. And send the rowData with additional fields to downstream.

## Brief change log

  - *The flink 1.12 and 1.14, 1.15 versions are affected.*

## How was this patch tested?
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
