### PR TITLE
[ARCTIC-525][FLINK]: Replace transactionId with ckpId in Log-store format

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/ArcticTable.java
+++ b/core/src/main/java/com/netease/arctic/table/ArcticTable.java
@@ -119,4 +119,13 @@ public interface ArcticTable extends Serializable {
   default KeyedTable asKeyedTable() {
     throw new IllegalStateException("Not a keyed table");
   }
+
+  /**
+   * Allocate a new transaction id from this table
+   *
+   * @param signature signature for this request. Requests with the same signature will get the same transaction id.
+   *                  Requests with signature NULL will always get different transaction id.
+   * @return a new transaction id
+   */
+  long beginTransaction(String signature);
 }

--- a/core/src/main/java/com/netease/arctic/table/BaseUnkeyedTable.java
+++ b/core/src/main/java/com/netease/arctic/table/BaseUnkeyedTable.java
@@ -63,10 +63,10 @@ import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.util.StructLikeMap;
+import org.apache.thrift.TException;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Base implementation of {@link UnkeyedTable}, wrapping a {@link Table}.
@@ -348,5 +348,17 @@ public class BaseUnkeyedTable implements UnkeyedTable, HasTableOperations {
   @Override
   public UpdatePartitionProperties updatePartitionProperties(Transaction transaction) {
     return new PartitionPropertiesUpdate(this, transaction);
+  }
+
+  @Override
+  public long beginTransaction(String signature) {
+    if (client == null) {
+      throw new UnsupportedOperationException("Ams client is null");
+    }
+    try {
+      return client.allocateTransactionId(tableIdentifier.buildTableIdentifier(), signature);
+    } catch (TException e) {
+      throw new IllegalStateException("failed begin transaction", e);
+    }
   }
 }

--- a/core/src/main/java/com/netease/arctic/table/KeyedTable.java
+++ b/core/src/main/java/com/netease/arctic/table/KeyedTable.java
@@ -63,15 +63,6 @@ public interface KeyedTable extends ArcticTable {
    */
   KeyedTableScan newScan();
 
-  /**
-   * Allocate a new transaction id from this table
-   *
-   * @param signature signature for this request. Requests with the same signature will get the same transaction id.
-   *                  Requests with signature NULL will always get different transaction id.
-   * @return a new transaction id
-   */
-  long beginTransaction(String signature);
-
   @Override
   default boolean isKeyedTable() {
     return true;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticRowDataTaskWriterFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticRowDataTaskWriterFactory.java
@@ -59,12 +59,8 @@ public class ArcticRowDataTaskWriterFactory implements TaskWriterFactory<RowData
 
   @Override
   public void initialize(int taskId, int attemptId) {
-    if (table.isKeyedTable()) {
-      Preconditions.checkNotNull(transactionId, "TransactionId should be set first. " +
-          "Invoke setTransactionId() before this method");
-    } else {
-      Preconditions.checkArgument(transactionId == null, "TransactionId should be null for unkeyed table.");
-    }
+    Preconditions.checkNotNull(transactionId, "TransactionId should be set first. " +
+        "Invoke setTransactionId() before this method");
     this.taskId = taskId;
     this.attemptId = attemptId;
   }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
@@ -21,8 +21,8 @@ package com.netease.arctic.flink.write;
 import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.ArcticUtils;
-import com.netease.arctic.flink.write.hidden.AbstractHiddenLogWriter;
 import com.netease.arctic.table.ArcticTable;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;
@@ -91,7 +91,8 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
     Long transaction;
     String signature = BaseEncoding.base16().encode((jobId + checkpointId).getBytes());
     transaction = table.beginTransaction(signature);
-    LOG.info("get new TransactionId. table:{}, signature:{}, transactionId:{}", table.name(), signature, transaction);
+    LOG.info("get new TransactionId. table:{}, signature:{}, transactionId:{}. From jobId:{}, ckpId:{}",
+        table.name(), signature, transaction, jobId, checkpointId);
     transactionId = transaction;
     return transaction;
   }
@@ -166,6 +167,11 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
     if (fileWriter != null) {
       fileWriter.prepareSnapshotPreBarrier(checkpointId);
     }
+  }
+
+  @VisibleForTesting
+  public long getCheckpointId() {
+    return checkpointId;
   }
 
   @Override

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
@@ -19,6 +19,10 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.metric.MetricsGenerator;
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.flink.write.hidden.AbstractHiddenLogWriter;
+import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;
@@ -36,6 +40,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 
 import java.util.Objects;
 
@@ -51,18 +56,44 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   private transient Meter meterSpeed;
 
+  private byte[] arcticJobId;
+  /**
+   * flink jobId
+   */
+  private transient String jobId;
+  private transient long checkpointId = 0;
+  private transient Long transactionId = null;
+  /**
+   * Load table in runtime, because that table's refresh method will be invoked in serialization.
+   * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
+   * if Arctic's table is KERBEROS enabled. It will cause ugi relevant exception when deploy to yarn cluster.
+   */
+  private transient ArcticTable table;
+
   private final AbstractStreamOperator fileWriter;
   private final ArcticLogWriter logWriter;
   private final MetricsGenerator metricsGenerator;
+  private final ArcticTableLoader tableLoader;
 
   private static final String INFLUXDB_TAG_NAME = "arctic_task_id";
 
   public ArcticWriter(ArcticLogWriter logWriter,
                       AbstractStreamOperator fileWriter,
+                      ArcticTableLoader tableLoader,
                       MetricsGenerator metricsGenerator) {
     this.logWriter = logWriter;
     this.fileWriter = fileWriter;
+    this.tableLoader = tableLoader;
     this.metricsGenerator = metricsGenerator;
+  }
+
+  private Long getTransactionId() {
+    Long transaction;
+    String signature = BaseEncoding.base16().encode((jobId + checkpointId).getBytes());
+    transaction = table.beginTransaction(signature);
+    LOG.info("get new TransactionId. table:{}, signature:{}, transactionId:{}", table.name(), signature, transaction);
+    transactionId = transaction;
+    return transaction;
   }
 
   @Override
@@ -102,6 +133,10 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
           .meter("record-count", new MeterView(60));
       LOG.info("add metrics record-count");
     }
+
+    this.jobId = getContainingTask().getEnvironment().getJobID().toString();
+    table = ArcticUtils.loadArcticTable(tableLoader);
+
     if (logWriter != null) {
       logWriter.open();
     }
@@ -122,6 +157,9 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+    this.checkpointId = checkpointId;
+    transactionId = null;
+    
     if (logWriter != null) {
       logWriter.prepareSnapshotPreBarrier(checkpointId);
     }
