### PR TITLE
[ARCTIC-558] Drop table operation will leave an empty table directory in hdfs

### DIFF
--- a/core/src/main/java/com/netease/arctic/catalog/BaseArcticCatalog.java
+++ b/core/src/main/java/com/netease/arctic/catalog/BaseArcticCatalog.java
@@ -265,6 +265,17 @@ public class BaseArcticCatalog implements ArcticCatalog {
     } catch (Exception e) {
       LOG.warn("drop base/change iceberg table fail ", e);
     }
+
+    try {
+      ArcticFileIO fileIO = new ArcticHadoopFileIO(tableMetaStore);
+      String tableLocation = meta.getLocations().get(MetaTableProperties.LOCATION_KEY_TABLE);
+      if (fileIO.exists(tableLocation) && purge) {
+        LOG.info("try to delete table directory location is " + tableLocation);
+        fileIO.deleteFileWithResult(tableLocation, true);
+      }
+    } catch (Exception e) {
+      LOG.warn("drop table directory fail ", e);
+    }
   }
 
   @Override

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
@@ -59,7 +59,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
     sql("SHOW tables");
 
@@ -99,7 +99,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("INSERT INTO arcticCatalog." + DB + "." + TABLE +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
@@ -59,7 +59,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
     sql("SHOW tables");
 
@@ -99,7 +99,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("INSERT INTO arcticCatalog." + DB + "." + TABLE +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -98,7 +98,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
@@ -155,7 +155,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -98,7 +98,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
@@ -155,7 +155,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -214,7 +214,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -270,7 +270,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -356,7 +356,7 @@ public class TestKeyed extends FlinkTestBase {
 
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -410,7 +410,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -468,7 +468,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -156,7 +156,7 @@ public class TestKeyed extends FlinkTestBase {
         ") PARTITIONED BY(op_time) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -156,7 +156,7 @@ public class TestKeyed extends FlinkTestBase {
         ") PARTITIONED BY(op_time) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -214,7 +214,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -270,7 +270,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -320,7 +320,7 @@ public class TestKeyed extends FlinkTestBase {
 
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
-        ") PARTITIONED BY(op_time) WITH ('connector' = 'arctic', 'location' = '" + tableDir.getAbsolutePath() + "')");
+        ") PARTITIONED BY(op_time) WITH ('connector' = 'arctic', 'location' = '" + tableDir.getAbsolutePath() + TABLE + "')");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
         "/*+ OPTIONS(" +
@@ -356,7 +356,7 @@ public class TestKeyed extends FlinkTestBase {
 
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -410,7 +410,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -468,7 +468,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -136,7 +136,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     ArcticTable table = arcticCatalog.loadTable(TableIdentifier.of(catalog, db, TABLE));
@@ -162,7 +162,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " PARTITIONED BY (ts)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     Schema required = new Schema(
@@ -207,7 +207,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -250,7 +250,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(id INT, name STRING) " +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " select * from input");
@@ -419,7 +419,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -474,7 +474,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -306,7 +306,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -361,7 +361,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -542,7 +542,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, actualTopic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
 
@@ -599,7 +599,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, actualTopic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -136,7 +136,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     ArcticTable table = arcticCatalog.loadTable(TableIdentifier.of(catalog, db, TABLE));
@@ -162,7 +162,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " PARTITIONED BY (ts)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     Schema required = new Schema(
@@ -207,7 +207,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -250,7 +250,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(id INT, name STRING) " +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " select * from input");
@@ -306,7 +306,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -361,7 +361,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -419,7 +419,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -474,7 +474,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -542,7 +542,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, actualTopic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
 
@@ -599,7 +599,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, actualTopic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -89,7 +89,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testWatermark() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +
@@ -137,7 +137,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testSelectWatermarkField() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -89,7 +89,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testWatermark() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +
@@ -137,7 +137,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testSelectWatermarkField() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
@@ -59,7 +59,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
     sql("SHOW tables");
 
@@ -99,7 +99,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("INSERT INTO arcticCatalog." + DB + "." + TABLE +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
@@ -59,7 +59,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
     sql("SHOW tables");
 
@@ -99,7 +99,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("INSERT INTO arcticCatalog." + DB + "." + TABLE +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -102,7 +102,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
@@ -160,7 +160,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -102,7 +102,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
@@ -160,7 +160,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -160,7 +160,7 @@ public class TestKeyed extends FlinkTestBase {
         ") PARTITIONED BY(op_time) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -324,7 +324,7 @@ public class TestKeyed extends FlinkTestBase {
 
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
-        ") PARTITIONED BY(op_time) WITH ('connector' = 'arctic', 'location' = '" + tableDir.getAbsolutePath() + "')");
+        ") PARTITIONED BY(op_time) WITH ('connector' = 'arctic', 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "')");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
         "/*+ OPTIONS(" +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -218,7 +218,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -274,7 +274,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -360,7 +360,7 @@ public class TestKeyed extends FlinkTestBase {
 
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -414,7 +414,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -472,7 +472,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -160,7 +160,7 @@ public class TestKeyed extends FlinkTestBase {
         ") PARTITIONED BY(op_time) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -218,7 +218,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -274,7 +274,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -360,7 +360,7 @@ public class TestKeyed extends FlinkTestBase {
 
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -414,7 +414,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -472,7 +472,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -136,7 +136,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     ArcticTable table = arcticCatalog.loadTable(TableIdentifier.of(catalog, db, TestUnkeyed.TABLE));
@@ -162,7 +162,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " PARTITIONED BY (ts)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     Schema required = new Schema(
@@ -207,7 +207,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -250,7 +250,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(id INT, name STRING) " +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " select * from input");
@@ -306,7 +306,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -361,7 +361,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -419,7 +419,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -474,7 +474,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -542,7 +542,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
 
@@ -599,7 +599,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -306,7 +306,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -361,7 +361,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -542,7 +542,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
 
@@ -599,7 +599,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -136,7 +136,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     ArcticTable table = arcticCatalog.loadTable(TableIdentifier.of(catalog, db, TestUnkeyed.TABLE));
@@ -162,7 +162,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " PARTITIONED BY (ts)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     Schema required = new Schema(
@@ -207,7 +207,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -250,7 +250,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(id INT, name STRING) " +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " select * from input");
@@ -419,7 +419,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -474,7 +474,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -89,7 +89,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testWatermark() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +
@@ -137,7 +137,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testSelectWatermarkField() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -89,7 +89,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testWatermark() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +
@@ -137,7 +137,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testSelectWatermarkField() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
@@ -59,7 +59,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
     sql("SHOW tables");
 
@@ -99,7 +99,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("INSERT INTO arcticCatalog." + DB + "." + TABLE +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/catalog/TestCatalog.java
@@ -59,7 +59,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
     sql("SHOW tables");
 
@@ -99,7 +99,7 @@ public class TestCatalog extends FlinkTestBase {
         ") PARTITIONED BY(t) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("INSERT INTO arcticCatalog." + DB + "." + TABLE +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -100,7 +100,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
@@ -157,7 +157,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestJoin.java
@@ -100,7 +100,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +
@@ -157,7 +157,7 @@ public class TestJoin extends FlinkTestBase {
 
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     String sql = String.format("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -160,7 +160,7 @@ public class TestKeyed extends FlinkTestBase {
         ") PARTITIONED BY(op_time) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -324,7 +324,7 @@ public class TestKeyed extends FlinkTestBase {
 
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
-        ") PARTITIONED BY(op_time) WITH ('connector' = 'arctic', 'location' = '" + tableDir.getAbsolutePath() + "')");
+        ") PARTITIONED BY(op_time) WITH ('connector' = 'arctic', 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "')");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
         "/*+ OPTIONS(" +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -218,7 +218,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -274,7 +274,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -360,7 +360,7 @@ public class TestKeyed extends FlinkTestBase {
 
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -414,7 +414,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -472,7 +472,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -160,7 +160,7 @@ public class TestKeyed extends FlinkTestBase {
         ") PARTITIONED BY(op_time) " +
         " WITH (" +
         " 'connector' = 'arctic'," +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -218,7 +218,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -274,7 +274,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
@@ -360,7 +360,7 @@ public class TestKeyed extends FlinkTestBase {
 
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -414,7 +414,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
@@ -472,7 +472,7 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
         ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -136,7 +136,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     ArcticTable table = arcticCatalog.loadTable(TableIdentifier.of(catalog, db, TestUnkeyed.TABLE));
@@ -162,7 +162,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " PARTITIONED BY (ts)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     Schema required = new Schema(
@@ -207,7 +207,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -250,7 +250,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(id INT, name STRING) " +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " select * from input");
@@ -306,7 +306,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -361,7 +361,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -419,7 +419,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -474,7 +474,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -542,7 +542,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
 
@@ -599,7 +599,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -306,7 +306,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -361,7 +361,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING) WITH %s", toWithClause(tableProperties));
 
@@ -542,7 +542,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
 
@@ -599,7 +599,7 @@ public class TestUnkeyed extends FlinkTestBase {
     tableProperties.put(ENABLE_LOG_STORE, "true");
     tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
     tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -136,7 +136,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     ArcticTable table = arcticCatalog.loadTable(TableIdentifier.of(catalog, db, TestUnkeyed.TABLE));
@@ -162,7 +162,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, age SMALLINT, sex TINYINT, score BIGINT, height FLOAT, speed DOUBLE, ts TIMESTAMP)" +
         " PARTITIONED BY (ts)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     Schema required = new Schema(
@@ -207,7 +207,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -250,7 +250,7 @@ public class TestUnkeyed extends FlinkTestBase {
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(id INT, name STRING) " +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " select * from input");
@@ -419,7 +419,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
@@ -474,7 +474,7 @@ public class TestUnkeyed extends FlinkTestBase {
         " id INT, name STRING, dt STRING)" +
         " PARTITIONED BY (dt)" +
         " WITH (" +
-        " 'location' = '" + tableDir.getAbsolutePath() + "'" +
+        " 'location' = '" + tableDir.getAbsolutePath() + TABLE + "'" +
         ")");
 
     sql("insert into arcticCatalog." + db + "." + TABLE +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -89,7 +89,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testWatermark() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +
@@ -137,7 +137,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testSelectWatermarkField() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath());
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -89,7 +89,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testWatermark() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +
@@ -137,7 +137,7 @@ public class TestWatermark extends FlinkTestBase {
   public void testSelectWatermarkField() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     String table = String.format("arcticCatalog.%s.%s", DB, TABLE);
 
     sql("CREATE TABLE IF NOT EXISTS %s (" +

--- a/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
@@ -125,18 +125,20 @@ public class ArcticHiveCatalog extends BaseArcticCatalog {
 
   @Override
   protected void doDropTable(TableMeta meta, boolean purge) {
-    super.doDropTable(meta, purge);
+    // drop hive table operation will only delete hive table metadata
+    // delete data files operation will use BaseArcticCatalog
     try {
       hiveClientPool.run(client -> {
         client.dropTable(meta.getTableIdentifier().getDatabase(),
             meta.getTableIdentifier().getTableName(),
-            purge /* deleteData */,
+            false /* deleteData */,
             false /* ignoreUnknownTab */);
         return null;
       });
     } catch (TException | InterruptedException e) {
       throw new RuntimeException("Failed to drop table:" + meta.getTableIdentifier(), e);
     }
+    super.doDropTable(meta, purge);
   }
 
   public void dropTableButNotDropHiveTable(TableIdentifier tableIdentifier) {


### PR DESCRIPTION
Fix #558 
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

* Now drop arctic table will leave an empty directory in hdfs

## Brief change log

  -After drop table, delete table directory 

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
