### PR TITLE
[CORE]Make BaseIcebergReader can read "transaction_id, offset,action"

### DIFF
--- a/core/src/main/java/com/netease/arctic/io/reader/DataReaderCommon.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/DataReaderCommon.java
@@ -17,7 +17,7 @@ import java.util.function.BiFunction;
 
 public class DataReaderCommon {
 
-  protected static Map<Integer, ?> getIdToConstant(ArcticFileScanTask task, Schema projectedSchema,
+  protected static Map<Integer, ?> getIdToConstant(FileScanTask task, Schema projectedSchema,
       BiFunction<Type, Object, Object> convertConstant) {
     Schema partitionSchema = TypeUtil.select(projectedSchema, task.spec().identitySourceIds());
     Map<Integer, Object> idToConstant = new HashMap<>();
@@ -26,38 +26,28 @@ public class DataReaderCommon {
     }
     idToConstant.put(org.apache.iceberg.MetadataColumns.FILE_PATH.fieldId(),
         convertConstant.apply(Types.StringType.get(), task.file().path().toString()));
-    idToConstant.put(
-        MetadataColumns.TRANSACTION_ID_FILED_ID,
-        convertConstant.apply(Types.LongType.get(), task.file().transactionId()));
 
-    if (task.fileType() == DataFileType.BASE_FILE) {
+    if (task instanceof ArcticFileScanTask) {
+      ArcticFileScanTask arcticFileScanTask = (ArcticFileScanTask)task;
       idToConstant.put(
-          MetadataColumns.FILE_OFFSET_FILED_ID,
-          convertConstant.apply(Types.LongType.get(), Long.MAX_VALUE));
-    }
-    if (task.fileType() == DataFileType.EQ_DELETE_FILE) {
-      idToConstant.put(MetadataColumns.CHANGE_ACTION_ID, convertConstant.apply(
-          Types.StringType.get(),
-          ChangeAction.DELETE.toString()));
-    } else if (task.fileType() == DataFileType.INSERT_FILE) {
-      idToConstant.put(MetadataColumns.CHANGE_ACTION_ID, convertConstant.apply(
-          Types.StringType.get(),
-          ChangeAction.INSERT.toString()));
+          MetadataColumns.TRANSACTION_ID_FILED_ID,
+          convertConstant.apply(Types.LongType.get(), arcticFileScanTask.file().transactionId()));
+
+      if (arcticFileScanTask.fileType() == DataFileType.BASE_FILE) {
+        idToConstant.put(
+            MetadataColumns.FILE_OFFSET_FILED_ID,
+            convertConstant.apply(Types.LongType.get(), Long.MAX_VALUE));
+      }
+      if (arcticFileScanTask.fileType() == DataFileType.EQ_DELETE_FILE) {
+        idToConstant.put(MetadataColumns.CHANGE_ACTION_ID, convertConstant.apply(
+            Types.StringType.get(),
+            ChangeAction.DELETE.toString()));
+      } else if (arcticFileScanTask.fileType() == DataFileType.INSERT_FILE) {
+        idToConstant.put(MetadataColumns.CHANGE_ACTION_ID, convertConstant.apply(
+            Types.StringType.get(),
+            ChangeAction.INSERT.toString()));
+      }
     }
     return idToConstant;
   }
-
-  protected static Map<Integer, ?> getIdToConstant(FileScanTask task, Schema projectedSchema,
-                                                   BiFunction<Type, Object, Object> convertConstant) {
-    Schema partitionSchema = TypeUtil.select(projectedSchema, task.spec().identitySourceIds());
-    Map<Integer, Object> idToConstant = new HashMap<>();
-    if (!partitionSchema.columns().isEmpty()) {
-      idToConstant.putAll(PartitionUtil.constantsMap(task, convertConstant));
-    }
-    idToConstant.put(org.apache.iceberg.MetadataColumns.FILE_PATH.fieldId(),
-        convertConstant.apply(Types.StringType.get(), task.file().path().toString()));
-
-    return idToConstant;
-  }
-
 }

--- a/core/src/main/java/com/netease/arctic/io/reader/GenericIcebergDataReader.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/GenericIcebergDataReader.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.io.reader;
+
+import com.netease.arctic.data.DataTreeNode;
+import com.netease.arctic.iceberg.optimize.InternalRecordWrapper;
+import com.netease.arctic.io.ArcticFileIO;
+import com.netease.arctic.table.PrimaryKeySpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.parquet.ParquetValueReader;
+import org.apache.iceberg.types.Type;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class GenericIcebergDataReader extends BaseIcebergDataReader<Record> {
+  public GenericIcebergDataReader(
+      ArcticFileIO fileIO,
+      Schema tableSchema,
+      Schema projectedSchema,
+      String nameMapping,
+      boolean caseSensitive,
+      BiFunction<Type, Object, Object> convertConstant,
+      boolean reuseContainer) {
+    super(fileIO, tableSchema, projectedSchema, nameMapping, caseSensitive, convertConstant, reuseContainer);
+  }
+
+  public GenericIcebergDataReader(
+      ArcticFileIO fileIO,
+      Schema tableSchema,
+      Schema projectedSchema,
+      PrimaryKeySpec primaryKeySpec,
+      String nameMapping,
+      boolean caseSensitive,
+      BiFunction<Type, Object, Object> convertConstant,
+      Set<DataTreeNode> sourceNodes,
+      boolean reuseContainer) {
+    super(
+        fileIO,
+        tableSchema,
+        projectedSchema,
+        primaryKeySpec,
+        nameMapping,
+        caseSensitive,
+        convertConstant,
+        sourceNodes,
+        reuseContainer);
+  }
+
+  @Override
+  protected Function<MessageType, ParquetValueReader<?>> getNewReaderFunction(
+      Schema projectedSchema, Map<Integer, ?> idToConstant) {
+    return fileSchema -> GenericParquetReaders.buildReader(projectedSchema, fileSchema, idToConstant);
+  }
+
+  @Override
+  protected Function<Schema, Function<Record, StructLike>> toStructLikeFunction() {
+    return schema -> record -> new InternalRecordWrapper(schema.asStruct()).wrap(record);
+  }
+}


### PR DESCRIPTION
## Why are the changes needed?
spark need read change table with "_transaction_id, _file_offset,_action" columns.
subtask of #521 
## Brief change log
com.netease.arctic.io.reader.BaseIcebergDataReader can read  "_transaction_id, _file_offset,_action" columns

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
