### PR TITLE
[ARCTIC-504]When the catalog name contains line-through, terminal executes sql with an error

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/TerminalService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/TerminalService.java
@@ -61,6 +61,7 @@ public class TerminalService {
   private static int sessionId = 1;
   private static final Map<Integer, SqlRunningInfo> sqlSessionInfoCache = new HashMap<>();
   private static final SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS");
+  private static final String QUOTE  = "`";
 
   public static LogInfo getLogs(int sessionId) {
     return new LogInfo(sqlSessionInfoCache.get(sessionId).getLogStatus(), sqlSessionInfoCache.get(sessionId).getLogs());
@@ -149,7 +150,7 @@ public class TerminalService {
         }
         try {
           sqlRunningInfo.getLogs().add(df.format(new Date()) + " use " + catalog);
-          spark.sql("use " + "`" + catalog + "`");
+          spark.sql("use " + QUOTE + catalog + QUOTE);
         } catch (Throwable t) {
           LOG.error("use catalog " + catalog + " failed ", t);
           sqlRunningInfo.getLogs().add(df.format(new Date()) + " use catalog " + catalog + " failed " + t);

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/TerminalService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/TerminalService.java
@@ -149,7 +149,7 @@ public class TerminalService {
         }
         try {
           sqlRunningInfo.getLogs().add(df.format(new Date()) + " use " + catalog);
-          spark.sql("use " + catalog);
+          spark.sql("use " + "`" + catalog + "`");
         } catch (Throwable t) {
           LOG.error("use catalog " + catalog + " failed ", t);
           sqlRunningInfo.getLogs().add(df.format(new Date()) + " use catalog " + catalog + " failed " + t);


### PR DESCRIPTION
Resolve #504 
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

* Resolve catalog names with special characters may lead terminal execute sql failed

## Brief change log
  - *Add back-quotes when execute "use catalog" 

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
