### PR TITLE
[ARCTIC-528][AMS]if ams start error there should be shutdown first and then restart

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/ArcticMetaStore.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/ArcticMetaStore.java
@@ -114,6 +114,7 @@ public class ArcticMetaStore {
         startMetaStore(conf);
       }
     } catch (Throwable t) {
+      failover();
       LOG.error("MetaStore Thrift Server threw an exception...", t);
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
resolve #528 

## Brief change log

execute failover() when there is error occur in ArcticMetaStore.tryStartServer()

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