@@ -152,6 +190,16 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void processElement(StreamRecord<RowData> element) throws Exception {
+    if (transactionId == null) {
+      transactionId = getTransactionId();
+      // setTransactionId should be invoked before log/file writer#processElement
+      if (logWriter != null) {
+        logWriter.setTransactionId(transactionId);
+      }
+      if (fileWriter != null && fileWriter instanceof TransactionIdAware) {
+        ((TransactionIdAware) fileWriter).setTransactionId(transactionId);
+      }
+    }
     if (metricsGenerator.isMetricEnable()) {
       meterSpeed.markEvent();
     }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
@@ -56,7 +56,7 @@ public class AutomaticLogWriter extends ArcticLogWriter {
       ArcticTableLoader tableLoader,
       Duration writeLogstoreWatermarkGap) {
     this.arcticLogWriter =
-        new HiddenLogWriter(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
+        new HiddenLogWriter(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper, tableLoader);
     this.status = new AutomaticDoubleWriteStatus(tableLoader, writeLogstoreWatermarkGap);
   }
 
@@ -121,6 +121,11 @@ public class AutomaticLogWriter extends ArcticLogWriter {
     if (status.isDoubleWrite()) {
       arcticLogWriter.notifyCheckpointAborted(checkpointId);
     }
+  }
+
+  @Override
+  public void setTransactionId(Long transactionId) {
+    arcticLogWriter.setTransactionId(transactionId);
   }
 
   @Override

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
-import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
@@ -140,13 +139,14 @@ public class FlinkSink {
         DataStream<RowData> input,
         ArcticLogWriter logWriter,
         ArcticFileWriter fileWriter,
+        ArcticTableLoader tableLoader,
         OneInputStreamOperator<WriteResult, Void> committer,
         int writeOperatorParallelism,
         MetricsGenerator metricsGenerator,
         String arcticEmitMode) {
       SingleOutputStreamOperator writerStream = input
           .transform(ArcticWriter.class.getName(), TypeExtractor.createTypeInfo(WriteResult.class),
-              new ArcticWriter<>(logWriter, fileWriter, metricsGenerator))
+              new ArcticWriter<>(logWriter, fileWriter, tableLoader, metricsGenerator))
           .name(String.format("ArcticWriter %s(%s)", table.name(), arcticEmitMode))
           .setParallelism(writeOperatorParallelism);
 
@@ -212,6 +212,7 @@ public class FlinkSink {
           rowDataInput,
           logWriter,
           fileWriter,
+          tableLoader,
           createFileCommitter(table, tableLoader, overwrite, arcticEmitMode),
           writeOperatorParallelism,
           metricsGenerator,

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -111,11 +111,6 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
   }
 
   private FlinkBaseTaskWriter buildBaseWriter(LocationKind locationKind) {
-    if (table.isKeyedTable()) {
-      Preconditions.checkNotNull(transactionId);
-    } else {
-      Preconditions.checkArgument(transactionId == null);
-    }
     FileFormat fileFormat = FileFormat.valueOf((table.properties().getOrDefault(
         TableProperties.BASE_FILE_FORMAT,
         TableProperties.BASE_FILE_FORMAT_DEFAULT).toUpperCase(Locale.ENGLISH)));

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/TransactionIdAware.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/TransactionIdAware.java
@@ -18,14 +18,9 @@
 
 package com.netease.arctic.flink.write;
 
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.table.data.RowData;
-
 /**
- * This is a common abstract arctic log writer.
+ * Indicate the transactionId may be useful for it.
  */
-public abstract class ArcticLogWriter extends AbstractStreamOperator<RowData>
-    implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput, TransactionIdAware {
+public interface TransactionIdAware {
+  void setTransactionId(Long transactionId);
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/WriteResult.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/WriteResult.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.CharSequenceSet;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+public class WriteResult implements Serializable {
+
+  private final List<Long> transactionIds;
+  private org.apache.iceberg.io.WriteResult writeResult;
+
+  public WriteResult(org.apache.iceberg.io.WriteResult writeResult, List<Long> transactionIds) {
+    this.writeResult = writeResult;
+    this.transactionIds = transactionIds;
+  }
+
+  public DataFile[] dataFiles() {
+    return writeResult.dataFiles();
+  }
+
+  public DeleteFile[] deleteFiles() {
+    return writeResult.deleteFiles();
+  }
+
+  public CharSequence[] referencedDataFiles() {
+    return writeResult.referencedDataFiles();
+  }
+
+  public List<Long> getTransactionIds() {
+    return transactionIds;
+  }
+
+  public org.apache.iceberg.io.WriteResult getInternal() {
+    return writeResult;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final List<DataFile> dataFiles;
+    private final List<DeleteFile> deleteFiles;
+    private final CharSequenceSet referencedDataFiles;
+    private final List<Long> transactionIds;
+
+    private Builder() {
+      this.dataFiles = Lists.newArrayList();
+      this.deleteFiles = Lists.newArrayList();
+      this.referencedDataFiles = CharSequenceSet.empty();
+      this.transactionIds = Lists.newArrayList();
+    }
+
+    public Builder add(WriteResult result) {
+      addDataFiles(result.dataFiles());
+      addDeleteFiles(result.deleteFiles());
+      addReferencedDataFiles(result.referencedDataFiles());
+      transactionIds.addAll(result.getTransactionIds());
+      return this;
+    }
+
+    public Builder addAll(Iterable<WriteResult> results) {
+      results.forEach(this::add);
+      return this;
+    }
+
+    public Builder addDataFiles(DataFile... files) {
+      Collections.addAll(dataFiles, files);
+      return this;
+    }
+
+    public Builder addDataFiles(Iterable<DataFile> files) {
+      Iterables.addAll(dataFiles, files);
+      return this;
+    }
+
+    public Builder addDeleteFiles(DeleteFile... files) {
+      Collections.addAll(deleteFiles, files);
+      return this;
+    }
+
+    public Builder addDeleteFiles(Iterable<DeleteFile> files) {
+      Iterables.addAll(deleteFiles, files);
+      return this;
+    }
+
+    public Builder addReferencedDataFiles(CharSequence... files) {
+      Collections.addAll(referencedDataFiles, files);
+      return this;
+    }
+
+    public Builder addReferencedDataFiles(Iterable<CharSequence> files) {
+      Iterables.addAll(referencedDataFiles, files);
+      return this;
+    }
+
+    public Builder addTransactionIds(Iterable<Long> transactionId) {
+      Iterables.addAll(transactionIds, transactionId);
+      return this;
+    }
+
+    public WriteResult build() {
+      org.apache.iceberg.io.WriteResult internal = org.apache.iceberg.io.WriteResult.builder()
+          .addDataFiles(dataFiles).addDeleteFiles(deleteFiles).addReferencedDataFiles(referencedDataFiles).build();
+      return new WriteResult(internal, transactionIds);
+    }
+  }
+}

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
@@ -20,6 +20,7 @@ package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.log.LogData;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
@@ -42,8 +43,9 @@ public class HiddenLogWriter extends AbstractHiddenLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
-    super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
+      ShuffleHelper helper,
+      ArcticTableLoader tableLoader) {
+    super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper, tableLoader);
   }
 
   @Override

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
@@ -44,8 +44,8 @@ public class DeltaManifests {
     this(dataManifest, deleteManifest, referencedDataFiles, EMPTY_TRANSACTION);
   }
 
-  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles
-      , List<Long> transactionIds) {
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles,
+                 List<Long> transactionIds) {
     Preconditions.checkNotNull(referencedDataFiles, "Referenced data files shouldn't be null.");
 
     this.dataManifest = dataManifest;

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DeltaManifests {
+
+  private static final CharSequence[] EMPTY_REF_DATA_FILES = new CharSequence[0];
+  public static final List<Long> EMPTY_TRANSACTION = Collections.emptyList();
+
+  private final ManifestFile dataManifest;
+  private final ManifestFile deleteManifest;
+  private final CharSequence[] referencedDataFiles;
+  private final List<Long> transactionIds;
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest) {
+    this(dataManifest, deleteManifest, EMPTY_REF_DATA_FILES);
+  }
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles) {
+    this(dataManifest, deleteManifest, referencedDataFiles, EMPTY_TRANSACTION);
+  }
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles
+      , List<Long> transactionIds) {
+    Preconditions.checkNotNull(referencedDataFiles, "Referenced data files shouldn't be null.");
+
+    this.dataManifest = dataManifest;
+    this.deleteManifest = deleteManifest;
+    this.referencedDataFiles = referencedDataFiles;
+    this.transactionIds = transactionIds;
+  }
+
+  ManifestFile dataManifest() {
+    return dataManifest;
+  }
+
+  ManifestFile deleteManifest() {
+    return deleteManifest;
+  }
+
+  CharSequence[] referencedDataFiles() {
+    return referencedDataFiles;
+  }
+
+  public List<Long> getTransactionIds() {
+    return transactionIds;
+  }
+
+  List<ManifestFile> manifests() {
+    List<ManifestFile> manifests = Lists.newArrayListWithCapacity(2);
+    if (dataManifest != null) {
+      manifests.add(dataManifest);
+    }
+
+    if (deleteManifest != null) {
+      manifests.add(deleteManifest);
+    }
+
+    return manifests;
+  }
+}

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifestsSerializer.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifestsSerializer.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeltaManifestsSerializer implements SimpleVersionedSerializer<DeltaManifests> {
+  private static final int VERSION_1 = 1;
+  private static final int VERSION_2 = 2;
+  private static final int VERSION_3 = 3;
+  private static final byte[] EMPTY_BINARY = new byte[0];
+
+  static final DeltaManifestsSerializer INSTANCE = new DeltaManifestsSerializer();
+
+  @Override
+  public int getVersion() {
+    return VERSION_3;
+  }
+
+  @Override
+  public byte[] serialize(DeltaManifests deltaManifests) throws IOException {
+    Preconditions.checkNotNull(deltaManifests, "DeltaManifests to be serialized should not be null");
+
+    ByteArrayOutputStream binaryOut = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(binaryOut);
+
+    byte[] dataManifestBinary = EMPTY_BINARY;
+    if (deltaManifests.dataManifest() != null) {
+      dataManifestBinary = ManifestFiles.encode(deltaManifests.dataManifest());
+    }
+
+    out.writeInt(dataManifestBinary.length);
+    out.write(dataManifestBinary);
+
+    byte[] deleteManifestBinary = EMPTY_BINARY;
+    if (deltaManifests.deleteManifest() != null) {
+      deleteManifestBinary = ManifestFiles.encode(deltaManifests.deleteManifest());
+    }
+
+    out.writeInt(deleteManifestBinary.length);
+    out.write(deleteManifestBinary);
+
+    CharSequence[] referencedDataFiles = deltaManifests.referencedDataFiles();
+    out.writeInt(referencedDataFiles.length);
+    for (int i = 0; i < referencedDataFiles.length; i++) {
+      out.writeUTF(referencedDataFiles[i].toString());
+    }
+
+    List<Long> txs = deltaManifests.getTransactionIds();
+    out.writeInt(txs.size());
+    for (Long tx : txs) {
+      out.writeLong(tx);
+    }
+    return binaryOut.toByteArray();
+  }
+
+  @Override
+  public DeltaManifests deserialize(int version, byte[] serialized) throws IOException {
+    if (version == VERSION_1) {
+      return deserializeV1(serialized);
+    } else if (version == VERSION_2) {
+      return deserializeV2(serialized);
+    } else if (version == VERSION_3) {
+      return deserializeV3(serialized);
+    } else {
+      throw new RuntimeException("Unknown serialize version: " + version);
+    }
+  }
+
+  private DeltaManifests deserializeV1(byte[] serialized) throws IOException {
+    return new DeltaManifests(ManifestFiles.decode(serialized), null);
+  }
+
+  private DeltaManifests deserializeV2(byte[] serialized) throws IOException {
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    ByteArrayInputStream binaryIn = new ByteArrayInputStream(serialized);
+    DataInputStream in = new DataInputStream(binaryIn);
+
+    int dataManifestSize = in.readInt();
+    if (dataManifestSize > 0) {
+      byte[] dataManifestBinary = new byte[dataManifestSize];
+      Preconditions.checkState(in.read(dataManifestBinary) == dataManifestSize);
+
+      dataManifest = ManifestFiles.decode(dataManifestBinary);
+    }
+
+    int deleteManifestSize = in.readInt();
+    if (deleteManifestSize > 0) {
+      byte[] deleteManifestBinary = new byte[deleteManifestSize];
+      Preconditions.checkState(in.read(deleteManifestBinary) == deleteManifestSize);
+
+      deleteManifest = ManifestFiles.decode(deleteManifestBinary);
+    }
+
+    int referenceDataFileNum = in.readInt();
+    CharSequence[] referencedDataFiles = new CharSequence[referenceDataFileNum];
+    for (int i = 0; i < referenceDataFileNum; i++) {
+      referencedDataFiles[i] = in.readUTF();
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, referencedDataFiles);
+  }
+
+  private DeltaManifests deserializeV3(byte[] serialized) throws IOException {
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    ByteArrayInputStream binaryIn = new ByteArrayInputStream(serialized);
+    DataInputStream in = new DataInputStream(binaryIn);
+
+    int dataManifestSize = in.readInt();
+    if (dataManifestSize > 0) {
+      byte[] dataManifestBinary = new byte[dataManifestSize];
+      Preconditions.checkState(in.read(dataManifestBinary) == dataManifestSize);
+
+      dataManifest = ManifestFiles.decode(dataManifestBinary);
+    }
+
+    int deleteManifestSize = in.readInt();
+    if (deleteManifestSize > 0) {
+      byte[] deleteManifestBinary = new byte[deleteManifestSize];
+      Preconditions.checkState(in.read(deleteManifestBinary) == deleteManifestSize);
+
+      deleteManifest = ManifestFiles.decode(deleteManifestBinary);
+    }
+
+    int referenceDataFileNum = in.readInt();
+    CharSequence[] referencedDataFiles = new CharSequence[referenceDataFileNum];
+    for (int i = 0; i < referenceDataFileNum; i++) {
+      referencedDataFiles[i] = in.readUTF();
+    }
+
+    int txNum = in.readInt();
+    List<Long> txs = new ArrayList<>(txNum);
+    for (int i = 0; i < txNum; i++) {
+      txs.add(in.readLong());
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, referencedDataFiles, txs);
+  }
+
+}

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import com.netease.arctic.flink.write.WriteResult;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+class FlinkManifestUtil {
+  private static final int FORMAT_V2 = 2;
+  private static final Long DUMMY_SNAPSHOT_ID = 0L;
+
+  private FlinkManifestUtil() {
+  }
+
+  static ManifestFile writeDataFiles(OutputFile outputFile, PartitionSpec spec, List<DataFile> dataFiles)
+      throws IOException {
+    ManifestWriter<DataFile> writer = ManifestFiles.write(FORMAT_V2, spec, outputFile, DUMMY_SNAPSHOT_ID);
+
+    try (ManifestWriter<DataFile> closeableWriter = writer) {
+      closeableWriter.addAll(dataFiles);
+    }
+
+    return writer.toManifestFile();
+  }
+
+  static List<DataFile> readDataFiles(ManifestFile manifestFile, FileIO io) throws IOException {
+    try (CloseableIterable<DataFile> dataFiles = ManifestFiles.read(manifestFile, io)) {
+      return Lists.newArrayList(dataFiles);
+    }
+  }
+
+  static ManifestOutputFileFactory createOutputFileFactory(Table table, String flinkJobId, int subTaskId,
+                                                           long attemptNumber) {
+    TableOperations ops = ((HasTableOperations) table).operations();
+    return new ManifestOutputFileFactory(ops, table.io(), table.properties(), flinkJobId, subTaskId, attemptNumber);
+  }
+
+  static DeltaManifests writeCompletedFiles(WriteResult result,
+                                            Supplier<OutputFile> outputFileSupplier,
+                                            PartitionSpec spec) throws IOException {
+
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    // Write the completed data files into a newly created data manifest file.
+    if (result.dataFiles() != null && result.dataFiles().length > 0) {
+      dataManifest = writeDataFiles(outputFileSupplier.get(), spec, Lists.newArrayList(result.dataFiles()));
+    }
+
+    // Write the completed delete files into a newly created delete manifest file.
+    if (result.deleteFiles() != null && result.deleteFiles().length > 0) {
+      OutputFile deleteManifestFile = outputFileSupplier.get();
+
+      ManifestWriter<DeleteFile> deleteManifestWriter = ManifestFiles.writeDeleteManifest(FORMAT_V2, spec,
+          deleteManifestFile, DUMMY_SNAPSHOT_ID);
+      try (ManifestWriter<DeleteFile> writer = deleteManifestWriter) {
+        for (DeleteFile deleteFile : result.deleteFiles()) {
+          writer.add(deleteFile);
+        }
+      }
+
+      deleteManifest = deleteManifestWriter.toManifestFile();
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, result.referencedDataFiles(), result.getTransactionIds());
+  }
+
+  static WriteResult readCompletedFiles(DeltaManifests deltaManifests, FileIO io) throws IOException {
+    WriteResult.Builder builder = WriteResult.builder();
+
+    // Read the completed data files from persisted data manifest file.
+    if (deltaManifests.dataManifest() != null) {
+      builder.addDataFiles(readDataFiles(deltaManifests.dataManifest(), io));
+    }
+
+    // Read the completed delete files from persisted delete manifests file.
+    if (deltaManifests.deleteManifest() != null) {
+      try (CloseableIterable<DeleteFile> deleteFiles = ManifestFiles
+          .readDeleteManifest(deltaManifests.deleteManifest(), io, null)) {
+        builder.addDeleteFiles(deleteFiles);
+      }
+    }
+
+    return builder.addReferencedDataFiles(deltaManifests.referencedDataFiles())
+        .addTransactionIds(deltaManifests.getTransactionIds())
+        .build();
+  }
+}

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -1,0 +1,401 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import com.netease.arctic.flink.write.WriteResult;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.runtime.typeutils.SortedMapTypeInfo;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ReplacePartitions;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+
+/**
+ * Add
+ * <p>
+ * Note: Copy from Iceberg
+ */
+public class IcebergFilesCommitter extends AbstractStreamOperator<Void>
+    implements OneInputStreamOperator<WriteResult, Void>, BoundedOneInput {
+
+  private static final long serialVersionUID = 1L;
+  private static final long INITIAL_CHECKPOINT_ID = -1L;
+  private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergFilesCommitter.class);
+  public static final String FLINK_JOB_ID = "flink.job-id";
+  public static final String TRANSACTION_ID = "transaction-id";
+  public static final String TRANSACTION_ID_SEPARATOR = ",";
+
+  // The max checkpoint id we've committed to iceberg table. As the flink's checkpoint is always increasing, so we could
+  // correctly commit all the data files whose checkpoint id is greater than the max committed one to iceberg table, for
+  // avoiding committing the same data files twice. This id will be attached to iceberg's meta when committing the
+  // iceberg transaction.
+  private static final String MAX_COMMITTED_CHECKPOINT_ID = "flink.max-committed-checkpoint-id";
+  static final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
+
+  // TableLoader to load iceberg table lazily.
+  private final TableLoader tableLoader;
+  private final boolean replacePartitions;
+
+  // A sorted map to maintain the completed data files for each pending checkpointId (which have not been committed
+  // to iceberg table). We need a sorted map here because there's possible that few checkpoints snapshot failed, for
+  // example: the 1st checkpoint have 2 data files <1, <file0, file1>>, the 2st checkpoint have 1 data files
+  // <2, <file3>>. Snapshot for checkpoint#1 interrupted because of network/disk failure etc, while we don't expect
+  // any data loss in iceberg table. So we keep the finished files <1, <file0, file1>> in memory and retry to commit
+  // iceberg table when the next checkpoint happen.
+  private final NavigableMap<Long, byte[]> dataFilesPerCheckpoint = Maps.newTreeMap();
+
+  // The completed files cache for current checkpoint. Once the snapshot barrier received, it will be flushed to the
+  // 'dataFilesPerCheckpoint'.
+  private final List<WriteResult> writeResultsOfCurrentCkpt = Lists.newArrayList();
+
+  // It will have an unique identifier for one job.
+  private transient String flinkJobId;
+  private transient Table table;
+  private transient ManifestOutputFileFactory manifestOutputFileFactory;
+  private transient long maxCommittedCheckpointId;
+  private transient int continuousEmptyCheckpoints;
+  private transient int maxContinuousEmptyCommits;
+  // There're two cases that we restore from flink checkpoints: the first case is restoring from snapshot created by the
+  // same flink job; another case is restoring from snapshot created by another different job. For the second case, we
+  // need to maintain the old flink job's id in flink state backend to find the max-committed-checkpoint-id when
+  // traversing iceberg table's snapshots.
+  private static final ListStateDescriptor<String> JOB_ID_DESCRIPTOR = new ListStateDescriptor<>(
+      "iceberg-flink-job-id", BasicTypeInfo.STRING_TYPE_INFO);
+  private transient ListState<String> jobIdState;
+  // All pending checkpoints states for this function.
+  private static final ListStateDescriptor<SortedMap<Long, byte[]>> STATE_DESCRIPTOR = buildStateDescriptor();
+  private transient ListState<SortedMap<Long, byte[]>> checkpointsState;
+
+  IcebergFilesCommitter(TableLoader tableLoader, boolean replacePartitions) {
+    this.tableLoader = tableLoader;
+    this.replacePartitions = replacePartitions;
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    this.flinkJobId = getContainingTask().getEnvironment().getJobID().toString();
+
+    // Open the table loader and load the table.
+    this.tableLoader.open();
+    this.table = tableLoader.loadTable();
+
+    maxContinuousEmptyCommits = PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
+    Preconditions.checkArgument(maxContinuousEmptyCommits > 0,
+        MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+
+    int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
+    int attemptId = getRuntimeContext().getAttemptNumber();
+    this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, subTaskId, attemptId);
+    this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+
+    this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);
+    this.jobIdState = context.getOperatorStateStore().getListState(JOB_ID_DESCRIPTOR);
+    if (context.isRestored()) {
+      String restoredFlinkJobId = jobIdState.get().iterator().next();
+      Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),
+          "Flink job id parsed from checkpoint snapshot shouldn't be null or empty");
+
+      // Since flink's checkpoint id will start from the max-committed-checkpoint-id + 1 in the new flink job even if
+      // it's restored from a snapshot created by another different flink job, so it's safe to assign the max committed
+      // checkpoint id from restored flink job to the current flink job.
+      this.maxCommittedCheckpointId = getMaxCommittedCheckpointId(table, restoredFlinkJobId);
+
+      NavigableMap<Long, byte[]> uncommittedDataFiles = Maps
+          .newTreeMap(checkpointsState.get().iterator().next())
+          .tailMap(maxCommittedCheckpointId, false);
+      if (!uncommittedDataFiles.isEmpty()) {
+        // Committed all uncommitted data files from the old flink job to iceberg table.
+        long maxUncommittedCheckpointId = uncommittedDataFiles.lastKey();
+        commitUpToCheckpoint(uncommittedDataFiles, restoredFlinkJobId, maxUncommittedCheckpointId);
+      }
+    }
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    long checkpointId = context.getCheckpointId();
+    LOG.info("Start to flush snapshot state to state backend, table: {}, checkpointId: {}", table, checkpointId);
+
+    // Update the checkpoint state.
+    dataFilesPerCheckpoint.put(checkpointId, writeToManifest(checkpointId));
+    // Reset the snapshot state to the latest state.
+    checkpointsState.clear();
+    checkpointsState.add(dataFilesPerCheckpoint);
+
+    jobIdState.clear();
+    jobIdState.add(flinkJobId);
+
+    // Clear the local buffer for current checkpoint.
+    writeResultsOfCurrentCkpt.clear();
+  }
+
+  @Override
+  public void notifyCheckpointComplete(long checkpointId) throws Exception {
+    super.notifyCheckpointComplete(checkpointId);
+    // It's possible that we have the following events:
+    //   1. snapshotState(ckpId);
+    //   2. snapshotState(ckpId+1);
+    //   3. notifyCheckpointComplete(ckpId+1);
+    //   4. notifyCheckpointComplete(ckpId);
+    // For step#4, we don't need to commit iceberg table again because in step#3 we've committed all the files,
+    // Besides, we need to maintain the max-committed-checkpoint-id to be increasing.
+    if (checkpointId > maxCommittedCheckpointId) {
+      commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, checkpointId);
+      this.maxCommittedCheckpointId = checkpointId;
+    }
+  }
+
+  private void commitUpToCheckpoint(NavigableMap<Long, byte[]> deltaManifestsMap,
+                                    String newFlinkJobId,
+                                    long checkpointId) throws IOException {
+    NavigableMap<Long, byte[]> pendingMap = deltaManifestsMap.headMap(checkpointId, true);
+    List<ManifestFile> manifests = Lists.newArrayList();
+    NavigableMap<Long, WriteResult> pendingResults = Maps.newTreeMap();
+    for (Map.Entry<Long, byte[]> e : pendingMap.entrySet()) {
+      if (Arrays.equals(EMPTY_MANIFEST_DATA, e.getValue())) {
+        // Skip the empty flink manifest.
+        continue;
+      }
+
+      DeltaManifests deltaManifests = SimpleVersionedSerialization
+          .readVersionAndDeSerialize(DeltaManifestsSerializer.INSTANCE, e.getValue());
+      pendingResults.put(e.getKey(), FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io()));
+      manifests.addAll(deltaManifests.manifests());
+    }
+
+    int totalFiles = pendingResults.values().stream()
+        .mapToInt(r -> r.dataFiles().length + r.deleteFiles().length).sum();
+    continuousEmptyCheckpoints = totalFiles == 0 ? continuousEmptyCheckpoints + 1 : 0;
+    if (totalFiles != 0 || continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0) {
+      if (replacePartitions) {
+        replacePartitions(pendingResults, newFlinkJobId, checkpointId);
+      } else {
+        commitDeltaTxn(pendingResults, newFlinkJobId, checkpointId);
+      }
+      continuousEmptyCheckpoints = 0;
+    }
+    pendingMap.clear();
+
+    // Delete the committed manifests.
+    for (ManifestFile manifest : manifests) {
+      try {
+        table.io().deleteFile(manifest.path());
+      } catch (Exception e) {
+        // The flink manifests cleaning failure shouldn't abort the completed checkpoint.
+        String details = MoreObjects.toStringHelper(this)
+            .add("flinkJobId", newFlinkJobId)
+            .add("checkpointId", checkpointId)
+            .add("manifestPath", manifest.path())
+            .toString();
+        LOG.warn("The iceberg transaction has been committed, but we failed to clean the temporary flink manifests: {}",
+            details, e);
+      }
+    }
+  }
+
+  private void replacePartitions(NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId,
+                                 long checkpointId) {
+    // Partition overwrite does not support delete files.
+    int deleteFilesNum = pendingResults.values().stream().mapToInt(r -> r.deleteFiles().length).sum();
+    Preconditions.checkState(deleteFilesNum == 0, "Cannot overwrite partitions with delete files.");
+
+    // Commit the overwrite transaction.
+    ReplacePartitions dynamicOverwrite = table.newReplacePartitions();
+
+    int numFiles = 0;
+    List<Long> transactionIds = new ArrayList<>(pendingResults.values().size());
+    for (WriteResult result : pendingResults.values()) {
+      Preconditions.checkState(result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+
+      transactionIds.addAll(result.getTransactionIds());
+      numFiles += result.dataFiles().length;
+      Arrays.stream(result.dataFiles()).forEach(dynamicOverwrite::addFile);
+    }
+
+    commitOperation(dynamicOverwrite, numFiles, 0, "dynamic partition overwrite", newFlinkJobId,
+        checkpointId, transactionIds);
+  }
+
+  private void commitDeltaTxn(NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId, long checkpointId) {
+    int deleteFilesNum = pendingResults.values().stream().mapToInt(r -> r.deleteFiles().length).sum();
+
+    if (deleteFilesNum == 0) {
+      // To be compatible with iceberg format V1.
+      AppendFiles appendFiles = table.newAppend();
+
+      int numFiles = 0;
+      List<Long> transactionIds = new ArrayList<>(pendingResults.values().size());
+      for (WriteResult result : pendingResults.values()) {
+        Preconditions.checkState(result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+
+        transactionIds.addAll(result.getTransactionIds());
+        numFiles += result.dataFiles().length;
+        Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+      }
+
+      commitOperation(appendFiles, numFiles, 0, "append", newFlinkJobId, checkpointId,
+          transactionIds);
+    } else {
+      // To be compatible with iceberg format V2.
+      for (Map.Entry<Long, WriteResult> e : pendingResults.entrySet()) {
+        // We don't commit the merged result into a single transaction because for the sequential transaction txn1 and
+        // txn2, the equality-delete files of txn2 are required to be applied to data files from txn1. Committing the
+        // merged one will lead to the incorrect delete semantic.
+        WriteResult result = e.getValue();
+        RowDelta rowDelta = table.newRowDelta()
+            .validateDataFilesExist(ImmutableList.copyOf(result.referencedDataFiles()))
+            .validateDeletedFiles();
+
+        int numDataFiles = result.dataFiles().length;
+        Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
+
+        int numDeleteFiles = result.deleteFiles().length;
+        Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
+
+        commitOperation(rowDelta, numDataFiles, numDeleteFiles, "rowDelta", newFlinkJobId, e.getKey(),
+            result.getTransactionIds());
+      }
+    }
+  }
+
+  private void commitOperation(SnapshotUpdate<?> operation, int numDataFiles, int numDeleteFiles, String description,
+                               String newFlinkJobId, long checkpointId, List<Long> transactionIds) {
+    LOG.info("Committing {} with {} data files and {} delete files to table {}. transactionIds {}", description,
+        numDataFiles, numDeleteFiles, table, transactionIds);
+    operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));
+    operation.set(FLINK_JOB_ID, newFlinkJobId);
+    if (!CollectionUtil.isNullOrEmpty(transactionIds)) {
+      operation.set(TRANSACTION_ID, StringUtils.join(transactionIds, ""));
+    }
+
+    long start = System.currentTimeMillis();
+    operation.commit(); // abort is automatically called if this fails.
+    long duration = System.currentTimeMillis() - start;
+    LOG.info("Committed in {} ms", duration);
+  }
+
+  @Override
+  public void processElement(StreamRecord<WriteResult> element) {
+    this.writeResultsOfCurrentCkpt.add(element.getValue());
+  }
+
+  @Override
+  public void endInput() throws IOException {
+    // Flush the buffered data files into 'dataFilesPerCheckpoint' firstly.
+    long currentCheckpointId = Long.MAX_VALUE;
+    dataFilesPerCheckpoint.put(currentCheckpointId, writeToManifest(currentCheckpointId));
+    writeResultsOfCurrentCkpt.clear();
+
+    commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, currentCheckpointId);
+  }
+
+  /**
+   * Write all the complete data files to a newly created manifest file and return the manifest's avro serialized bytes.
+   */
+  private byte[] writeToManifest(long checkpointId) throws IOException {
+    if (writeResultsOfCurrentCkpt.isEmpty()) {
+      return EMPTY_MANIFEST_DATA;
+    }
+
+    WriteResult result = WriteResult.builder().addAll(writeResultsOfCurrentCkpt).build();
+
+    DeltaManifests deltaManifests = FlinkManifestUtil.writeCompletedFiles(result,
+        () -> manifestOutputFileFactory.create(checkpointId), table.spec());
+
+    return SimpleVersionedSerialization.writeVersionAndSerialize(DeltaManifestsSerializer.INSTANCE, deltaManifests);
+  }
+
+  @Override
+  public void dispose() throws Exception {
+    if (tableLoader != null) {
+      tableLoader.close();
+    }
+  }
+
+  private static ListStateDescriptor<SortedMap<Long, byte[]>> buildStateDescriptor() {
+    Comparator<Long> longComparator = Comparators.forType(Types.LongType.get());
+    // Construct a SortedMapTypeInfo.
+    SortedMapTypeInfo<Long, byte[]> sortedMapTypeInfo = new SortedMapTypeInfo<>(
+        BasicTypeInfo.LONG_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO, longComparator
+    );
+    return new ListStateDescriptor<>("iceberg-files-committer-state", sortedMapTypeInfo);
+  }
+
+  static long getMaxCommittedCheckpointId(Table table, String flinkJobId) {
+    Snapshot snapshot = table.currentSnapshot();
+    long lastCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+
+    while (snapshot != null) {
+      Map<String, String> summary = snapshot.summary();
+      String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
+      if (flinkJobId.equals(snapshotFlinkJobId)) {
+        String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
+        if (value != null) {
+          lastCommittedCheckpointId = Long.parseLong(value);
+          break;
+        }
+      }
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
+    }
+
+    return lastCommittedCheckpointId;
+  }
+}

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/kafka/testutils/KafkaTestBase.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/kafka/testutils/KafkaTestBase.java
@@ -103,8 +103,16 @@ public class KafkaTestBase {
 
   public void startClusters(boolean secureMode)
       throws Exception {
+    Properties props = new Properties();
+    props.put("offsets.topic.num.partitions", "3");
+    props.put("offsets.topic.segment.bytes", "1048576");
+    props.put("transaction.state.log.num.partitions", "3");
+    props.put("transaction.state.log.segment.bytes", "1048576");
+    props.put("metadata.log.max.record.bytes.between.snapshots", "1048576");
+    
     startClusters(
         KafkaTestEnvironment.createConfig()
+            .setKafkaServerProperties(props)
             .setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
             .setSecureMode(secureMode));
   }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -69,7 +69,6 @@ import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -162,14 +161,12 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     assertArrayEquals(excepts(), actualResult);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStaticJobManagerFailover() throws Exception {
     testArcticSource(FailoverType.JM);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStaticTaskManagerFailover() throws Exception {
     testArcticSource(FailoverType.TM);
   }
@@ -256,7 +253,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     Assert.assertEquals(Long.MAX_VALUE, WatermarkAwareFailWrapper.getWatermarkAfterFailover());
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSource() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSource(true);
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -354,14 +351,12 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceJobManagerFailover() throws Exception {
     testArcticContinuousSource(FailoverType.JM);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceTaskManagerFailover() throws Exception {
     testArcticContinuousSource(FailoverType.TM);
   }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -137,7 +137,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     testCatalog.dropTable(FAIL_TABLE_ID, true);
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStatic() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSource(false);
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileCommitterTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileCommitterTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.types.RowKind;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.WriteResult;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -176,7 +176,10 @@ public class ArcticFileWriterTest extends FlinkTestBase {
       testHarness.initializeState(state);
       testHarness.open();
 
-      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
+      testHarness.prepareSnapshotPreBarrier(checkpointId + 1);
+      testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
+
+      ArcticWriter fileWriter = (ArcticWriter) testHarness.getOneInputOperator();
       Assert.assertEquals(checkpointId + 1, fileWriter.getCheckpointId());
     }
   }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.flink.util.TestGlobalAggregateManager;
@@ -34,7 +35,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.sink.RowDataTaskWriterFactory;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.io.TaskWriter;
-import org.apache.iceberg.io.WriteResult;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,9 +90,12 @@ public class ArcticFileWriterTest extends FlinkTestBase {
         false,
         (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType(),
         tableLoader);
+
+    ArcticWriter arcticWriter = new ArcticWriter(null, streamWriter, tableLoader,
+        MetricsGenerator.empty(false));
     OneInputStreamOperatorInternTest<RowData, WriteResult> harness =
         new OneInputStreamOperatorInternTest<>(
-            streamWriter, 1, 1, 0, restoredCheckpointId,
+            arcticWriter, 1, 1, 0, restoredCheckpointId,
             new TestGlobalAggregateManager());
 
     return harness;
@@ -113,15 +116,12 @@ public class ArcticFileWriterTest extends FlinkTestBase {
     try (
         OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = createArcticStreamWriter(
             tableLoader)) {
-      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
-      Assert.assertNotNull(fileWriter.getWriter());
       // The first checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
 
       testHarness.prepareSnapshotPreBarrier(checkpointId);
-      Assert.assertNull(fileWriter.getWriter());
       Assert.assertEquals(1, testHarness.extractOutputValues().size());
       Assert.assertEquals(3, testHarness.extractOutputValues().get(0).dataFiles().length);
 
@@ -129,7 +129,6 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
       // The second checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-12T10:10:11.0"), 1);
-      Assert.assertNotNull(fileWriter.getWriter());
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-12T10:10:11.0"), 1);
 
@@ -328,7 +327,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
       // The second checkpoint
       testHarness.prepareSnapshotPreBarrier(checkpointId);
-      Assert.assertEquals(excepted, testHarness.extractOutputValues().size());
+      Assert.assertEquals(excepted + (submitEmptySnapshots ? 1 : 0), testHarness.extractOutputValues().size());
     }
   }
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
@@ -29,6 +29,7 @@ import com.netease.arctic.flink.util.DataUtil;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.flink.util.TestGlobalAggregateManager;
 import com.netease.arctic.flink.write.hidden.kafka.HiddenKafkaFactory;
+import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonDeserialization;
 import com.netease.arctic.utils.IdGenerator;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -44,7 +45,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
-import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -252,15 +252,20 @@ public class AutomaticLogWriterTest extends FlinkTestBase {
             LogRecordV1.mapFactory
         );
     ConsumerRecords<byte[], byte[]> consumerRecords = kafkaTestBase.readRecordsBytes(topic);
-    Assertions.assertEquals(expects.size(), consumerRecords.count());
+    
     List<RowData> actual = new ArrayList<>();
     consumerRecords.forEach(consumerRecord -> {
       try {
-        actual.add(logDataJsonDeserialization.deserialize(consumerRecord.value()).getActualValue());
+        LogData<RowData> row = logDataJsonDeserialization.deserialize(consumerRecord.value());
+        if (row.getFlip()) {
+          return;
+        }
+        actual.add(row.getActualValue());
       } catch (IOException e) {
         e.printStackTrace();
       }
     });
+    Assertions.assertEquals(expects.size(), actual.size());
     Collection<RowData> expected = DataUtil.toRowData(expects);
     Assertions.assertEquals(
         expected.stream().sorted(
@@ -316,7 +321,8 @@ public class AutomaticLogWriterTest extends FlinkTestBase {
         (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType(),
         tableLoader);
 
-    ArcticWriter<WriteResult> arcticWriter = new ArcticWriter<>(automaticLogWriter, streamWriter, metricsGenerator);
+    ArcticWriter<WriteResult> arcticWriter = new ArcticWriter<>(automaticLogWriter, streamWriter, tableLoader,
+        metricsGenerator);
 
     OneInputStreamOperatorInternTest<RowData, WriteResult> harness =
         new OneInputStreamOperatorInternTest<>(

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
@@ -47,7 +47,13 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.conversion.DataStructureConverter;
+import org.apache.flink.table.data.conversion.DataStructureConverters;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -230,7 +236,8 @@ public class HiddenLogOperatorsTest extends BaseLogTest {
       output.addAll(collect(harness2));
       Assertions.assertEquals(11, output.size());
       ConsumerRecords<byte[], byte[]> consumerRecords = kafkaTestBase.readRecordsBytes(topic);
-      Assertions.assertEquals(11, consumerRecords.count());
+      // additional one is flip in init
+      Assertions.assertEquals(12, consumerRecords.count());
       LogDataJsonDeserialization<RowData> deserialization = createLogDataDeserialization();
       consumerRecords.forEach(consumerRecord -> {
         try {
@@ -293,7 +300,8 @@ public class HiddenLogOperatorsTest extends BaseLogTest {
           e.printStackTrace();
         }
       });
-      Assertions.assertEquals(20, consumerRecords.count());
+      // two flip
+      Assertions.assertEquals(21, consumerRecords.count());
     } catch (Exception e) {
       e.printStackTrace();
       throw e;
@@ -405,11 +413,14 @@ public class HiddenLogOperatorsTest extends BaseLogTest {
     CloseableIterator<RowData> iterator = clientAndIterator.iterator;
 
     List<RowData> actualResult = new ArrayList<>();
-
+    
+    DataStructureConverter converter = DataStructureConverters.getConverter(
+        DataTypeUtils.toInternalDataType(flinkUserSchema).bridgedTo(Row.class));
+    
     while (iterator.hasNext()) {
       RowData row = iterator.next();
       actualResult.add(row);
-      LOG.info("size {}, {}.", actualResult.size(), row);
+      LOG.info("size {}, {}.", actualResult.size(), converter.toExternal(row));
       if (actualResult.size() == count) {
         break;
       }
@@ -477,7 +488,8 @@ public class HiddenLogOperatorsTest extends BaseLogTest {
             new HiddenKafkaFactory<>(),
             LogRecordV1.fieldGetterFactory,
             jobId,
-            ShuffleHelper.EMPTY
+            ShuffleHelper.EMPTY,
+            null
         );
 
     OneInputStreamOperatorInternTest<RowData, RowData> harness =

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -37,23 +37,31 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.sink.IcebergFilesCommitter;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION_DEFAULT;
+import static org.apache.iceberg.flink.sink.IcebergFilesCommitter.FLINK_JOB_ID;
+import static org.apache.iceberg.flink.sink.IcebergFilesCommitter.TRANSACTION_ID;
 
 /**
  * An util that loads arctic table, build arctic log writer and so on.
@@ -167,7 +175,8 @@ public class ArcticUtils {
           new HiddenKafkaFactory<>(),
           LogRecordV1.fieldGetterFactory,
           IdGenerator.generateUpstreamId(),
-          helper);
+          helper,
+          tableLoader);
     }
     throw new UnsupportedOperationException("don't support log version '" + version +
         "'. only support 'v1' or empty");
@@ -199,4 +208,76 @@ public class ArcticUtils {
             rowData.getClass().getSimpleName()));
   }
 
+  public static Optional<Long> getMaxCommittedTransactionId(@Nullable ArcticTable table, String jobId) {
+    if (table == null) {
+      return Optional.empty();
+    }
+    if (table.isUnkeyedTable()) {
+      return getMaxCommittedTransactionIdFromTable(table.asUnkeyedTable(), jobId);
+    }
+    return getMaxCommittedTransactionIdFromTable(table.asKeyedTable().changeTable(), jobId);
+  }
+
+  public static Optional<Long> getMaxCommittedTransactionIdFromTable(Table table, String jobId) {
+    Snapshot snapshot = table.currentSnapshot();
+
+    while (snapshot != null) {
+      long crt = snapshot.snapshotId();
+      Map<String, String> summary = snapshot.summary();
+      String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
+
+
+      if (!jobId.equals(snapshotFlinkJobId)) {
+        continue;
+      }
+
+      String value = summary.get(TRANSACTION_ID);
+      if (value == null) {
+        continue;
+      }
+      String[] txs = value.split(IcebergFilesCommitter.TRANSACTION_ID_SEPARATOR);
+      long maxTx = Long.MIN_VALUE;
+      try {
+        for (String tx : txs) {
+          maxTx = Math.max(maxTx, Long.parseLong(tx));
+        }
+      } catch (Exception e) {
+        throw new IllegalStateException(String.format("there is invalid '%s' data in snapshot '%d', value: '%s'",
+            TRANSACTION_ID, crt, value));
+      }
+      return Optional.of(maxTx);
+    }
+
+    return Optional.empty();
+  }
+
+  public static boolean isTransactionCommitted(Table table, String jobId, String txId) {
+    Snapshot snapshot = table.currentSnapshot();
+
+    while (snapshot != null) {
+      Map<String, String> summary = snapshot.summary();
+      String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
+
+      if (!jobId.equals(snapshotFlinkJobId)) {
+        continue;
+      }
+
+      String value = summary.get(TRANSACTION_ID);
+      if (value == null) {
+        continue;
+      }
+      String[] txs = value.split(IcebergFilesCommitter.TRANSACTION_ID_SEPARATOR);
+      for (String tx : txs) {
+        if (Objects.equals(txId, tx.trim())) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -37,9 +37,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.io.TaskWriter;
-import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +51,7 @@ import java.util.stream.IntStream;
  * This is arctic table includes writing file data to un keyed table and keyed table.
  */
 public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
-    implements OneInputStreamOperator<RowData, WriteResult>, BoundedOneInput {
+    implements OneInputStreamOperator<RowData, WriteResult>, BoundedOneInput, TransactionIdAware {
 
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(ArcticFileWriter.class);
@@ -68,8 +67,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private transient org.apache.iceberg.io.TaskWriter<RowData> writer;
   private transient int subTaskId;
   private transient int attemptId;
-  private transient String jobId;
-  private transient long checkpointId = 0;
+  private transient Long transactionId;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
    * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
@@ -94,58 +92,32 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
         minFileSplitCount, upsert, submitEmptySnapshot);
   }
 
-
   @Override
   public void open() {
     this.attemptId = getRuntimeContext().getAttemptNumber();
-    this.jobId = getContainingTask().getEnvironment().getJobID().toString();
     table = ArcticUtils.loadArcticTable(tableLoader);
-
-    long mask = getMask(subTaskId);
-    initTaskWriterFactory(mask);
-
-    this.writer = table.io().doAs(taskWriterFactory::create);
+    setMask();
   }
 
-  @Override
-  public void initializeState(StateInitializationContext context) throws Exception {
-    super.initializeState(context);
-
-    this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
-
-    if (context.isRestored()) {
-      checkpointId = context.getRestoredCheckpointId().getAsLong();
-      // prepare for the writer init in open(). It is used for next ckpId.
-      checkpointId++;
+  private void setMask() {
+    if (!(taskWriterFactory instanceof ArcticRowDataTaskWriterFactory)) {
+      return;
     }
+    long mask = getMask(subTaskId);
+    ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setMask(mask);
   }
 
-  private void initTaskWriterFactory(Long mask) {
+  /**
+   * Reassign transaction id when processing the new file data to avoid the situation that there is no data
+   * written during the next checkpoint period.
+   * It should be invoked before taskWriterFactory#create
+   */
+  public void setTransactionId(Long transactionId) {
+    this.transactionId = transactionId;
     if (taskWriterFactory instanceof ArcticRowDataTaskWriterFactory) {
-      if (mask != null) {
-        ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setMask(mask);
-      }
-      ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setTransactionId(getTransactionId());
+      ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setTransactionId(transactionId);
     }
     taskWriterFactory.initialize(subTaskId, attemptId);
-  }
-
-  private Long getTransactionId() {
-    Long transaction;
-    if (table.isKeyedTable()) {
-      String signature = BaseEncoding.base16().encode((jobId + checkpointId).getBytes());
-      transaction = table.asKeyedTable().beginTransaction(signature);
-      LOG.info("table:{}, signature:{}, transactionId:{}. From jobId:{}, ckpId:{}", table.name(), signature,
-          transaction, jobId, checkpointId);
-    } else {
-      transaction = null;
-    }
-    return transaction;
-  }
-
-  @VisibleForTesting
-  public long getCheckpointId() {
-    return checkpointId;
   }
 
   private long getMask(int subTaskId) {
@@ -167,12 +139,11 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-    this.checkpointId = checkpointId;
-
     table.io().doAs(() -> {
       completeAndEmitFiles();
 
       this.writer = null;
+      this.transactionId = null;
       return null;
     });
   }
@@ -189,7 +160,9 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     // For bounded stream, it may don't enable the checkpoint mechanism so we'd better to emit the remaining
     // completed files to downstream before closing the writer so that we won't miss any of them.
     if (writer != null) {
-      emit(writer.complete());
+      emit(new WriteResult(writer.complete(), Lists.newArrayList(transactionId)));
+    } else {
+      emit(WriteResult.builder().build());
     }
   }
 
@@ -198,9 +171,6 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     RowData row = element.getValue();
     table.io().doAs(() -> {
       if (writer == null) {
-        // Reassign transaction id when processing the new file data to avoid the situation that there is no data
-        // written during the next checkpoint period.
-        initTaskWriterFactory(null);
         this.writer = taskWriterFactory.create();
       }
 
@@ -239,7 +209,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    *
    * @param writeResult the WriteResult to emit
    * @return true if the WriteResult should be emitted, or the WriteResult isn't empty,
-   *         false only if the WriteResult is empty and the submitEmptySnapshot is false.
+   * false only if the WriteResult is empty and the submitEmptySnapshot is false.
    */
   private boolean shouldEmit(WriteResult writeResult) {
     return submitEmptySnapshot || (writeResult != null &&

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticRowDataTaskWriterFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticRowDataTaskWriterFactory.java
@@ -59,12 +59,8 @@ public class ArcticRowDataTaskWriterFactory implements TaskWriterFactory<RowData
 
   @Override
   public void initialize(int taskId, int attemptId) {
-    if (table.isKeyedTable()) {
-      Preconditions.checkNotNull(transactionId, "TransactionId should be set first. " +
-          "Invoke setTransactionId() before this method");
-    } else {
-      Preconditions.checkArgument(transactionId == null, "TransactionId should be null for unkeyed table.");
-    }
+    Preconditions.checkNotNull(transactionId, "TransactionId should be set first. " +
+        "Invoke setTransactionId() before this method");
     this.taskId = taskId;
     this.attemptId = attemptId;
   }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
@@ -19,6 +19,10 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.metric.MetricsGenerator;
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.table.ArcticTable;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;
@@ -37,6 +41,7 @@ import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 
 import java.util.Objects;
 
@@ -52,21 +57,47 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   private transient Meter meterSpeed;
 
+  private byte[] arcticJobId;
+  /**
+   * flink jobId
+   */
+  private transient String jobId;
+  private transient long checkpointId = 0;
+  private transient Long transactionId = null;
+  /**
+   * Load table in runtime, because that table's refresh method will be invoked in serialization.
+   * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
+   * if Arctic's table is KERBEROS enabled. It will cause ugi relevant exception when deploy to yarn cluster.
+   */
+  private transient ArcticTable table;
+
   private final AbstractStreamOperator fileWriter;
   private final ArcticLogWriter logWriter;
   private final MetricsGenerator metricsGenerator;
+  private final ArcticTableLoader tableLoader;
 
   private static final String INFLUXDB_TAG_NAME = "arctic_task_id";
 
-  public ArcticWriter(
-      ArcticLogWriter logWriter,
-      AbstractStreamOperator fileWriter,
-      MetricsGenerator metricsGenerator) {
+  public ArcticWriter(ArcticLogWriter logWriter,
+                      AbstractStreamOperator fileWriter,
+                      ArcticTableLoader tableLoader,
+                      MetricsGenerator metricsGenerator) {
     this.logWriter = logWriter;
     this.fileWriter = fileWriter;
+    this.tableLoader = tableLoader;
     this.metricsGenerator = metricsGenerator;
   }
 
+  private Long getTransactionId() {
+    Long transaction;
+    String signature = BaseEncoding.base16().encode((jobId + checkpointId).getBytes());
+    transaction = table.beginTransaction(signature);
+    LOG.info("get new TransactionId. table:{}, signature:{}, transactionId:{}. From jobId:{}, ckpId:{}",
+        table.name(), signature, transaction, jobId, checkpointId);
+    transactionId = transaction;
+    return transaction;
+  }
+  
   @Override
   public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<OUT>> output) {
     super.setup(containingTask, config, output);
@@ -104,6 +135,10 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
           .meter("record-count", new MeterView(60));
       LOG.info("add metrics record-count");
     }
+
+    this.jobId = getContainingTask().getEnvironment().getJobID().toString();
+    table = ArcticUtils.loadArcticTable(tableLoader);
+    
     if (logWriter != null) {
       logWriter.open();
     }
@@ -124,12 +159,20 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+    this.checkpointId = checkpointId;
+    transactionId = null;
+    
     if (logWriter != null) {
       logWriter.prepareSnapshotPreBarrier(checkpointId);
     }
     if (fileWriter != null) {
       fileWriter.prepareSnapshotPreBarrier(checkpointId);
     }
+  }
+
+  @VisibleForTesting
+  public long getCheckpointId() {
+    return checkpointId;
   }
 
   @Override
@@ -154,6 +197,16 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void processElement(StreamRecord<RowData> element) throws Exception {
+    if (transactionId == null) {
+      transactionId = getTransactionId();
+      // setTransactionId should be invoked before log/file writer#processElement
+      if (logWriter != null) {
+        logWriter.setTransactionId(transactionId);
+      }
+      if (fileWriter != null && fileWriter instanceof TransactionIdAware) {
+        ((TransactionIdAware) fileWriter).setTransactionId(transactionId);
+      }
+    }
     if (metricsGenerator.isMetricEnable()) {
       meterSpeed.markEvent();
     }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
@@ -56,7 +56,7 @@ public class AutomaticLogWriter extends ArcticLogWriter {
       ArcticTableLoader tableLoader,
       Duration writeLogstoreWatermarkGap) {
     this.arcticLogWriter =
-        new HiddenLogWriter(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
+        new HiddenLogWriter(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper, tableLoader);
     this.status = new AutomaticDoubleWriteStatus(tableLoader, writeLogstoreWatermarkGap);
   }
 
@@ -123,6 +123,11 @@ public class AutomaticLogWriter extends ArcticLogWriter {
     }
   }
 
+  @Override
+  public void setTransactionId(Long transactionId) {
+    arcticLogWriter.setTransactionId(transactionId);
+  }
+  
   @Override
   public void close() throws Exception {
     if (status.isDoubleWrite()) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
-import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
@@ -140,13 +139,14 @@ public class FlinkSink {
         DataStream<RowData> input,
         ArcticLogWriter logWriter,
         ArcticFileWriter fileWriter,
+        ArcticTableLoader tableLoader,
         OneInputStreamOperator<WriteResult, Void> committer,
         int writeOperatorParallelism,
         MetricsGenerator metricsGenerator,
         String arcticEmitMode) {
       SingleOutputStreamOperator writerStream = input
           .transform(ArcticWriter.class.getName(), TypeExtractor.createTypeInfo(WriteResult.class),
-              new ArcticWriter<>(logWriter, fileWriter, metricsGenerator))
+              new ArcticWriter<>(logWriter, fileWriter, tableLoader, metricsGenerator))
           .name(String.format("ArcticWriter %s(%s)", table.name(), arcticEmitMode))
           .setParallelism(writeOperatorParallelism);
 
@@ -213,6 +213,7 @@ public class FlinkSink {
           rowDataInput,
           logWriter,
           fileWriter,
+          tableLoader,
           createFileCommitter(table, tableLoader, overwrite, arcticEmitMode),
           writeOperatorParallelism,
           metricsGenerator,

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -111,11 +111,7 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
   }
 
   private FlinkBaseTaskWriter buildBaseWriter(LocationKind locationKind) {
-    if (table.isKeyedTable()) {
-      Preconditions.checkNotNull(transactionId);
-    } else {
-      Preconditions.checkArgument(transactionId == null);
-    }
+    Preconditions.checkNotNull(transactionId);
     FileFormat fileFormat = FileFormat.valueOf((table.properties().getOrDefault(
         TableProperties.BASE_FILE_FORMAT,
         TableProperties.BASE_FILE_FORMAT_DEFAULT).toUpperCase(Locale.ENGLISH)));

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -111,7 +111,6 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
   }
 
   private FlinkBaseTaskWriter buildBaseWriter(LocationKind locationKind) {
-    Preconditions.checkNotNull(transactionId);
     FileFormat fileFormat = FileFormat.valueOf((table.properties().getOrDefault(
         TableProperties.BASE_FILE_FORMAT,
         TableProperties.BASE_FILE_FORMAT_DEFAULT).toUpperCase(Locale.ENGLISH)));

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/TransactionIdAware.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/TransactionIdAware.java
@@ -18,14 +18,9 @@
 
 package com.netease.arctic.flink.write;
 
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.table.data.RowData;
-
 /**
- * This is a common abstract arctic log writer.
+ * Indicate the transactionId may be useful for it.
  */
-public abstract class ArcticLogWriter extends AbstractStreamOperator<RowData>
-    implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput, TransactionIdAware {
+public interface TransactionIdAware {
+  void setTransactionId(Long transactionId);
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/WriteResult.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/WriteResult.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.CharSequenceSet;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+public class WriteResult implements Serializable {
+
+  private final List<Long> transactionIds;
+  private org.apache.iceberg.io.WriteResult writeResult;
+
+  public WriteResult(org.apache.iceberg.io.WriteResult writeResult, List<Long> transactionIds) {
+    this.writeResult = writeResult;
+    this.transactionIds = transactionIds;
+  }
+
+  public DataFile[] dataFiles() {
+    return writeResult.dataFiles();
+  }
+
+  public DeleteFile[] deleteFiles() {
+    return writeResult.deleteFiles();
+  }
+
+  public CharSequence[] referencedDataFiles() {
+    return writeResult.referencedDataFiles();
+  }
+
+  public List<Long> getTransactionIds() {
+    return transactionIds;
+  }
+
+  public org.apache.iceberg.io.WriteResult getInternal() {
+    return writeResult;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final List<DataFile> dataFiles;
+    private final List<DeleteFile> deleteFiles;
+    private final CharSequenceSet referencedDataFiles;
+    private final List<Long> transactionIds;
+
+    private Builder() {
+      this.dataFiles = Lists.newArrayList();
+      this.deleteFiles = Lists.newArrayList();
+      this.referencedDataFiles = CharSequenceSet.empty();
+      this.transactionIds = Lists.newArrayList();
+    }
+
+    public Builder add(WriteResult result) {
+      addDataFiles(result.dataFiles());
+      addDeleteFiles(result.deleteFiles());
+      addReferencedDataFiles(result.referencedDataFiles());
+      transactionIds.addAll(result.getTransactionIds());
+      return this;
+    }
+
+    public Builder addAll(Iterable<WriteResult> results) {
+      results.forEach(this::add);
+      return this;
+    }
+
+    public Builder addDataFiles(DataFile... files) {
+      Collections.addAll(dataFiles, files);
+      return this;
+    }
+
+    public Builder addDataFiles(Iterable<DataFile> files) {
+      Iterables.addAll(dataFiles, files);
+      return this;
+    }
+
+    public Builder addDeleteFiles(DeleteFile... files) {
+      Collections.addAll(deleteFiles, files);
+      return this;
+    }
+
+    public Builder addDeleteFiles(Iterable<DeleteFile> files) {
+      Iterables.addAll(deleteFiles, files);
+      return this;
+    }
+
+    public Builder addReferencedDataFiles(CharSequence... files) {
+      Collections.addAll(referencedDataFiles, files);
+      return this;
+    }
+
+    public Builder addReferencedDataFiles(Iterable<CharSequence> files) {
+      Iterables.addAll(referencedDataFiles, files);
+      return this;
+    }
+
+    public Builder addTransactionIds(Iterable<Long> transactionId) {
+      Iterables.addAll(transactionIds, transactionId);
+      return this;
+    }
+
+    public WriteResult build() {
+      org.apache.iceberg.io.WriteResult internal = org.apache.iceberg.io.WriteResult.builder()
+          .addDataFiles(dataFiles).addDeleteFiles(deleteFiles).addReferencedDataFiles(referencedDataFiles).build();
+      return new WriteResult(internal, transactionIds);
+    }
+  }
+}

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -21,10 +21,13 @@ package com.netease.arctic.flink.write.hidden;
 import com.netease.arctic.data.ChangeAction;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.write.ArcticLogWriter;
 import com.netease.arctic.log.FormatVersion;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
+import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
@@ -38,11 +41,13 @@ import org.apache.iceberg.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Properties;
 
+import static com.netease.arctic.flink.util.ArcticUtils.getMaxCommittedTransactionId;
 import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -56,6 +61,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
   public static final Logger LOG = LoggerFactory.getLogger(AbstractHiddenLogWriter.class);
 
   private static final long serialVersionUID = 1L;
+  public static final long EPIC_NO_INIT = 0L;
   private int subtaskId;
   private transient ListState<String> hiddenLogJobIdentifyState;
   private transient ListState<Integer> parallelismState;
@@ -76,8 +82,11 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
 
   protected FormatVersion logVersion = FormatVersion.FORMAT_VERSION_V1;
   protected byte[] jobIdentify;
-  // start from 1L, epicNo is similar to checkpoint id.
-  protected long epicNo = 1L;
+  // store transactionId
+  protected long epicNo = EPIC_NO_INIT;
+  @Nullable
+  protected ArcticTableLoader tableLoader;
+  protected transient ArcticTable table;
 
   protected transient LogData<RowData> logFlip;
 
@@ -88,7 +97,8 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
+      ShuffleHelper helper,
+      @Nullable ArcticTableLoader tableLoader) {
     this.schema = schema;
     this.producerConfig = checkNotNull(producerConfig);
     this.topic = checkNotNull(topic);
@@ -96,11 +106,15 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
     this.fieldGetterFactory = fieldGetterFactory;
     this.jobIdentify = jobId;
     this.helper = helper;
+    this.tableLoader = tableLoader;
   }
 
   @Override
   public void initializeState(StateInitializationContext context) throws Exception {
     super.initializeState(context);
+    if (tableLoader != null) {
+      table = ArcticUtils.loadArcticTable(tableLoader);
+    }
     subtaskId = getRuntimeContext().getIndexOfThisSubtask();
 
     hiddenLogJobIdentifyState =
@@ -131,31 +145,27 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
                 helper));
     int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
 
+    // send flip in init for all task
+    epicNo = getCommittedEpicNo(context, parallelism);
+
     if (context.isRestored() && parallelismSame(parallelism)) {
-      ckpComplete = context.getRestoredCheckpointId().getAsLong();
-
       jobIdentify = hiddenLogJobIdentifyState.get().iterator().next().getBytes(StandardCharsets.UTF_8);
-
-      epicNo = ckpComplete;
-
-      logFlip = new LogRecordV1(
-          logVersion,
-          jobIdentify,
-          epicNo,
-          true,
-          ChangeAction.INSERT,
-          new GenericRowData(0)
-      );
-      // signal flip topic
-      shouldCheckFlipSent = true;
-      flipSentSucceed = flipCommitter.commit(subtaskId, logFlip);
-      // after send flip, epicNo + 1 The epicNo of the data sent by the subsequent processElement()
-      // method will be 1 larger than the flip.epicNo.
-      epicNo++;
     } else {
       hiddenLogJobIdentifyState.clear();
       hiddenLogJobIdentifyState.add(new String(jobIdentify, 0, jobIdentify.length, StandardCharsets.UTF_8));
     }
+
+    logFlip = new LogRecordV1(
+        logVersion,
+        jobIdentify,
+        epicNo,
+        true,
+        ChangeAction.INSERT,
+        new GenericRowData(0)
+    );
+    // signal flip topic
+    shouldCheckFlipSent = true;
+    flipSentSucceed = flipCommitter.commit(subtaskId, logFlip);
 
     logDataJsonSerialization = new LogDataJsonSerialization<>(
         checkNotNull(schema),
@@ -176,6 +186,31 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
         subtaskId,
         context.isRestored(),
         ckpComplete);
+
+    if (isLogOnly()) {
+      epicNo++;
+    }
+  }
+
+  public boolean isLogOnly() {
+    return table == null;
+  }
+
+  public long getCommittedEpicNo(StateInitializationContext context, int parallelism) throws Exception {
+    if (isLogOnly()) {
+      // for the case which only write into log.
+      if (context.isRestored() && parallelismSame(parallelism)) {
+        ckpComplete = context.getRestoredCheckpointId().getAsLong();
+        return ckpComplete;
+      }
+      return EPIC_NO_INIT;
+    }
+    return getMaxCommittedTransactionId(table, new String(jobIdentify)).orElse(EPIC_NO_INIT);
+  }
+
+  @Override
+  public void setTransactionId(Long transactionId) {
+    this.epicNo = transactionId;
   }
 
   private boolean parallelismSame(int parallelism) throws Exception {
@@ -236,7 +271,6 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
         "prepareSnapshotPreBarrier subtaskId={}, checkpointId={}.",
         subtaskId,
         checkpointId);
-
   }
 
   @Override
@@ -247,7 +281,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
         "snapshotState subtaskId={}, checkpointId={}.",
         subtaskId,
         context.getCheckpointId());
-    epicNo++;
+    epicNo = context.getCheckpointId() + 1;
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
@@ -20,6 +20,7 @@ package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.log.LogData;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
@@ -42,8 +43,9 @@ public class HiddenLogWriter extends AbstractHiddenLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
-    super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
+      ShuffleHelper helper,
+      ArcticTableLoader tableLoader) {
+    super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper, tableLoader);
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
@@ -44,8 +44,8 @@ public class DeltaManifests {
     this(dataManifest, deleteManifest, referencedDataFiles, EMPTY_TRANSACTION);
   }
 
-  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles
-      , List<Long> transactionIds) {
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles,
+                 List<Long> transactionIds) {
     Preconditions.checkNotNull(referencedDataFiles, "Referenced data files shouldn't be null.");
 
     this.dataManifest = dataManifest;

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DeltaManifests {
+
+  private static final CharSequence[] EMPTY_REF_DATA_FILES = new CharSequence[0];
+  public static final List<Long> EMPTY_TRANSACTION = Collections.emptyList();
+
+  private final ManifestFile dataManifest;
+  private final ManifestFile deleteManifest;
+  private final CharSequence[] referencedDataFiles;
+  private final List<Long> transactionIds;
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest) {
+    this(dataManifest, deleteManifest, EMPTY_REF_DATA_FILES);
+  }
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles) {
+    this(dataManifest, deleteManifest, referencedDataFiles, EMPTY_TRANSACTION);
+  }
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles
+      , List<Long> transactionIds) {
+    Preconditions.checkNotNull(referencedDataFiles, "Referenced data files shouldn't be null.");
+
+    this.dataManifest = dataManifest;
+    this.deleteManifest = deleteManifest;
+    this.referencedDataFiles = referencedDataFiles;
+    this.transactionIds = transactionIds;
+  }
+
+  ManifestFile dataManifest() {
+    return dataManifest;
+  }
+
+  ManifestFile deleteManifest() {
+    return deleteManifest;
+  }
+
+  CharSequence[] referencedDataFiles() {
+    return referencedDataFiles;
+  }
+
+  public List<Long> getTransactionIds() {
+    return transactionIds;
+  }
+
+  List<ManifestFile> manifests() {
+    List<ManifestFile> manifests = Lists.newArrayListWithCapacity(2);
+    if (dataManifest != null) {
+      manifests.add(dataManifest);
+    }
+
+    if (deleteManifest != null) {
+      manifests.add(deleteManifest);
+    }
+
+    return manifests;
+  }
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifestsSerializer.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifestsSerializer.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeltaManifestsSerializer implements SimpleVersionedSerializer<DeltaManifests> {
+  private static final int VERSION_1 = 1;
+  private static final int VERSION_2 = 2;
+  private static final int VERSION_3 = 3;
+  private static final byte[] EMPTY_BINARY = new byte[0];
+
+  static final DeltaManifestsSerializer INSTANCE = new DeltaManifestsSerializer();
+
+  @Override
+  public int getVersion() {
+    return VERSION_3;
+  }
+
+  @Override
+  public byte[] serialize(DeltaManifests deltaManifests) throws IOException {
+    Preconditions.checkNotNull(deltaManifests, "DeltaManifests to be serialized should not be null");
+
+    ByteArrayOutputStream binaryOut = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(binaryOut);
+
+    byte[] dataManifestBinary = EMPTY_BINARY;
+    if (deltaManifests.dataManifest() != null) {
+      dataManifestBinary = ManifestFiles.encode(deltaManifests.dataManifest());
+    }
+
+    out.writeInt(dataManifestBinary.length);
+    out.write(dataManifestBinary);
+
+    byte[] deleteManifestBinary = EMPTY_BINARY;
+    if (deltaManifests.deleteManifest() != null) {
+      deleteManifestBinary = ManifestFiles.encode(deltaManifests.deleteManifest());
+    }
+
+    out.writeInt(deleteManifestBinary.length);
+    out.write(deleteManifestBinary);
+
+    CharSequence[] referencedDataFiles = deltaManifests.referencedDataFiles();
+    out.writeInt(referencedDataFiles.length);
+    for (int i = 0; i < referencedDataFiles.length; i++) {
+      out.writeUTF(referencedDataFiles[i].toString());
+    }
+
+    List<Long> txs = deltaManifests.getTransactionIds();
+    out.writeInt(txs.size());
+    for (Long tx : txs) {
+      out.writeLong(tx);
+    }
+    return binaryOut.toByteArray();
+  }
+
+  @Override
+  public DeltaManifests deserialize(int version, byte[] serialized) throws IOException {
+    if (version == VERSION_1) {
+      return deserializeV1(serialized);
+    } else if (version == VERSION_2) {
+      return deserializeV2(serialized);
+    } else if (version == VERSION_3) {
+      return deserializeV3(serialized);
+    } else {
+      throw new RuntimeException("Unknown serialize version: " + version);
+    }
+  }
+
+  private DeltaManifests deserializeV1(byte[] serialized) throws IOException {
+    return new DeltaManifests(ManifestFiles.decode(serialized), null);
+  }
+
+  private DeltaManifests deserializeV2(byte[] serialized) throws IOException {
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    ByteArrayInputStream binaryIn = new ByteArrayInputStream(serialized);
+    DataInputStream in = new DataInputStream(binaryIn);
+
+    int dataManifestSize = in.readInt();
+    if (dataManifestSize > 0) {
+      byte[] dataManifestBinary = new byte[dataManifestSize];
+      Preconditions.checkState(in.read(dataManifestBinary) == dataManifestSize);
+
+      dataManifest = ManifestFiles.decode(dataManifestBinary);
+    }
+
+    int deleteManifestSize = in.readInt();
+    if (deleteManifestSize > 0) {
+      byte[] deleteManifestBinary = new byte[deleteManifestSize];
+      Preconditions.checkState(in.read(deleteManifestBinary) == deleteManifestSize);
+
+      deleteManifest = ManifestFiles.decode(deleteManifestBinary);
+    }
+
+    int referenceDataFileNum = in.readInt();
+    CharSequence[] referencedDataFiles = new CharSequence[referenceDataFileNum];
+    for (int i = 0; i < referenceDataFileNum; i++) {
+      referencedDataFiles[i] = in.readUTF();
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, referencedDataFiles);
+  }
+
+  private DeltaManifests deserializeV3(byte[] serialized) throws IOException {
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    ByteArrayInputStream binaryIn = new ByteArrayInputStream(serialized);
+    DataInputStream in = new DataInputStream(binaryIn);
+
+    int dataManifestSize = in.readInt();
+    if (dataManifestSize > 0) {
+      byte[] dataManifestBinary = new byte[dataManifestSize];
+      Preconditions.checkState(in.read(dataManifestBinary) == dataManifestSize);
+
+      dataManifest = ManifestFiles.decode(dataManifestBinary);
+    }
+
+    int deleteManifestSize = in.readInt();
+    if (deleteManifestSize > 0) {
+      byte[] deleteManifestBinary = new byte[deleteManifestSize];
+      Preconditions.checkState(in.read(deleteManifestBinary) == deleteManifestSize);
+
+      deleteManifest = ManifestFiles.decode(deleteManifestBinary);
+    }
+
+    int referenceDataFileNum = in.readInt();
+    CharSequence[] referencedDataFiles = new CharSequence[referenceDataFileNum];
+    for (int i = 0; i < referenceDataFileNum; i++) {
+      referencedDataFiles[i] = in.readUTF();
+    }
+
+    int txNum = in.readInt();
+    List<Long> txs = new ArrayList<>(txNum);
+    for (int i = 0; i < txNum; i++) {
+      txs.add(in.readLong());
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, referencedDataFiles, txs);
+  }
+
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -62,10 +62,11 @@ class FlinkManifestUtil {
     }
   }
 
-  static ManifestOutputFileFactory createOutputFileFactory(Table table, String flinkJobId, int subTaskId,
-                                                           long attemptNumber) {
+  static ManifestOutputFileFactory createOutputFileFactory(Table table, String flinkJobId, String operatorUniqueId,
+                                                           int subTaskId, long attemptNumber) {
     TableOperations ops = ((HasTableOperations) table).operations();
-    return new ManifestOutputFileFactory(ops, table.io(), table.properties(), flinkJobId, subTaskId, attemptNumber);
+    return new ManifestOutputFileFactory(ops, table.io(), table.properties(), flinkJobId, operatorUniqueId,
+        subTaskId, attemptNumber);
   }
 
   static DeltaManifests writeCompletedFiles(WriteResult result,

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import com.netease.arctic.flink.write.WriteResult;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+class FlinkManifestUtil {
+  private static final int FORMAT_V2 = 2;
+  private static final Long DUMMY_SNAPSHOT_ID = 0L;
+
+  private FlinkManifestUtil() {
+  }
+
+  static ManifestFile writeDataFiles(OutputFile outputFile, PartitionSpec spec, List<DataFile> dataFiles)
+      throws IOException {
+    ManifestWriter<DataFile> writer = ManifestFiles.write(FORMAT_V2, spec, outputFile, DUMMY_SNAPSHOT_ID);
+
+    try (ManifestWriter<DataFile> closeableWriter = writer) {
+      closeableWriter.addAll(dataFiles);
+    }
+
+    return writer.toManifestFile();
+  }
+
+  static List<DataFile> readDataFiles(ManifestFile manifestFile, FileIO io) throws IOException {
+    try (CloseableIterable<DataFile> dataFiles = ManifestFiles.read(manifestFile, io)) {
+      return Lists.newArrayList(dataFiles);
+    }
+  }
+
+  static ManifestOutputFileFactory createOutputFileFactory(Table table, String flinkJobId, int subTaskId,
+                                                           long attemptNumber) {
+    TableOperations ops = ((HasTableOperations) table).operations();
+    return new ManifestOutputFileFactory(ops, table.io(), table.properties(), flinkJobId, subTaskId, attemptNumber);
+  }
+
+  static DeltaManifests writeCompletedFiles(WriteResult result,
+                                            Supplier<OutputFile> outputFileSupplier,
+                                            PartitionSpec spec) throws IOException {
+
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    // Write the completed data files into a newly created data manifest file.
+    if (result.dataFiles() != null && result.dataFiles().length > 0) {
+      dataManifest = writeDataFiles(outputFileSupplier.get(), spec, Lists.newArrayList(result.dataFiles()));
+    }
+
+    // Write the completed delete files into a newly created delete manifest file.
+    if (result.deleteFiles() != null && result.deleteFiles().length > 0) {
+      OutputFile deleteManifestFile = outputFileSupplier.get();
+
+      ManifestWriter<DeleteFile> deleteManifestWriter = ManifestFiles.writeDeleteManifest(FORMAT_V2, spec,
+          deleteManifestFile, DUMMY_SNAPSHOT_ID);
+      try (ManifestWriter<DeleteFile> writer = deleteManifestWriter) {
+        for (DeleteFile deleteFile : result.deleteFiles()) {
+          writer.add(deleteFile);
+        }
+      }
+
+      deleteManifest = deleteManifestWriter.toManifestFile();
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, result.referencedDataFiles(), result.getTransactionIds());
+  }
+
+  static WriteResult readCompletedFiles(DeltaManifests deltaManifests, FileIO io) throws IOException {
+    WriteResult.Builder builder = WriteResult.builder();
+
+    // Read the completed data files from persisted data manifest file.
+    if (deltaManifests.dataManifest() != null) {
+      builder.addDataFiles(readDataFiles(deltaManifests.dataManifest(), io));
+    }
+
+    // Read the completed delete files from persisted delete manifests file.
+    if (deltaManifests.deleteManifest() != null) {
+      try (CloseableIterable<DeleteFile> deleteFiles = ManifestFiles
+          .readDeleteManifest(deltaManifests.deleteManifest(), io, null)) {
+        builder.addDeleteFiles(deleteFiles);
+      }
+    }
+
+    return builder.addReferencedDataFiles(deltaManifests.referencedDataFiles())
+        .addTransactionIds(deltaManifests.getTransactionIds())
+        .build();
+  }
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -141,7 +141,9 @@ public class IcebergFilesCommitter extends AbstractStreamOperator<Void>
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     int attemptId = getRuntimeContext().getAttemptNumber();
-    this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, subTaskId, attemptId);
+    String operatorUniqueID = getRuntimeContext().getOperatorUniqueID();
+    this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, operatorUniqueID,
+        subTaskId, attemptId);
     this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
 
     this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -362,13 +362,6 @@ public class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     return SimpleVersionedSerialization.writeVersionAndSerialize(DeltaManifestsSerializer.INSTANCE, deltaManifests);
   }
 
-  @Override
-  public void dispose() throws Exception {
-    if (tableLoader != null) {
-      tableLoader.close();
-    }
-  }
-
   private static ListStateDescriptor<SortedMap<Long, byte[]>> buildStateDescriptor() {
     Comparator<Long> longComparator = Comparators.forType(Types.LongType.get());
     // Construct a SortedMapTypeInfo.

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -1,0 +1,401 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import com.netease.arctic.flink.write.WriteResult;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.runtime.typeutils.SortedMapTypeInfo;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ReplacePartitions;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+
+/**
+ * Add
+ * <p>
+ * Note: Copy from Iceberg
+ */
+public class IcebergFilesCommitter extends AbstractStreamOperator<Void>
+    implements OneInputStreamOperator<WriteResult, Void>, BoundedOneInput {
+
+  private static final long serialVersionUID = 1L;
+  private static final long INITIAL_CHECKPOINT_ID = -1L;
+  private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergFilesCommitter.class);
+  public static final String FLINK_JOB_ID = "flink.job-id";
+  public static final String TRANSACTION_ID = "transaction-id";
+  public static final String TRANSACTION_ID_SEPARATOR = ",";
+
+  // The max checkpoint id we've committed to iceberg table. As the flink's checkpoint is always increasing, so we could
+  // correctly commit all the data files whose checkpoint id is greater than the max committed one to iceberg table, for
+  // avoiding committing the same data files twice. This id will be attached to iceberg's meta when committing the
+  // iceberg transaction.
+  private static final String MAX_COMMITTED_CHECKPOINT_ID = "flink.max-committed-checkpoint-id";
+  static final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
+
+  // TableLoader to load iceberg table lazily.
+  private final TableLoader tableLoader;
+  private final boolean replacePartitions;
+
+  // A sorted map to maintain the completed data files for each pending checkpointId (which have not been committed
+  // to iceberg table). We need a sorted map here because there's possible that few checkpoints snapshot failed, for
+  // example: the 1st checkpoint have 2 data files <1, <file0, file1>>, the 2st checkpoint have 1 data files
+  // <2, <file3>>. Snapshot for checkpoint#1 interrupted because of network/disk failure etc, while we don't expect
+  // any data loss in iceberg table. So we keep the finished files <1, <file0, file1>> in memory and retry to commit
+  // iceberg table when the next checkpoint happen.
+  private final NavigableMap<Long, byte[]> dataFilesPerCheckpoint = Maps.newTreeMap();
+
+  // The completed files cache for current checkpoint. Once the snapshot barrier received, it will be flushed to the
+  // 'dataFilesPerCheckpoint'.
+  private final List<WriteResult> writeResultsOfCurrentCkpt = Lists.newArrayList();
+
+  // It will have an unique identifier for one job.
+  private transient String flinkJobId;
+  private transient Table table;
+  private transient ManifestOutputFileFactory manifestOutputFileFactory;
+  private transient long maxCommittedCheckpointId;
+  private transient int continuousEmptyCheckpoints;
+  private transient int maxContinuousEmptyCommits;
+  // There're two cases that we restore from flink checkpoints: the first case is restoring from snapshot created by the
+  // same flink job; another case is restoring from snapshot created by another different job. For the second case, we
+  // need to maintain the old flink job's id in flink state backend to find the max-committed-checkpoint-id when
+  // traversing iceberg table's snapshots.
+  private static final ListStateDescriptor<String> JOB_ID_DESCRIPTOR = new ListStateDescriptor<>(
+      "iceberg-flink-job-id", BasicTypeInfo.STRING_TYPE_INFO);
+  private transient ListState<String> jobIdState;
+  // All pending checkpoints states for this function.
+  private static final ListStateDescriptor<SortedMap<Long, byte[]>> STATE_DESCRIPTOR = buildStateDescriptor();
+  private transient ListState<SortedMap<Long, byte[]>> checkpointsState;
+
+  IcebergFilesCommitter(TableLoader tableLoader, boolean replacePartitions) {
+    this.tableLoader = tableLoader;
+    this.replacePartitions = replacePartitions;
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    this.flinkJobId = getContainingTask().getEnvironment().getJobID().toString();
+
+    // Open the table loader and load the table.
+    this.tableLoader.open();
+    this.table = tableLoader.loadTable();
+
+    maxContinuousEmptyCommits = PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
+    Preconditions.checkArgument(maxContinuousEmptyCommits > 0,
+        MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+
+    int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
+    int attemptId = getRuntimeContext().getAttemptNumber();
+    this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, subTaskId, attemptId);
+    this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+
+    this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);
+    this.jobIdState = context.getOperatorStateStore().getListState(JOB_ID_DESCRIPTOR);
+    if (context.isRestored()) {
+      String restoredFlinkJobId = jobIdState.get().iterator().next();
+      Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),
+          "Flink job id parsed from checkpoint snapshot shouldn't be null or empty");
+
+      // Since flink's checkpoint id will start from the max-committed-checkpoint-id + 1 in the new flink job even if
+      // it's restored from a snapshot created by another different flink job, so it's safe to assign the max committed
+      // checkpoint id from restored flink job to the current flink job.
+      this.maxCommittedCheckpointId = getMaxCommittedCheckpointId(table, restoredFlinkJobId);
+
+      NavigableMap<Long, byte[]> uncommittedDataFiles = Maps
+          .newTreeMap(checkpointsState.get().iterator().next())
+          .tailMap(maxCommittedCheckpointId, false);
+      if (!uncommittedDataFiles.isEmpty()) {
+        // Committed all uncommitted data files from the old flink job to iceberg table.
+        long maxUncommittedCheckpointId = uncommittedDataFiles.lastKey();
+        commitUpToCheckpoint(uncommittedDataFiles, restoredFlinkJobId, maxUncommittedCheckpointId);
+      }
+    }
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    long checkpointId = context.getCheckpointId();
+    LOG.info("Start to flush snapshot state to state backend, table: {}, checkpointId: {}", table, checkpointId);
+
+    // Update the checkpoint state.
+    dataFilesPerCheckpoint.put(checkpointId, writeToManifest(checkpointId));
+    // Reset the snapshot state to the latest state.
+    checkpointsState.clear();
+    checkpointsState.add(dataFilesPerCheckpoint);
+
+    jobIdState.clear();
+    jobIdState.add(flinkJobId);
+
+    // Clear the local buffer for current checkpoint.
+    writeResultsOfCurrentCkpt.clear();
+  }
+
+  @Override
+  public void notifyCheckpointComplete(long checkpointId) throws Exception {
+    super.notifyCheckpointComplete(checkpointId);
+    // It's possible that we have the following events:
+    //   1. snapshotState(ckpId);
+    //   2. snapshotState(ckpId+1);
+    //   3. notifyCheckpointComplete(ckpId+1);
+    //   4. notifyCheckpointComplete(ckpId);
+    // For step#4, we don't need to commit iceberg table again because in step#3 we've committed all the files,
+    // Besides, we need to maintain the max-committed-checkpoint-id to be increasing.
+    if (checkpointId > maxCommittedCheckpointId) {
+      commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, checkpointId);
+      this.maxCommittedCheckpointId = checkpointId;
+    }
+  }
+
+  private void commitUpToCheckpoint(NavigableMap<Long, byte[]> deltaManifestsMap,
+                                    String newFlinkJobId,
+                                    long checkpointId) throws IOException {
+    NavigableMap<Long, byte[]> pendingMap = deltaManifestsMap.headMap(checkpointId, true);
+    List<ManifestFile> manifests = Lists.newArrayList();
+    NavigableMap<Long, WriteResult> pendingResults = Maps.newTreeMap();
+    for (Map.Entry<Long, byte[]> e : pendingMap.entrySet()) {
+      if (Arrays.equals(EMPTY_MANIFEST_DATA, e.getValue())) {
+        // Skip the empty flink manifest.
+        continue;
+      }
+
+      DeltaManifests deltaManifests = SimpleVersionedSerialization
+          .readVersionAndDeSerialize(DeltaManifestsSerializer.INSTANCE, e.getValue());
+      pendingResults.put(e.getKey(), FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io()));
+      manifests.addAll(deltaManifests.manifests());
+    }
+
+    int totalFiles = pendingResults.values().stream()
+        .mapToInt(r -> r.dataFiles().length + r.deleteFiles().length).sum();
+    continuousEmptyCheckpoints = totalFiles == 0 ? continuousEmptyCheckpoints + 1 : 0;
+    if (totalFiles != 0 || continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0) {
+      if (replacePartitions) {
+        replacePartitions(pendingResults, newFlinkJobId, checkpointId);
+      } else {
+        commitDeltaTxn(pendingResults, newFlinkJobId, checkpointId);
+      }
+      continuousEmptyCheckpoints = 0;
+    }
+    pendingMap.clear();
+
+    // Delete the committed manifests.
+    for (ManifestFile manifest : manifests) {
+      try {
+        table.io().deleteFile(manifest.path());
+      } catch (Exception e) {
+        // The flink manifests cleaning failure shouldn't abort the completed checkpoint.
+        String details = MoreObjects.toStringHelper(this)
+            .add("flinkJobId", newFlinkJobId)
+            .add("checkpointId", checkpointId)
+            .add("manifestPath", manifest.path())
+            .toString();
+        LOG.warn("The iceberg transaction has been committed, but we failed to clean the temporary flink manifests: {}",
+            details, e);
+      }
+    }
+  }
+
+  private void replacePartitions(NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId,
+                                 long checkpointId) {
+    // Partition overwrite does not support delete files.
+    int deleteFilesNum = pendingResults.values().stream().mapToInt(r -> r.deleteFiles().length).sum();
+    Preconditions.checkState(deleteFilesNum == 0, "Cannot overwrite partitions with delete files.");
+
+    // Commit the overwrite transaction.
+    ReplacePartitions dynamicOverwrite = table.newReplacePartitions();
+
+    int numFiles = 0;
+    List<Long> transactionIds = new ArrayList<>(pendingResults.values().size());
+    for (WriteResult result : pendingResults.values()) {
+      Preconditions.checkState(result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+
+      transactionIds.addAll(result.getTransactionIds());
+      numFiles += result.dataFiles().length;
+      Arrays.stream(result.dataFiles()).forEach(dynamicOverwrite::addFile);
+    }
+
+    commitOperation(dynamicOverwrite, numFiles, 0, "dynamic partition overwrite", newFlinkJobId,
+        checkpointId, transactionIds);
+  }
+
+  private void commitDeltaTxn(NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId, long checkpointId) {
+    int deleteFilesNum = pendingResults.values().stream().mapToInt(r -> r.deleteFiles().length).sum();
+
+    if (deleteFilesNum == 0) {
+      // To be compatible with iceberg format V1.
+      AppendFiles appendFiles = table.newAppend();
+
+      int numFiles = 0;
+      List<Long> transactionIds = new ArrayList<>(pendingResults.values().size());
+      for (WriteResult result : pendingResults.values()) {
+        Preconditions.checkState(result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+
+        transactionIds.addAll(result.getTransactionIds());
+        numFiles += result.dataFiles().length;
+        Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+      }
+
+      commitOperation(appendFiles, numFiles, 0, "append", newFlinkJobId, checkpointId,
+          transactionIds);
+    } else {
+      // To be compatible with iceberg format V2.
+      for (Map.Entry<Long, WriteResult> e : pendingResults.entrySet()) {
+        // We don't commit the merged result into a single transaction because for the sequential transaction txn1 and
+        // txn2, the equality-delete files of txn2 are required to be applied to data files from txn1. Committing the
+        // merged one will lead to the incorrect delete semantic.
+        WriteResult result = e.getValue();
+        RowDelta rowDelta = table.newRowDelta()
+            .validateDataFilesExist(ImmutableList.copyOf(result.referencedDataFiles()))
+            .validateDeletedFiles();
+
+        int numDataFiles = result.dataFiles().length;
+        Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
+
+        int numDeleteFiles = result.deleteFiles().length;
+        Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
+
+        commitOperation(rowDelta, numDataFiles, numDeleteFiles, "rowDelta", newFlinkJobId, e.getKey(),
+            result.getTransactionIds());
+      }
+    }
+  }
+
+  private void commitOperation(SnapshotUpdate<?> operation, int numDataFiles, int numDeleteFiles, String description,
+                               String newFlinkJobId, long checkpointId, List<Long> transactionIds) {
+    LOG.info("Committing {} with {} data files and {} delete files to table {}. transactionIds {}", description,
+        numDataFiles, numDeleteFiles, table, transactionIds);
+    operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));
+    operation.set(FLINK_JOB_ID, newFlinkJobId);
+    if (!CollectionUtil.isNullOrEmpty(transactionIds)) {
+      operation.set(TRANSACTION_ID, StringUtils.join(transactionIds, ""));
+    }
+
+    long start = System.currentTimeMillis();
+    operation.commit(); // abort is automatically called if this fails.
+    long duration = System.currentTimeMillis() - start;
+    LOG.info("Committed in {} ms", duration);
+  }
+
+  @Override
+  public void processElement(StreamRecord<WriteResult> element) {
+    this.writeResultsOfCurrentCkpt.add(element.getValue());
+  }
+
+  @Override
+  public void endInput() throws IOException {
+    // Flush the buffered data files into 'dataFilesPerCheckpoint' firstly.
+    long currentCheckpointId = Long.MAX_VALUE;
+    dataFilesPerCheckpoint.put(currentCheckpointId, writeToManifest(currentCheckpointId));
+    writeResultsOfCurrentCkpt.clear();
+
+    commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, currentCheckpointId);
+  }
+
+  /**
+   * Write all the complete data files to a newly created manifest file and return the manifest's avro serialized bytes.
+   */
+  private byte[] writeToManifest(long checkpointId) throws IOException {
+    if (writeResultsOfCurrentCkpt.isEmpty()) {
+      return EMPTY_MANIFEST_DATA;
+    }
+
+    WriteResult result = WriteResult.builder().addAll(writeResultsOfCurrentCkpt).build();
+
+    DeltaManifests deltaManifests = FlinkManifestUtil.writeCompletedFiles(result,
+        () -> manifestOutputFileFactory.create(checkpointId), table.spec());
+
+    return SimpleVersionedSerialization.writeVersionAndSerialize(DeltaManifestsSerializer.INSTANCE, deltaManifests);
+  }
+
+  @Override
+  public void dispose() throws Exception {
+    if (tableLoader != null) {
+      tableLoader.close();
+    }
+  }
+
+  private static ListStateDescriptor<SortedMap<Long, byte[]>> buildStateDescriptor() {
+    Comparator<Long> longComparator = Comparators.forType(Types.LongType.get());
+    // Construct a SortedMapTypeInfo.
+    SortedMapTypeInfo<Long, byte[]> sortedMapTypeInfo = new SortedMapTypeInfo<>(
+        BasicTypeInfo.LONG_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO, longComparator
+    );
+    return new ListStateDescriptor<>("iceberg-files-committer-state", sortedMapTypeInfo);
+  }
+
+  static long getMaxCommittedCheckpointId(Table table, String flinkJobId) {
+    Snapshot snapshot = table.currentSnapshot();
+    long lastCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+
+    while (snapshot != null) {
+      Map<String, String> summary = snapshot.summary();
+      String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
+      if (flinkJobId.equals(snapshotFlinkJobId)) {
+        String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
+        if (value != null) {
+          lastCommittedCheckpointId = Long.parseLong(value);
+          break;
+        }
+      }
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
+    }
+
+    return lastCommittedCheckpointId;
+  }
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/kafka/testutils/KafkaTestBase.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/kafka/testutils/KafkaTestBase.java
@@ -102,8 +102,16 @@ public class KafkaTestBase {
 
   public void startClusters(boolean secureMode)
       throws Exception {
+    Properties props = new Properties();
+    props.put("offsets.topic.num.partitions", "3");
+    props.put("offsets.topic.segment.bytes", "1048576");
+    props.put("transaction.state.log.num.partitions", "3");
+    props.put("transaction.state.log.segment.bytes", "1048576");
+    props.put("metadata.log.max.record.bytes.between.snapshots", "1048576");
+
     startClusters(
         KafkaTestEnvironment.createConfig()
+            .setKafkaServerProperties(props)
             .setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
             .setSecureMode(secureMode));
   }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -69,7 +69,6 @@ import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -162,14 +161,12 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     assertArrayEquals(excepts(), actualResult);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStaticJobManagerFailover() throws Exception {
     testArcticSource(FailoverType.JM);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStaticTaskManagerFailover() throws Exception {
     testArcticSource(FailoverType.TM);
   }
@@ -256,7 +253,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     Assert.assertEquals(Long.MAX_VALUE, WatermarkAwareFailWrapper.getWatermarkAfterFailover());
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSource() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSource(true);
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -354,14 +351,12 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceJobManagerFailover() throws Exception {
     testArcticContinuousSource(FailoverType.JM);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceTaskManagerFailover() throws Exception {
     testArcticContinuousSource(FailoverType.TM);
   }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -137,7 +137,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     testCatalog.dropTable(FAIL_TABLE_ID, true);
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStatic() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSource(false);
 

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileCommitterTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileCommitterTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.types.RowKind;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.WriteResult;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.flink.util.TestGlobalAggregateManager;
@@ -34,7 +35,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.sink.RowDataTaskWriterFactory;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.io.TaskWriter;
-import org.apache.iceberg.io.WriteResult;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,9 +90,12 @@ public class ArcticFileWriterTest extends FlinkTestBase {
         false,
         (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType(),
         tableLoader);
+
+    ArcticWriter arcticWriter = new ArcticWriter(null, streamWriter, tableLoader,
+        MetricsGenerator.empty(false));
     OneInputStreamOperatorInternTest<RowData, WriteResult> harness =
         new OneInputStreamOperatorInternTest<>(
-            streamWriter, 1, 1, 0, restoredCheckpointId,
+            arcticWriter, 1, 1, 0, restoredCheckpointId,
             new TestGlobalAggregateManager());
 
     return harness;
@@ -113,15 +116,12 @@ public class ArcticFileWriterTest extends FlinkTestBase {
     try (
         OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = createArcticStreamWriter(
             tableLoader)) {
-      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
-      Assert.assertNotNull(fileWriter.getWriter());
       // The first checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
 
       testHarness.prepareSnapshotPreBarrier(checkpointId);
-      Assert.assertNull(fileWriter.getWriter());
       Assert.assertEquals(1, testHarness.extractOutputValues().size());
       Assert.assertEquals(3, testHarness.extractOutputValues().get(0).dataFiles().length);
 
@@ -129,7 +129,6 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
       // The second checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-12T10:10:11.0"), 1);
-      Assert.assertNotNull(fileWriter.getWriter());
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-12T10:10:11.0"), 1);
 
@@ -177,7 +176,10 @@ public class ArcticFileWriterTest extends FlinkTestBase {
       testHarness.initializeState(state);
       testHarness.open();
 
-      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
+      testHarness.prepareSnapshotPreBarrier(checkpointId + 1);
+      testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
+
+      ArcticWriter fileWriter = (ArcticWriter) testHarness.getOneInputOperator();
       Assert.assertEquals(checkpointId + 1, fileWriter.getCheckpointId());
     }
   }
@@ -329,7 +331,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
       // The second checkpoint
       testHarness.prepareSnapshotPreBarrier(checkpointId);
-      Assert.assertEquals(excepted, testHarness.extractOutputValues().size());
+      Assert.assertEquals(excepted + (submitEmptySnapshots ? 1 : 0), testHarness.extractOutputValues().size());
     }
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -37,23 +37,31 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.sink.IcebergFilesCommitter;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION_DEFAULT;
+import static org.apache.iceberg.flink.sink.IcebergFilesCommitter.FLINK_JOB_ID;
+import static org.apache.iceberg.flink.sink.IcebergFilesCommitter.TRANSACTION_ID;
 
 /**
  * An util that loads arctic table, build arctic log writer and so on.
@@ -167,7 +175,8 @@ public class ArcticUtils {
           new HiddenKafkaFactory<>(),
           LogRecordV1.fieldGetterFactory,
           IdGenerator.generateUpstreamId(),
-          helper);
+          helper,
+          tableLoader);
     }
     throw new UnsupportedOperationException("don't support log version '" + version +
         "'. only support 'v1' or empty");
@@ -197,6 +206,79 @@ public class ArcticUtils {
         String.format(
             "Can't remove arctic meta column from this RowData %s",
             rowData.getClass().getSimpleName()));
+  }
+
+  public static Optional<Long> getMaxCommittedTransactionId(@Nullable ArcticTable table, String jobId) {
+    if (table == null) {
+      return Optional.empty();
+    }
+    if (table.isUnkeyedTable()) {
+      return getMaxCommittedTransactionIdFromTable(table.asUnkeyedTable(), jobId);
+    }
+    return getMaxCommittedTransactionIdFromTable(table.asKeyedTable().changeTable(), jobId);
+  }
+
+  public static Optional<Long> getMaxCommittedTransactionIdFromTable(Table table, String jobId) {
+    Snapshot snapshot = table.currentSnapshot();
+
+    while (snapshot != null) {
+      long crt = snapshot.snapshotId();
+      Map<String, String> summary = snapshot.summary();
+      String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
+
+
+      if (!jobId.equals(snapshotFlinkJobId)) {
+        continue;
+      }
+
+      String value = summary.get(TRANSACTION_ID);
+      if (value == null) {
+        continue;
+      }
+      String[] txs = value.split(IcebergFilesCommitter.TRANSACTION_ID_SEPARATOR);
+      long maxTx = Long.MIN_VALUE;
+      try {
+        for (String tx : txs) {
+          maxTx = Math.max(maxTx, Long.parseLong(tx));
+        }
+      } catch (Exception e) {
+        throw new IllegalStateException(String.format("there is invalid '%s' data in snapshot '%d', value: '%s'",
+            TRANSACTION_ID, crt, value));
+      }
+      return Optional.of(maxTx);
+    }
+
+    return Optional.empty();
+  }
+
+  public static boolean isTransactionCommitted(Table table, String jobId, String txId) {
+    Snapshot snapshot = table.currentSnapshot();
+
+    while (snapshot != null) {
+      Map<String, String> summary = snapshot.summary();
+      String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
+
+      if (!jobId.equals(snapshotFlinkJobId)) {
+        continue;
+      }
+
+      String value = summary.get(TRANSACTION_ID);
+      if (value == null) {
+        continue;
+      }
+      String[] txs = value.split(IcebergFilesCommitter.TRANSACTION_ID_SEPARATOR);
+      for (String tx : txs) {
+        if (Objects.equals(txId, tx.trim())) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -35,9 +35,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.io.TaskWriter;
-import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +49,7 @@ import java.util.stream.IntStream;
  * This is arctic table includes writing file data to un keyed table and keyed table.
  */
 public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
-    implements OneInputStreamOperator<RowData, WriteResult>, BoundedOneInput {
+    implements OneInputStreamOperator<RowData, WriteResult>, BoundedOneInput, TransactionIdAware {
 
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(ArcticFileWriter.class);
@@ -66,8 +65,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private transient org.apache.iceberg.io.TaskWriter<RowData> writer;
   private transient int subTaskId;
   private transient int attemptId;
-  private transient String jobId;
-  private transient long checkpointId = 0;
+  private transient Long transactionId;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
    * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
@@ -95,54 +93,29 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   @Override
   public void open() {
     this.attemptId = getRuntimeContext().getAttemptNumber();
-    this.jobId = getContainingTask().getEnvironment().getJobID().toString();
     table = ArcticUtils.loadArcticTable(tableLoader);
-
-    long mask = getMask(subTaskId);
-    initTaskWriterFactory(mask);
-
-    this.writer = table.io().doAs(taskWriterFactory::create);
+    setMask();
   }
 
-  @Override
-  public void initializeState(StateInitializationContext context) throws Exception {
-    super.initializeState(context);
-
-    this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
-
-    if (context.isRestored()) {
-      checkpointId = context.getRestoredCheckpointId().getAsLong();
-      // prepare for the writer init in open(). It is used for next ckpId.
-      checkpointId++;
+  private void setMask() {
+    if (!(taskWriterFactory instanceof ArcticRowDataTaskWriterFactory)) {
+      return;
     }
+    long mask = getMask(subTaskId);
+    ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setMask(mask);
   }
 
-  private void initTaskWriterFactory(Long mask) {
+  /**
+   * Reassign transaction id when processing the new file data to avoid the situation that there is no data
+   * written during the next checkpoint period.
+   * It should be invoked before taskWriterFactory#create
+   */
+  public void setTransactionId(Long transactionId) {
+    this.transactionId = transactionId;
     if (taskWriterFactory instanceof ArcticRowDataTaskWriterFactory) {
-      if (mask != null) {
-        ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setMask(mask);
-      }
-      ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setTransactionId(getTransactionId());
+      ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setTransactionId(transactionId);
     }
     taskWriterFactory.initialize(subTaskId, attemptId);
-  }
-
-  private Long getTransactionId() {
-    Long transaction;
-    if (table.isKeyedTable()) {
-      String signature = BaseEncoding.base16().encode((jobId + checkpointId).getBytes());
-      transaction = table.asKeyedTable().beginTransaction(signature);
-      LOG.info("table:{}, signature:{}, transactionId:{}. From jobId:{}, ckpId:{}", table.name(), signature,
-          transaction, jobId, checkpointId);
-    } else {
-      transaction = null;
-    }
-    return transaction;
-  }
-
-  @VisibleForTesting
-  public long getCheckpointId() {
-    return checkpointId;
   }
 
   private long getMask(int subTaskId) {
@@ -164,12 +137,11 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-    this.checkpointId = checkpointId;
-
     table.io().doAs(() -> {
       completeAndEmitFiles();
 
       this.writer = null;
+      this.transactionId = null;
       return null;
     });
   }
@@ -186,7 +158,9 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     // For bounded stream, it may don't enable the checkpoint mechanism so we'd better to emit the remaining
     // completed files to downstream before closing the writer so that we won't miss any of them.
     if (writer != null) {
-      emit(writer.complete());
+      emit(new WriteResult(writer.complete(), Lists.newArrayList(transactionId)));
+    } else {
+      emit(WriteResult.builder().build());
     }
   }
 
@@ -195,9 +169,6 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     RowData row = element.getValue();
     table.io().doAs(() -> {
       if (writer == null) {
-        // Reassign transaction id when processing the new file data to avoid the situation that there is no data
-        // written during the next checkpoint period.
-        initTaskWriterFactory(null);
         this.writer = taskWriterFactory.create();
       }
 
@@ -236,7 +207,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    *
    * @param writeResult the WriteResult to emit
    * @return true if the WriteResult should be emitted, or the WriteResult isn't empty,
-   *         false only if the WriteResult is empty and the submitEmptySnapshot is false.
+   * false only if the WriteResult is empty and the submitEmptySnapshot is false.
    */
   private boolean shouldEmit(WriteResult writeResult) {
     return submitEmptySnapshot || (writeResult != null &&

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticLogWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticLogWriter.java
@@ -27,5 +27,5 @@ import org.apache.flink.table.data.RowData;
  * This is a common abstract arctic log writer.
  */
 public abstract class ArcticLogWriter extends AbstractStreamOperator<RowData>
-    implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput {
+    implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput, TransactionIdAware {
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticRowDataTaskWriterFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticRowDataTaskWriterFactory.java
@@ -59,12 +59,8 @@ public class ArcticRowDataTaskWriterFactory implements TaskWriterFactory<RowData
 
   @Override
   public void initialize(int taskId, int attemptId) {
-    if (table.isKeyedTable()) {
-      Preconditions.checkNotNull(transactionId, "TransactionId should be set first. " +
-          "Invoke setTransactionId() before this method");
-    } else {
-      Preconditions.checkArgument(transactionId == null, "TransactionId should be null for unkeyed table.");
-    }
+    Preconditions.checkNotNull(transactionId, "TransactionId should be set first. " +
+        "Invoke setTransactionId() before this method");
     this.taskId = taskId;
     this.attemptId = attemptId;
   }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
@@ -19,6 +19,10 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.metric.MetricsGenerator;
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.table.ArcticTable;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;
@@ -37,6 +41,7 @@ import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 
 import java.util.Objects;
 
@@ -52,19 +57,45 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   private transient Meter meterSpeed;
 
+  private byte[] arcticJobId;
+  /**
+   * flink jobId
+   */
+  private transient String jobId;
+  private transient long checkpointId = 0;
+  private transient Long transactionId = null;
+  /**
+   * Load table in runtime, because that table's refresh method will be invoked in serialization.
+   * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
+   * if Arctic's table is KERBEROS enabled. It will cause ugi relevant exception when deploy to yarn cluster.
+   */
+  private transient ArcticTable table;
+
   private final AbstractStreamOperator fileWriter;
   private final ArcticLogWriter logWriter;
   private final MetricsGenerator metricsGenerator;
+  private final ArcticTableLoader tableLoader;
 
   private static final String INFLUXDB_TAG_NAME = "arctic_task_id";
 
-  public ArcticWriter(
-      ArcticLogWriter logWriter,
-      AbstractStreamOperator fileWriter,
-      MetricsGenerator metricsGenerator) {
+  public ArcticWriter(ArcticLogWriter logWriter,
+                      AbstractStreamOperator fileWriter,
+                      ArcticTableLoader tableLoader,
+                      MetricsGenerator metricsGenerator) {
     this.logWriter = logWriter;
     this.fileWriter = fileWriter;
+    this.tableLoader = tableLoader;
     this.metricsGenerator = metricsGenerator;
+  }
+
+  private Long getTransactionId() {
+    Long transaction;
+    String signature = BaseEncoding.base16().encode((jobId + checkpointId).getBytes());
+    transaction = table.beginTransaction(signature);
+    LOG.info("get new TransactionId. table:{}, signature:{}, transactionId:{}. From jobId:{}, ckpId:{}",
+        table.name(), signature, transaction, jobId, checkpointId);
+    transactionId = transaction;
+    return transaction;
   }
 
   @Override
@@ -104,6 +135,10 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
           .meter("record-count", new MeterView(60));
       LOG.info("add metrics record-count");
     }
+
+    this.jobId = getContainingTask().getEnvironment().getJobID().toString();
+    table = ArcticUtils.loadArcticTable(tableLoader);
+    
     if (logWriter != null) {
       logWriter.open();
     }
@@ -124,12 +159,20 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+    this.checkpointId = checkpointId;
+    transactionId = null;
+    
     if (logWriter != null) {
       logWriter.prepareSnapshotPreBarrier(checkpointId);
     }
     if (fileWriter != null) {
       fileWriter.prepareSnapshotPreBarrier(checkpointId);
     }
+  }
+
+  @VisibleForTesting
+  public long getCheckpointId() {
+    return checkpointId;
   }
 
   @Override
@@ -154,6 +197,16 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void processElement(StreamRecord<RowData> element) throws Exception {
+    if (transactionId == null) {
+      transactionId = getTransactionId();
+      // setTransactionId should be invoked before log/file writer#processElement
+      if (logWriter != null) {
+        logWriter.setTransactionId(transactionId);
+      }
+      if (fileWriter != null && fileWriter instanceof TransactionIdAware) {
+        ((TransactionIdAware) fileWriter).setTransactionId(transactionId);
+      }
+    }
     if (metricsGenerator.isMetricEnable()) {
       meterSpeed.markEvent();
     }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
@@ -56,7 +56,7 @@ public class AutomaticLogWriter extends ArcticLogWriter {
       ArcticTableLoader tableLoader,
       Duration writeLogstoreWatermarkGap) {
     this.arcticLogWriter =
-        new HiddenLogWriter(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
+        new HiddenLogWriter(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper, tableLoader);
     this.status = new AutomaticDoubleWriteStatus(tableLoader, writeLogstoreWatermarkGap);
   }
 
@@ -121,6 +121,11 @@ public class AutomaticLogWriter extends ArcticLogWriter {
     if (status.isDoubleWrite()) {
       arcticLogWriter.notifyCheckpointAborted(checkpointId);
     }
+  }
+
+  @Override
+  public void setTransactionId(Long transactionId) {
+    arcticLogWriter.setTransactionId(transactionId);
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -111,11 +111,7 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
   }
 
   private FlinkBaseTaskWriter buildBaseWriter(LocationKind locationKind) {
-    if (table.isKeyedTable()) {
-      Preconditions.checkNotNull(transactionId);
-    } else {
-      Preconditions.checkArgument(transactionId == null);
-    }
+    Preconditions.checkNotNull(transactionId);
     FileFormat fileFormat = FileFormat.valueOf((table.properties().getOrDefault(
         TableProperties.BASE_FILE_FORMAT,
         TableProperties.BASE_FILE_FORMAT_DEFAULT).toUpperCase(Locale.ENGLISH)));

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -111,7 +111,6 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
   }
 
   private FlinkBaseTaskWriter buildBaseWriter(LocationKind locationKind) {
-    Preconditions.checkNotNull(transactionId);
     FileFormat fileFormat = FileFormat.valueOf((table.properties().getOrDefault(
         TableProperties.BASE_FILE_FORMAT,
         TableProperties.BASE_FILE_FORMAT_DEFAULT).toUpperCase(Locale.ENGLISH)));

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/TransactionIdAware.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/TransactionIdAware.java
@@ -18,14 +18,9 @@
 
 package com.netease.arctic.flink.write;
 
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.table.data.RowData;
-
 /**
- * This is a common abstract arctic log writer.
+ * Indicate the transactionId may be useful for it.
  */
-public abstract class ArcticLogWriter extends AbstractStreamOperator<RowData>
-    implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput, TransactionIdAware {
+public interface TransactionIdAware {
+  void setTransactionId(Long transactionId);
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/WriteResult.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/WriteResult.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.CharSequenceSet;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+public class WriteResult implements Serializable {
+
+  private final List<Long> transactionIds;
+  private org.apache.iceberg.io.WriteResult writeResult;
+
+  public WriteResult(org.apache.iceberg.io.WriteResult writeResult, List<Long> transactionIds) {
+    this.writeResult = writeResult;
+    this.transactionIds = transactionIds;
+  }
+
+  public DataFile[] dataFiles() {
+    return writeResult.dataFiles();
+  }
+
+  public DeleteFile[] deleteFiles() {
+    return writeResult.deleteFiles();
+  }
+
+  public CharSequence[] referencedDataFiles() {
+    return writeResult.referencedDataFiles();
+  }
+
+  public List<Long> getTransactionIds() {
+    return transactionIds;
+  }
+
+  public org.apache.iceberg.io.WriteResult getInternal() {
+    return writeResult;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final List<DataFile> dataFiles;
+    private final List<DeleteFile> deleteFiles;
+    private final CharSequenceSet referencedDataFiles;
+    private final List<Long> transactionIds;
+
+    private Builder() {
+      this.dataFiles = Lists.newArrayList();
+      this.deleteFiles = Lists.newArrayList();
+      this.referencedDataFiles = CharSequenceSet.empty();
+      this.transactionIds = Lists.newArrayList();
+    }
+
+    public Builder add(WriteResult result) {
+      addDataFiles(result.dataFiles());
+      addDeleteFiles(result.deleteFiles());
+      addReferencedDataFiles(result.referencedDataFiles());
+      transactionIds.addAll(result.getTransactionIds());
+      return this;
+    }
+
+    public Builder addAll(Iterable<WriteResult> results) {
+      results.forEach(this::add);
+      return this;
+    }
+
+    public Builder addDataFiles(DataFile... files) {
+      Collections.addAll(dataFiles, files);
+      return this;
+    }
+
+    public Builder addDataFiles(Iterable<DataFile> files) {
+      Iterables.addAll(dataFiles, files);
+      return this;
+    }
+
+    public Builder addDeleteFiles(DeleteFile... files) {
+      Collections.addAll(deleteFiles, files);
+      return this;
+    }
+
+    public Builder addDeleteFiles(Iterable<DeleteFile> files) {
+      Iterables.addAll(deleteFiles, files);
+      return this;
+    }
+
+    public Builder addReferencedDataFiles(CharSequence... files) {
+      Collections.addAll(referencedDataFiles, files);
+      return this;
+    }
+
+    public Builder addReferencedDataFiles(Iterable<CharSequence> files) {
+      Iterables.addAll(referencedDataFiles, files);
+      return this;
+    }
+
+    public Builder addTransactionIds(Iterable<Long> transactionId) {
+      Iterables.addAll(transactionIds, transactionId);
+      return this;
+    }
+
+    public WriteResult build() {
+      org.apache.iceberg.io.WriteResult internal = org.apache.iceberg.io.WriteResult.builder()
+          .addDataFiles(dataFiles).addDeleteFiles(deleteFiles).addReferencedDataFiles(referencedDataFiles).build();
+      return new WriteResult(internal, transactionIds);
+    }
+  }
+}

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -21,10 +21,13 @@ package com.netease.arctic.flink.write.hidden;
 import com.netease.arctic.data.ChangeAction;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.write.ArcticLogWriter;
 import com.netease.arctic.log.FormatVersion;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
+import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
@@ -38,11 +41,13 @@ import org.apache.iceberg.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Properties;
 
+import static com.netease.arctic.flink.util.ArcticUtils.getMaxCommittedTransactionId;
 import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -56,6 +61,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
   public static final Logger LOG = LoggerFactory.getLogger(AbstractHiddenLogWriter.class);
 
   private static final long serialVersionUID = 1L;
+  public static final long EPIC_NO_INIT = 0L;
   private int subtaskId;
   private transient ListState<String> hiddenLogJobIdentifyState;
   private transient ListState<Integer> parallelismState;
@@ -76,8 +82,11 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
 
   protected FormatVersion logVersion = FormatVersion.FORMAT_VERSION_V1;
   protected byte[] jobIdentify;
-  // start from 1L, epicNo is similar to checkpoint id.
-  protected long epicNo = 1L;
+  // store transactionId
+  protected long epicNo = EPIC_NO_INIT;
+  @Nullable
+  protected ArcticTableLoader tableLoader;
+  protected transient ArcticTable table;
 
   protected transient LogData<RowData> logFlip;
 
@@ -88,7 +97,8 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
+      ShuffleHelper helper,
+      @Nullable ArcticTableLoader tableLoader) {
     this.schema = schema;
     this.producerConfig = checkNotNull(producerConfig);
     this.topic = checkNotNull(topic);
@@ -96,11 +106,15 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
     this.fieldGetterFactory = fieldGetterFactory;
     this.jobIdentify = jobId;
     this.helper = helper;
+    this.tableLoader = tableLoader;
   }
 
   @Override
   public void initializeState(StateInitializationContext context) throws Exception {
     super.initializeState(context);
+    if (tableLoader != null) {
+      table = ArcticUtils.loadArcticTable(tableLoader);
+    }
     subtaskId = getRuntimeContext().getIndexOfThisSubtask();
 
     hiddenLogJobIdentifyState =
@@ -130,32 +144,27 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
                 topic,
                 helper));
     int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
+    // send flip in init for all task
+    epicNo = getCommittedEpicNo(context, parallelism);
 
     if (context.isRestored() && parallelismSame(parallelism)) {
-      ckpComplete = context.getRestoredCheckpointId().getAsLong();
-
       jobIdentify = hiddenLogJobIdentifyState.get().iterator().next().getBytes(StandardCharsets.UTF_8);
-
-      epicNo = ckpComplete;
-
-      logFlip = new LogRecordV1(
-          logVersion,
-          jobIdentify,
-          epicNo,
-          true,
-          ChangeAction.INSERT,
-          new GenericRowData(0)
-      );
-      // signal flip topic
-      shouldCheckFlipSent = true;
-      flipSentSucceed = flipCommitter.commit(subtaskId, logFlip);
-      // after send flip, epicNo + 1 The epicNo of the data sent by the subsequent processElement()
-      // method will be 1 larger than the flip.epicNo.
-      epicNo++;
     } else {
       hiddenLogJobIdentifyState.clear();
       hiddenLogJobIdentifyState.add(new String(jobIdentify, 0, jobIdentify.length, StandardCharsets.UTF_8));
     }
+
+    logFlip = new LogRecordV1(
+        logVersion,
+        jobIdentify,
+        epicNo,
+        true,
+        ChangeAction.INSERT,
+        new GenericRowData(0)
+    );
+    // signal flip topic
+    shouldCheckFlipSent = true;
+    flipSentSucceed = flipCommitter.commit(subtaskId, logFlip);
 
     logDataJsonSerialization = new LogDataJsonSerialization<>(
         checkNotNull(schema),
@@ -176,6 +185,32 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
         subtaskId,
         context.isRestored(),
         ckpComplete);
+
+    if (isLogOnly()) {
+      epicNo++;
+    }
+  }
+
+  public boolean isLogOnly() {
+    return table == null;
+  }
+
+  public long getCommittedEpicNo(StateInitializationContext context, int parallelism) throws Exception {
+    if (isLogOnly()) {
+      // for the case which only write into log.
+      if (context.isRestored() && parallelismSame(parallelism)) {
+        // get last ckp num from state when failover continuously
+        ckpComplete = context.getRestoredCheckpointId().getAsLong();
+        return ckpComplete;
+      }
+      return EPIC_NO_INIT;
+    }
+    return getMaxCommittedTransactionId(table, new String(jobIdentify)).orElse(EPIC_NO_INIT);
+  }
+
+  @Override
+  public void setTransactionId(Long transactionId) {
+    this.epicNo = transactionId;
   }
 
   private boolean parallelismSame(int parallelism) throws Exception {
@@ -247,7 +282,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
         "snapshotState subtaskId={}, checkpointId={}.",
         subtaskId,
         context.getCheckpointId());
-    epicNo++;
+    epicNo = context.getCheckpointId() + 1;
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
@@ -20,6 +20,7 @@ package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.log.LogData;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
@@ -42,8 +43,9 @@ public class HiddenLogWriter extends AbstractHiddenLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
-    super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
+      ShuffleHelper helper,
+      ArcticTableLoader tableLoader) {
+    super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper, tableLoader);
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
@@ -44,8 +44,8 @@ public class DeltaManifests {
     this(dataManifest, deleteManifest, referencedDataFiles, EMPTY_TRANSACTION);
   }
 
-  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles
-      , List<Long> transactionIds) {
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles,
+                 List<Long> transactionIds) {
     Preconditions.checkNotNull(referencedDataFiles, "Referenced data files shouldn't be null.");
 
     this.dataManifest = dataManifest;

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DeltaManifests {
+
+  private static final CharSequence[] EMPTY_REF_DATA_FILES = new CharSequence[0];
+  public static final List<Long> EMPTY_TRANSACTION = Collections.emptyList();
+
+  private final ManifestFile dataManifest;
+  private final ManifestFile deleteManifest;
+  private final CharSequence[] referencedDataFiles;
+  private final List<Long> transactionIds;
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest) {
+    this(dataManifest, deleteManifest, EMPTY_REF_DATA_FILES);
+  }
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles) {
+    this(dataManifest, deleteManifest, referencedDataFiles, EMPTY_TRANSACTION);
+  }
+
+  DeltaManifests(ManifestFile dataManifest, ManifestFile deleteManifest, CharSequence[] referencedDataFiles
+      , List<Long> transactionIds) {
+    Preconditions.checkNotNull(referencedDataFiles, "Referenced data files shouldn't be null.");
+
+    this.dataManifest = dataManifest;
+    this.deleteManifest = deleteManifest;
+    this.referencedDataFiles = referencedDataFiles;
+    this.transactionIds = transactionIds;
+  }
+
+  ManifestFile dataManifest() {
+    return dataManifest;
+  }
+
+  ManifestFile deleteManifest() {
+    return deleteManifest;
+  }
+
+  CharSequence[] referencedDataFiles() {
+    return referencedDataFiles;
+  }
+
+  public List<Long> getTransactionIds() {
+    return transactionIds;
+  }
+
+  List<ManifestFile> manifests() {
+    List<ManifestFile> manifests = Lists.newArrayListWithCapacity(2);
+    if (dataManifest != null) {
+      manifests.add(dataManifest);
+    }
+
+    if (deleteManifest != null) {
+      manifests.add(deleteManifest);
+    }
+
+    return manifests;
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifestsSerializer.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifestsSerializer.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeltaManifestsSerializer implements SimpleVersionedSerializer<DeltaManifests> {
+  private static final int VERSION_1 = 1;
+  private static final int VERSION_2 = 2;
+  private static final int VERSION_3 = 3;
+  private static final byte[] EMPTY_BINARY = new byte[0];
+
+  static final DeltaManifestsSerializer INSTANCE = new DeltaManifestsSerializer();
+
+  @Override
+  public int getVersion() {
+    return VERSION_3;
+  }
+
+  @Override
+  public byte[] serialize(DeltaManifests deltaManifests) throws IOException {
+    Preconditions.checkNotNull(deltaManifests, "DeltaManifests to be serialized should not be null");
+
+    ByteArrayOutputStream binaryOut = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(binaryOut);
+
+    byte[] dataManifestBinary = EMPTY_BINARY;
+    if (deltaManifests.dataManifest() != null) {
+      dataManifestBinary = ManifestFiles.encode(deltaManifests.dataManifest());
+    }
+
+    out.writeInt(dataManifestBinary.length);
+    out.write(dataManifestBinary);
+
+    byte[] deleteManifestBinary = EMPTY_BINARY;
+    if (deltaManifests.deleteManifest() != null) {
+      deleteManifestBinary = ManifestFiles.encode(deltaManifests.deleteManifest());
+    }
+
+    out.writeInt(deleteManifestBinary.length);
+    out.write(deleteManifestBinary);
+
+    CharSequence[] referencedDataFiles = deltaManifests.referencedDataFiles();
+    out.writeInt(referencedDataFiles.length);
+    for (int i = 0; i < referencedDataFiles.length; i++) {
+      out.writeUTF(referencedDataFiles[i].toString());
+    }
+
+    List<Long> txs = deltaManifests.getTransactionIds();
+    out.writeInt(txs.size());
+    for (Long tx : txs) {
+      out.writeLong(tx);
+    }
+    return binaryOut.toByteArray();
+  }
+
+  @Override
+  public DeltaManifests deserialize(int version, byte[] serialized) throws IOException {
+    if (version == VERSION_1) {
+      return deserializeV1(serialized);
+    } else if (version == VERSION_2) {
+      return deserializeV2(serialized);
+    } else if (version == VERSION_3) {
+      return deserializeV3(serialized);
+    } else {
+      throw new RuntimeException("Unknown serialize version: " + version);
+    }
+  }
+
+  private DeltaManifests deserializeV1(byte[] serialized) throws IOException {
+    return new DeltaManifests(ManifestFiles.decode(serialized), null);
+  }
+
+  private DeltaManifests deserializeV2(byte[] serialized) throws IOException {
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    ByteArrayInputStream binaryIn = new ByteArrayInputStream(serialized);
+    DataInputStream in = new DataInputStream(binaryIn);
+
+    int dataManifestSize = in.readInt();
+    if (dataManifestSize > 0) {
+      byte[] dataManifestBinary = new byte[dataManifestSize];
+      Preconditions.checkState(in.read(dataManifestBinary) == dataManifestSize);
+
+      dataManifest = ManifestFiles.decode(dataManifestBinary);
+    }
+
+    int deleteManifestSize = in.readInt();
+    if (deleteManifestSize > 0) {
+      byte[] deleteManifestBinary = new byte[deleteManifestSize];
+      Preconditions.checkState(in.read(deleteManifestBinary) == deleteManifestSize);
+
+      deleteManifest = ManifestFiles.decode(deleteManifestBinary);
+    }
+
+    int referenceDataFileNum = in.readInt();
+    CharSequence[] referencedDataFiles = new CharSequence[referenceDataFileNum];
+    for (int i = 0; i < referenceDataFileNum; i++) {
+      referencedDataFiles[i] = in.readUTF();
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, referencedDataFiles);
+  }
+
+  private DeltaManifests deserializeV3(byte[] serialized) throws IOException {
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    ByteArrayInputStream binaryIn = new ByteArrayInputStream(serialized);
+    DataInputStream in = new DataInputStream(binaryIn);
+
+    int dataManifestSize = in.readInt();
+    if (dataManifestSize > 0) {
+      byte[] dataManifestBinary = new byte[dataManifestSize];
+      Preconditions.checkState(in.read(dataManifestBinary) == dataManifestSize);
+
+      dataManifest = ManifestFiles.decode(dataManifestBinary);
+    }
+
+    int deleteManifestSize = in.readInt();
+    if (deleteManifestSize > 0) {
+      byte[] deleteManifestBinary = new byte[deleteManifestSize];
+      Preconditions.checkState(in.read(deleteManifestBinary) == deleteManifestSize);
+
+      deleteManifest = ManifestFiles.decode(deleteManifestBinary);
+    }
+
+    int referenceDataFileNum = in.readInt();
+    CharSequence[] referencedDataFiles = new CharSequence[referenceDataFileNum];
+    for (int i = 0; i < referenceDataFileNum; i++) {
+      referencedDataFiles[i] = in.readUTF();
+    }
+
+    int txNum = in.readInt();
+    List<Long> txs = new ArrayList<>(txNum);
+    for (int i = 0; i < txNum; i++) {
+      txs.add(in.readLong());
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, referencedDataFiles, txs);
+  }
+
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -62,10 +62,11 @@ class FlinkManifestUtil {
     }
   }
 
-  static ManifestOutputFileFactory createOutputFileFactory(Table table, String flinkJobId, int subTaskId,
-                                                           long attemptNumber) {
+  static ManifestOutputFileFactory createOutputFileFactory(Table table, String flinkJobId, String operatorUniqueId,
+                                                           int subTaskId, long attemptNumber) {
     TableOperations ops = ((HasTableOperations) table).operations();
-    return new ManifestOutputFileFactory(ops, table.io(), table.properties(), flinkJobId, subTaskId, attemptNumber);
+    return new ManifestOutputFileFactory(ops, table.io(), table.properties(), flinkJobId, operatorUniqueId,
+        subTaskId, attemptNumber);
   }
 
   static DeltaManifests writeCompletedFiles(WriteResult result,

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import com.netease.arctic.flink.write.WriteResult;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+class FlinkManifestUtil {
+  private static final int FORMAT_V2 = 2;
+  private static final Long DUMMY_SNAPSHOT_ID = 0L;
+
+  private FlinkManifestUtil() {
+  }
+
+  static ManifestFile writeDataFiles(OutputFile outputFile, PartitionSpec spec, List<DataFile> dataFiles)
+      throws IOException {
+    ManifestWriter<DataFile> writer = ManifestFiles.write(FORMAT_V2, spec, outputFile, DUMMY_SNAPSHOT_ID);
+
+    try (ManifestWriter<DataFile> closeableWriter = writer) {
+      closeableWriter.addAll(dataFiles);
+    }
+
+    return writer.toManifestFile();
+  }
+
+  static List<DataFile> readDataFiles(ManifestFile manifestFile, FileIO io) throws IOException {
+    try (CloseableIterable<DataFile> dataFiles = ManifestFiles.read(manifestFile, io)) {
+      return Lists.newArrayList(dataFiles);
+    }
+  }
+
+  static ManifestOutputFileFactory createOutputFileFactory(Table table, String flinkJobId, int subTaskId,
+                                                           long attemptNumber) {
+    TableOperations ops = ((HasTableOperations) table).operations();
+    return new ManifestOutputFileFactory(ops, table.io(), table.properties(), flinkJobId, subTaskId, attemptNumber);
+  }
+
+  static DeltaManifests writeCompletedFiles(WriteResult result,
+                                            Supplier<OutputFile> outputFileSupplier,
+                                            PartitionSpec spec) throws IOException {
+
+    ManifestFile dataManifest = null;
+    ManifestFile deleteManifest = null;
+
+    // Write the completed data files into a newly created data manifest file.
+    if (result.dataFiles() != null && result.dataFiles().length > 0) {
+      dataManifest = writeDataFiles(outputFileSupplier.get(), spec, Lists.newArrayList(result.dataFiles()));
+    }
+
+    // Write the completed delete files into a newly created delete manifest file.
+    if (result.deleteFiles() != null && result.deleteFiles().length > 0) {
+      OutputFile deleteManifestFile = outputFileSupplier.get();
+
+      ManifestWriter<DeleteFile> deleteManifestWriter = ManifestFiles.writeDeleteManifest(FORMAT_V2, spec,
+          deleteManifestFile, DUMMY_SNAPSHOT_ID);
+      try (ManifestWriter<DeleteFile> writer = deleteManifestWriter) {
+        for (DeleteFile deleteFile : result.deleteFiles()) {
+          writer.add(deleteFile);
+        }
+      }
+
+      deleteManifest = deleteManifestWriter.toManifestFile();
+    }
+
+    return new DeltaManifests(dataManifest, deleteManifest, result.referencedDataFiles(), result.getTransactionIds());
+  }
+
+  static WriteResult readCompletedFiles(DeltaManifests deltaManifests, FileIO io) throws IOException {
+    WriteResult.Builder builder = WriteResult.builder();
+
+    // Read the completed data files from persisted data manifest file.
+    if (deltaManifests.dataManifest() != null) {
+      builder.addDataFiles(readDataFiles(deltaManifests.dataManifest(), io));
+    }
+
+    // Read the completed delete files from persisted delete manifests file.
+    if (deltaManifests.deleteManifest() != null) {
+      try (CloseableIterable<DeleteFile> deleteFiles = ManifestFiles
+          .readDeleteManifest(deltaManifests.deleteManifest(), io, null)) {
+        builder.addDeleteFiles(deleteFiles);
+      }
+    }
+
+    return builder.addReferencedDataFiles(deltaManifests.referencedDataFiles())
+        .addTransactionIds(deltaManifests.getTransactionIds())
+        .build();
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -362,13 +362,6 @@ public class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     return SimpleVersionedSerialization.writeVersionAndSerialize(DeltaManifestsSerializer.INSTANCE, deltaManifests);
   }
 
-  @Override
-  public void dispose() throws Exception {
-    if (tableLoader != null) {
-      tableLoader.close();
-    }
-  }
-
   private static ListStateDescriptor<SortedMap<Long, byte[]>> buildStateDescriptor() {
     Comparator<Long> longComparator = Comparators.forType(Types.LongType.get());
     // Construct a SortedMapTypeInfo.

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -141,7 +141,9 @@ public class IcebergFilesCommitter extends AbstractStreamOperator<Void>
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     int attemptId = getRuntimeContext().getAttemptNumber();
-    this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, subTaskId, attemptId);
+    String operatorUniqueId = getRuntimeContext().getOperatorUniqueID();
+    this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, operatorUniqueId,
+        subTaskId, attemptId);
     this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
 
     this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -1,0 +1,401 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import com.netease.arctic.flink.write.WriteResult;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.runtime.typeutils.SortedMapTypeInfo;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ReplacePartitions;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+
+/**
+ * Add
+ * <p>
+ * Note: Copy from Iceberg
+ */
+public class IcebergFilesCommitter extends AbstractStreamOperator<Void>
+    implements OneInputStreamOperator<WriteResult, Void>, BoundedOneInput {
+
+  private static final long serialVersionUID = 1L;
+  private static final long INITIAL_CHECKPOINT_ID = -1L;
+  private static final byte[] EMPTY_MANIFEST_DATA = new byte[0];
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergFilesCommitter.class);
+  public static final String FLINK_JOB_ID = "flink.job-id";
+  public static final String TRANSACTION_ID = "transaction-id";
+  public static final String TRANSACTION_ID_SEPARATOR = ",";
+
+  // The max checkpoint id we've committed to iceberg table. As the flink's checkpoint is always increasing, so we could
+  // correctly commit all the data files whose checkpoint id is greater than the max committed one to iceberg table, for
+  // avoiding committing the same data files twice. This id will be attached to iceberg's meta when committing the
+  // iceberg transaction.
+  private static final String MAX_COMMITTED_CHECKPOINT_ID = "flink.max-committed-checkpoint-id";
+  static final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
+
+  // TableLoader to load iceberg table lazily.
+  private final TableLoader tableLoader;
+  private final boolean replacePartitions;
+
+  // A sorted map to maintain the completed data files for each pending checkpointId (which have not been committed
+  // to iceberg table). We need a sorted map here because there's possible that few checkpoints snapshot failed, for
+  // example: the 1st checkpoint have 2 data files <1, <file0, file1>>, the 2st checkpoint have 1 data files
+  // <2, <file3>>. Snapshot for checkpoint#1 interrupted because of network/disk failure etc, while we don't expect
+  // any data loss in iceberg table. So we keep the finished files <1, <file0, file1>> in memory and retry to commit
+  // iceberg table when the next checkpoint happen.
+  private final NavigableMap<Long, byte[]> dataFilesPerCheckpoint = Maps.newTreeMap();
+
+  // The completed files cache for current checkpoint. Once the snapshot barrier received, it will be flushed to the
+  // 'dataFilesPerCheckpoint'.
+  private final List<WriteResult> writeResultsOfCurrentCkpt = Lists.newArrayList();
+
+  // It will have an unique identifier for one job.
+  private transient String flinkJobId;
+  private transient Table table;
+  private transient ManifestOutputFileFactory manifestOutputFileFactory;
+  private transient long maxCommittedCheckpointId;
+  private transient int continuousEmptyCheckpoints;
+  private transient int maxContinuousEmptyCommits;
+  // There're two cases that we restore from flink checkpoints: the first case is restoring from snapshot created by the
+  // same flink job; another case is restoring from snapshot created by another different job. For the second case, we
+  // need to maintain the old flink job's id in flink state backend to find the max-committed-checkpoint-id when
+  // traversing iceberg table's snapshots.
+  private static final ListStateDescriptor<String> JOB_ID_DESCRIPTOR = new ListStateDescriptor<>(
+      "iceberg-flink-job-id", BasicTypeInfo.STRING_TYPE_INFO);
+  private transient ListState<String> jobIdState;
+  // All pending checkpoints states for this function.
+  private static final ListStateDescriptor<SortedMap<Long, byte[]>> STATE_DESCRIPTOR = buildStateDescriptor();
+  private transient ListState<SortedMap<Long, byte[]>> checkpointsState;
+
+  IcebergFilesCommitter(TableLoader tableLoader, boolean replacePartitions) {
+    this.tableLoader = tableLoader;
+    this.replacePartitions = replacePartitions;
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    this.flinkJobId = getContainingTask().getEnvironment().getJobID().toString();
+
+    // Open the table loader and load the table.
+    this.tableLoader.open();
+    this.table = tableLoader.loadTable();
+
+    maxContinuousEmptyCommits = PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
+    Preconditions.checkArgument(maxContinuousEmptyCommits > 0,
+        MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+
+    int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
+    int attemptId = getRuntimeContext().getAttemptNumber();
+    this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, subTaskId, attemptId);
+    this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+
+    this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);
+    this.jobIdState = context.getOperatorStateStore().getListState(JOB_ID_DESCRIPTOR);
+    if (context.isRestored()) {
+      String restoredFlinkJobId = jobIdState.get().iterator().next();
+      Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),
+          "Flink job id parsed from checkpoint snapshot shouldn't be null or empty");
+
+      // Since flink's checkpoint id will start from the max-committed-checkpoint-id + 1 in the new flink job even if
+      // it's restored from a snapshot created by another different flink job, so it's safe to assign the max committed
+      // checkpoint id from restored flink job to the current flink job.
+      this.maxCommittedCheckpointId = getMaxCommittedCheckpointId(table, restoredFlinkJobId);
+
+      NavigableMap<Long, byte[]> uncommittedDataFiles = Maps
+          .newTreeMap(checkpointsState.get().iterator().next())
+          .tailMap(maxCommittedCheckpointId, false);
+      if (!uncommittedDataFiles.isEmpty()) {
+        // Committed all uncommitted data files from the old flink job to iceberg table.
+        long maxUncommittedCheckpointId = uncommittedDataFiles.lastKey();
+        commitUpToCheckpoint(uncommittedDataFiles, restoredFlinkJobId, maxUncommittedCheckpointId);
+      }
+    }
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    long checkpointId = context.getCheckpointId();
+    LOG.info("Start to flush snapshot state to state backend, table: {}, checkpointId: {}", table, checkpointId);
+
+    // Update the checkpoint state.
+    dataFilesPerCheckpoint.put(checkpointId, writeToManifest(checkpointId));
+    // Reset the snapshot state to the latest state.
+    checkpointsState.clear();
+    checkpointsState.add(dataFilesPerCheckpoint);
+
+    jobIdState.clear();
+    jobIdState.add(flinkJobId);
+
+    // Clear the local buffer for current checkpoint.
+    writeResultsOfCurrentCkpt.clear();
+  }
+
+  @Override
+  public void notifyCheckpointComplete(long checkpointId) throws Exception {
+    super.notifyCheckpointComplete(checkpointId);
+    // It's possible that we have the following events:
+    //   1. snapshotState(ckpId);
+    //   2. snapshotState(ckpId+1);
+    //   3. notifyCheckpointComplete(ckpId+1);
+    //   4. notifyCheckpointComplete(ckpId);
+    // For step#4, we don't need to commit iceberg table again because in step#3 we've committed all the files,
+    // Besides, we need to maintain the max-committed-checkpoint-id to be increasing.
+    if (checkpointId > maxCommittedCheckpointId) {
+      commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, checkpointId);
+      this.maxCommittedCheckpointId = checkpointId;
+    }
+  }
+
+  private void commitUpToCheckpoint(NavigableMap<Long, byte[]> deltaManifestsMap,
+                                    String newFlinkJobId,
+                                    long checkpointId) throws IOException {
+    NavigableMap<Long, byte[]> pendingMap = deltaManifestsMap.headMap(checkpointId, true);
+    List<ManifestFile> manifests = Lists.newArrayList();
+    NavigableMap<Long, WriteResult> pendingResults = Maps.newTreeMap();
+    for (Map.Entry<Long, byte[]> e : pendingMap.entrySet()) {
+      if (Arrays.equals(EMPTY_MANIFEST_DATA, e.getValue())) {
+        // Skip the empty flink manifest.
+        continue;
+      }
+
+      DeltaManifests deltaManifests = SimpleVersionedSerialization
+          .readVersionAndDeSerialize(DeltaManifestsSerializer.INSTANCE, e.getValue());
+      pendingResults.put(e.getKey(), FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io()));
+      manifests.addAll(deltaManifests.manifests());
+    }
+
+    int totalFiles = pendingResults.values().stream()
+        .mapToInt(r -> r.dataFiles().length + r.deleteFiles().length).sum();
+    continuousEmptyCheckpoints = totalFiles == 0 ? continuousEmptyCheckpoints + 1 : 0;
+    if (totalFiles != 0 || continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0) {
+      if (replacePartitions) {
+        replacePartitions(pendingResults, newFlinkJobId, checkpointId);
+      } else {
+        commitDeltaTxn(pendingResults, newFlinkJobId, checkpointId);
+      }
+      continuousEmptyCheckpoints = 0;
+    }
+    pendingMap.clear();
+
+    // Delete the committed manifests.
+    for (ManifestFile manifest : manifests) {
+      try {
+        table.io().deleteFile(manifest.path());
+      } catch (Exception e) {
+        // The flink manifests cleaning failure shouldn't abort the completed checkpoint.
+        String details = MoreObjects.toStringHelper(this)
+            .add("flinkJobId", newFlinkJobId)
+            .add("checkpointId", checkpointId)
+            .add("manifestPath", manifest.path())
+            .toString();
+        LOG.warn("The iceberg transaction has been committed, but we failed to clean the temporary flink manifests: {}",
+            details, e);
+      }
+    }
+  }
+
+  private void replacePartitions(NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId,
+                                 long checkpointId) {
+    // Partition overwrite does not support delete files.
+    int deleteFilesNum = pendingResults.values().stream().mapToInt(r -> r.deleteFiles().length).sum();
+    Preconditions.checkState(deleteFilesNum == 0, "Cannot overwrite partitions with delete files.");
+
+    // Commit the overwrite transaction.
+    ReplacePartitions dynamicOverwrite = table.newReplacePartitions();
+
+    int numFiles = 0;
+    List<Long> transactionIds = new ArrayList<>(pendingResults.values().size());
+    for (WriteResult result : pendingResults.values()) {
+      Preconditions.checkState(result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+
+      transactionIds.addAll(result.getTransactionIds());
+      numFiles += result.dataFiles().length;
+      Arrays.stream(result.dataFiles()).forEach(dynamicOverwrite::addFile);
+    }
+
+    commitOperation(dynamicOverwrite, numFiles, 0, "dynamic partition overwrite", newFlinkJobId,
+        checkpointId, transactionIds);
+  }
+
+  private void commitDeltaTxn(NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId, long checkpointId) {
+    int deleteFilesNum = pendingResults.values().stream().mapToInt(r -> r.deleteFiles().length).sum();
+
+    if (deleteFilesNum == 0) {
+      // To be compatible with iceberg format V1.
+      AppendFiles appendFiles = table.newAppend();
+
+      int numFiles = 0;
+      List<Long> transactionIds = new ArrayList<>(pendingResults.values().size());
+      for (WriteResult result : pendingResults.values()) {
+        Preconditions.checkState(result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+
+        transactionIds.addAll(result.getTransactionIds());
+        numFiles += result.dataFiles().length;
+        Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+      }
+
+      commitOperation(appendFiles, numFiles, 0, "append", newFlinkJobId, checkpointId,
+          transactionIds);
+    } else {
+      // To be compatible with iceberg format V2.
+      for (Map.Entry<Long, WriteResult> e : pendingResults.entrySet()) {
+        // We don't commit the merged result into a single transaction because for the sequential transaction txn1 and
+        // txn2, the equality-delete files of txn2 are required to be applied to data files from txn1. Committing the
+        // merged one will lead to the incorrect delete semantic.
+        WriteResult result = e.getValue();
+        RowDelta rowDelta = table.newRowDelta()
+            .validateDataFilesExist(ImmutableList.copyOf(result.referencedDataFiles()))
+            .validateDeletedFiles();
+
+        int numDataFiles = result.dataFiles().length;
+        Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
+
+        int numDeleteFiles = result.deleteFiles().length;
+        Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
+
+        commitOperation(rowDelta, numDataFiles, numDeleteFiles, "rowDelta", newFlinkJobId, e.getKey(),
+            result.getTransactionIds());
+      }
+    }
+  }
+
+  private void commitOperation(SnapshotUpdate<?> operation, int numDataFiles, int numDeleteFiles, String description,
+                               String newFlinkJobId, long checkpointId, List<Long> transactionIds) {
+    LOG.info("Committing {} with {} data files and {} delete files to table {}. transactionIds {}", description,
+        numDataFiles, numDeleteFiles, table, transactionIds);
+    operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));
+    operation.set(FLINK_JOB_ID, newFlinkJobId);
+    if (!CollectionUtil.isNullOrEmpty(transactionIds)) {
+      operation.set(TRANSACTION_ID, StringUtils.join(transactionIds, ""));
+    }
+
+    long start = System.currentTimeMillis();
+    operation.commit(); // abort is automatically called if this fails.
+    long duration = System.currentTimeMillis() - start;
+    LOG.info("Committed in {} ms", duration);
+  }
+
+  @Override
+  public void processElement(StreamRecord<WriteResult> element) {
+    this.writeResultsOfCurrentCkpt.add(element.getValue());
+  }
+
+  @Override
+  public void endInput() throws IOException {
+    // Flush the buffered data files into 'dataFilesPerCheckpoint' firstly.
+    long currentCheckpointId = Long.MAX_VALUE;
+    dataFilesPerCheckpoint.put(currentCheckpointId, writeToManifest(currentCheckpointId));
+    writeResultsOfCurrentCkpt.clear();
+
+    commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, currentCheckpointId);
+  }
+
+  /**
+   * Write all the complete data files to a newly created manifest file and return the manifest's avro serialized bytes.
+   */
+  private byte[] writeToManifest(long checkpointId) throws IOException {
+    if (writeResultsOfCurrentCkpt.isEmpty()) {
+      return EMPTY_MANIFEST_DATA;
+    }
+
+    WriteResult result = WriteResult.builder().addAll(writeResultsOfCurrentCkpt).build();
+
+    DeltaManifests deltaManifests = FlinkManifestUtil.writeCompletedFiles(result,
+        () -> manifestOutputFileFactory.create(checkpointId), table.spec());
+
+    return SimpleVersionedSerialization.writeVersionAndSerialize(DeltaManifestsSerializer.INSTANCE, deltaManifests);
+  }
+
+  @Override
+  public void dispose() throws Exception {
+    if (tableLoader != null) {
+      tableLoader.close();
+    }
+  }
+
+  private static ListStateDescriptor<SortedMap<Long, byte[]>> buildStateDescriptor() {
+    Comparator<Long> longComparator = Comparators.forType(Types.LongType.get());
+    // Construct a SortedMapTypeInfo.
+    SortedMapTypeInfo<Long, byte[]> sortedMapTypeInfo = new SortedMapTypeInfo<>(
+        BasicTypeInfo.LONG_TYPE_INFO, PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO, longComparator
+    );
+    return new ListStateDescriptor<>("iceberg-files-committer-state", sortedMapTypeInfo);
+  }
+
+  static long getMaxCommittedCheckpointId(Table table, String flinkJobId) {
+    Snapshot snapshot = table.currentSnapshot();
+    long lastCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
+
+    while (snapshot != null) {
+      Map<String, String> summary = snapshot.summary();
+      String snapshotFlinkJobId = summary.get(FLINK_JOB_ID);
+      if (flinkJobId.equals(snapshotFlinkJobId)) {
+        String value = summary.get(MAX_COMMITTED_CHECKPOINT_ID);
+        if (value != null) {
+          lastCommittedCheckpointId = Long.parseLong(value);
+          break;
+        }
+      }
+      Long parentSnapshotId = snapshot.parentId();
+      snapshot = parentSnapshotId != null ? table.snapshot(parentSnapshotId) : null;
+    }
+
+    return lastCommittedCheckpointId;
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/kafka/testutils/KafkaTestBase.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/kafka/testutils/KafkaTestBase.java
@@ -102,8 +102,16 @@ public class KafkaTestBase {
 
   public void startClusters(boolean secureMode)
       throws Exception {
+    Properties props = new Properties();
+    props.put("offsets.topic.num.partitions", "3");
+    props.put("offsets.topic.segment.bytes", "1048576");
+    props.put("transaction.state.log.num.partitions", "3");
+    props.put("transaction.state.log.segment.bytes", "1048576");
+    props.put("metadata.log.max.record.bytes.between.snapshots", "1048576");
+
     startClusters(
         KafkaTestEnvironment.createConfig()
+            .setKafkaServerProperties(props)
             .setKafkaServersNumber(NUMBER_OF_KAFKA_SERVERS)
             .setSecureMode(secureMode));
   }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -69,7 +69,6 @@ import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -162,14 +161,12 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     assertArrayEquals(excepts(), actualResult);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStaticJobManagerFailover() throws Exception {
     testArcticSource(FailoverType.JM);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStaticTaskManagerFailover() throws Exception {
     testArcticSource(FailoverType.TM);
   }
@@ -256,7 +253,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     Assert.assertEquals(Long.MAX_VALUE, WatermarkAwareFailWrapper.getWatermarkAfterFailover());
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSource() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSource(true);
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -354,14 +351,12 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceJobManagerFailover() throws Exception {
     testArcticContinuousSource(FailoverType.JM);
   }
 
-  @Ignore
-  @Test
+  @Test(timeout = 30000)
   public void testArcticContinuousSourceTaskManagerFailover() throws Exception {
     testArcticContinuousSource(FailoverType.TM);
   }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -137,7 +137,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     testCatalog.dropTable(FAIL_TABLE_ID, true);
   }
 
-  @Test
+  @Test(timeout = 30000)
   public void testArcticSourceStatic() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSource(false);
 

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileCommitterTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileCommitterTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.types.RowKind;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.WriteResult;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.flink.util.TestGlobalAggregateManager;
@@ -34,7 +35,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.sink.RowDataTaskWriterFactory;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.io.TaskWriter;
-import org.apache.iceberg.io.WriteResult;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,9 +90,12 @@ public class ArcticFileWriterTest extends FlinkTestBase {
         false,
         (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType(),
         tableLoader);
+
+    ArcticWriter arcticWriter = new ArcticWriter(null, streamWriter, tableLoader,
+        MetricsGenerator.empty(false));
     OneInputStreamOperatorInternTest<RowData, WriteResult> harness =
         new OneInputStreamOperatorInternTest<>(
-            streamWriter, 1, 1, 0, restoredCheckpointId,
+            arcticWriter, 1, 1, 0, restoredCheckpointId,
             new TestGlobalAggregateManager());
 
     return harness;
@@ -113,15 +116,12 @@ public class ArcticFileWriterTest extends FlinkTestBase {
     try (
         OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = createArcticStreamWriter(
             tableLoader)) {
-      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
-      Assert.assertNotNull(fileWriter.getWriter());
       // The first checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
 
       testHarness.prepareSnapshotPreBarrier(checkpointId);
-      Assert.assertNull(fileWriter.getWriter());
       Assert.assertEquals(1, testHarness.extractOutputValues().size());
       Assert.assertEquals(3, testHarness.extractOutputValues().get(0).dataFiles().length);
 
@@ -129,7 +129,6 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
       // The second checkpoint
       testHarness.processElement(createRowData(1, "hello", "2020-10-12T10:10:11.0"), 1);
-      Assert.assertNotNull(fileWriter.getWriter());
       testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
       testHarness.processElement(createRowData(3, "hello", "2020-10-12T10:10:11.0"), 1);
 
@@ -177,7 +176,10 @@ public class ArcticFileWriterTest extends FlinkTestBase {
       testHarness.initializeState(state);
       testHarness.open();
 
-      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
+      testHarness.prepareSnapshotPreBarrier(checkpointId + 1);
+      testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
+
+      ArcticWriter fileWriter = (ArcticWriter) testHarness.getOneInputOperator();
       Assert.assertEquals(checkpointId + 1, fileWriter.getCheckpointId());
     }
   }
@@ -329,7 +331,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
       // The second checkpoint
       testHarness.prepareSnapshotPreBarrier(checkpointId);
-      Assert.assertEquals(excepted, testHarness.extractOutputValues().size());
+      Assert.assertEquals(excepted + (submitEmptySnapshots ? 1 : 0), testHarness.extractOutputValues().size());
     }
   }
 

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
@@ -29,6 +29,7 @@ import com.netease.arctic.flink.util.DataUtil;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.flink.util.TestGlobalAggregateManager;
 import com.netease.arctic.flink.write.hidden.kafka.HiddenKafkaFactory;
+import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonDeserialization;
 import com.netease.arctic.utils.IdGenerator;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -44,7 +45,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
-import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -254,15 +254,19 @@ public class AutomaticLogWriterTest extends FlinkTestBase {
             LogRecordV1.mapFactory
         );
     ConsumerRecords<byte[], byte[]> consumerRecords = kafkaTestBase.readRecordsBytes(topic);
-    Assertions.assertEquals(expects.size(), consumerRecords.count());
     List<RowData> actual = new ArrayList<>();
     consumerRecords.forEach(consumerRecord -> {
       try {
-        actual.add(logDataJsonDeserialization.deserialize(consumerRecord.value()).getActualValue());
+        LogData<RowData> row = logDataJsonDeserialization.deserialize(consumerRecord.value());
+        if (row.getFlip()) {
+          return;
+        }
+        actual.add(row.getActualValue());
       } catch (IOException e) {
         e.printStackTrace();
       }
     });
+    Assertions.assertEquals(expects.size(), actual.size());
     Collection<RowData> expected = DataUtil.toRowData(expects);
     Assertions.assertEquals(
         expected.stream().sorted(
@@ -318,7 +322,8 @@ public class AutomaticLogWriterTest extends FlinkTestBase {
         (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType(),
         tableLoader);
 
-    ArcticWriter<WriteResult> arcticWriter = new ArcticWriter<>(automaticLogWriter, streamWriter, metricsGenerator);
+    ArcticWriter<WriteResult> arcticWriter = new ArcticWriter<>(automaticLogWriter, streamWriter, tableLoader,
+        metricsGenerator);
 
     OneInputStreamOperatorInternTest<RowData, WriteResult> harness =
         new OneInputStreamOperatorInternTest<>(

--- a/trino/src/main/java/com/netease/arctic/trino/ArcticCatalogSupportTableSuffix.java
+++ b/trino/src/main/java/com/netease/arctic/trino/ArcticCatalogSupportTableSuffix.java
@@ -253,6 +253,11 @@ public class ArcticCatalogSupportTableSuffix implements ArcticCatalog {
     }
 
     @Override
+    public long beginTransaction(String signature) {
+      return table.beginTransaction(signature);
+    }
+
+    @Override
     public ReplaceSortOrder replaceSortOrder() {
       return table.replaceSortOrder();
     }


### PR DESCRIPTION
resolve #525 
Replace transactionId with ckpId in Log-store format

## Why are the changes needed?
Replace transactionId with ckpId in Log-store format. It can avoid the duplicated epicNo in Logstore when task restore from a previous ckp.
With the help of transactionId, it would be achievable to keep the eventual consistency of logstore and filestore, even if task restores from a previous ckp.

## Brief change log
  - *The flink 1.12 and 1.14, 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
