### PR TITLE
[ARCTIC-576] Bugfix for initTableOptimizeRuntime

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableOptimizeRuntime.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableOptimizeRuntime.java
@@ -57,7 +57,7 @@ public class TableOptimizeRuntime implements Cloneable {
   @Override
   public TableOptimizeRuntime clone() {
     TableOptimizeRuntime newTableOptimizeRuntime = new TableOptimizeRuntime(this.tableIdentifier.getCatalog(),
-      this.tableIdentifier.getDatabase(), this.tableIdentifier.getTableName());
+        this.tableIdentifier.getDatabase(), this.tableIdentifier.getTableName());
     newTableOptimizeRuntime.currentSnapshotId = this.currentSnapshotId;
     newTableOptimizeRuntime.currentChangeSnapshotId = this.currentChangeSnapshotId;
     newTableOptimizeRuntime.optimizeStatus = this.optimizeStatus;

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableOptimizeRuntime.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableOptimizeRuntime.java
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class TableOptimizeRuntime {
+public class TableOptimizeRuntime implements Cloneable {
   public static final long INVALID_SNAPSHOT_ID = -1L;
 
   private TableIdentifier tableIdentifier;
@@ -52,6 +52,39 @@ public class TableOptimizeRuntime {
 
   public TableOptimizeRuntime(String catalog, String database, String tableName) {
     this.tableIdentifier = TableIdentifier.of(catalog, database, tableName);
+  }
+
+  @Override
+  public TableOptimizeRuntime clone() {
+    TableOptimizeRuntime newTableOptimizeRuntime = new TableOptimizeRuntime(this.tableIdentifier.getCatalog(),
+      this.tableIdentifier.getDatabase(), this.tableIdentifier.getTableName());
+    newTableOptimizeRuntime.currentSnapshotId = this.currentSnapshotId;
+    newTableOptimizeRuntime.currentChangeSnapshotId = this.currentChangeSnapshotId;
+    newTableOptimizeRuntime.optimizeStatus = this.optimizeStatus;
+    newTableOptimizeRuntime.optimizeStatusStartTime = this.optimizeStatusStartTime;
+    newTableOptimizeRuntime.latestMajorOptimizeTime.putAll(this.latestMajorOptimizeTime);
+    newTableOptimizeRuntime.latestFullOptimizeTime.putAll(this.latestFullOptimizeTime);
+    newTableOptimizeRuntime.latestMinorOptimizeTime.putAll(this.latestMinorOptimizeTime);
+    newTableOptimizeRuntime.latestTaskPlanGroup = this.latestTaskPlanGroup;
+    newTableOptimizeRuntime.isRunning = this.isRunning;
+    return newTableOptimizeRuntime;
+  }
+
+  public void restoreTableOptimizeRuntime(TableOptimizeRuntime old) {
+    this.tableIdentifier = TableIdentifier.of(old.tableIdentifier.getCatalog(),
+        old.tableIdentifier.getDatabase(), old.tableIdentifier.getTableName());
+    this.currentSnapshotId = old.currentSnapshotId;
+    this.currentChangeSnapshotId = old.currentChangeSnapshotId;
+    this.optimizeStatus = old.optimizeStatus;
+    this.optimizeStatusStartTime = old.optimizeStatusStartTime;
+    this.latestMajorOptimizeTime.clear();
+    this.latestMajorOptimizeTime.putAll(old.latestMajorOptimizeTime);
+    this.latestFullOptimizeTime.clear();
+    this.latestFullOptimizeTime.putAll(old.latestFullOptimizeTime);
+    this.latestMinorOptimizeTime.clear();
+    this.latestMinorOptimizeTime.putAll(old.latestMinorOptimizeTime);
+    this.latestTaskPlanGroup = old.latestTaskPlanGroup;
+    this.isRunning = old.isRunning;
   }
 
   public TableIdentifier getTableIdentifier() {

--- a/trino/src/test/java/com/netease/arctic/trino/iceberg/BaseConnectorTest.java
+++ b/trino/src/test/java/com/netease/arctic/trino/iceberg/BaseConnectorTest.java
@@ -1396,7 +1396,7 @@ public abstract class BaseConnectorTest
    */
   protected Callable<Void> queryRepeatedly(int minIterations, AtomicInteger incompleteReadTasks, @Language("SQL") String sql)
   {
-    return new Callable<Void>()
+    return new Callable<>()
     {
       @Override
       public Void call()
@@ -1427,7 +1427,7 @@ public abstract class BaseConnectorTest
 
   protected Callable<Void> createDropRepeatedly(Runnable initReady, Supplier<Boolean> done, String namePrefix, String createTemplate, String dropTemplate)
   {
-    return new Callable<Void>()
+    return new Callable<>()
     {
       @Override
       public Void call()

--- a/trino/src/test/java/com/netease/arctic/trino/iceberg/BaseConnectorTest.java
+++ b/trino/src/test/java/com/netease/arctic/trino/iceberg/BaseConnectorTest.java
@@ -1396,7 +1396,7 @@ public abstract class BaseConnectorTest
    */
   protected Callable<Void> queryRepeatedly(int minIterations, AtomicInteger incompleteReadTasks, @Language("SQL") String sql)
   {
-    return new Callable<>()
+    return new Callable<Void>()
     {
       @Override
       public Void call()
@@ -1427,7 +1427,7 @@ public abstract class BaseConnectorTest
 
   protected Callable<Void> createDropRepeatedly(Runnable initReady, Supplier<Boolean> done, String namePrefix, String createTemplate, String dropTemplate)
   {
-    return new Callable<>()
+    return new Callable<Void>()
     {
       @Override
       public Void call()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
As https://github.com/NetEase/arctic/issues/576 described, the lock timeout will cause the initTableOptimizeRuntime method return directly with restore the TableOptimizeRuntime object history status. This will cause this table optimize job always in Pending status and no optimize job plan  for the Arctic table anymore.

## Brief change log
 - add cloneTableOptimizeRuntime and restoreTableOptimizeRuntime methods to clone and restore TableOptimizeRuntime status.
 - add try catch cause to wrap the method, when exception occurrs, restore the history status before persist to database.

## How was this patch tested?
- [x] In test environment, I see the same log occurs in the `ams-error.log` file, and later the optimize job plans well. so I think the bugs fixed well. the logs and later optimize task screen picture show as below:
<pre>
2022-11-08 20:49:40,733 ERROR [Optimize Plan Thread Queue-1] [com.netease.arctic.ams.server.service.impl.OptimizeQueueService] [] - hadoop_catalog.iceberg_test.xxxxx plan failed, continue
org.apache.ibatis.exceptions.PersistenceException:
### Error updating database.  Cause: com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException: Lock wait timeout exceeded; try restarting transaction
### The error may exist in com/netease/arctic/ams/server/mapper/TableOptimizeRuntimeMapper.java (best guess)
### The error may involve com.netease.arctic.ams.server.mapper.TableOptimizeRuntimeMapper.updateTableOptimizeRuntime-Inline
### The error occurred while setting parameters
### SQL: update optimize_table_runtime set current_snapshot_id = ?, current_change_snapshotId = ?, latest_major_optimize_time = ?, latest_full_optimize_time = ?, latest_minor_optimize_time = ?, latest_task_plan_group = ?, optimize_status = ?, optimize_status_start_time = ? where catalog_name = ? and db_name = ? and table_name = ?
### Cause: com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException: Lock wait timeout exceeded; try restarting transaction
	at org.apache.ibatis.exceptions.ExceptionFactory.wrapException(ExceptionFactory.java:30) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.session.defaults.DefaultSqlSession.update(DefaultSqlSession.java:199) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.binding.MapperMethod.execute(MapperMethod.java:67) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.binding.MapperProxy$PlainMethodInvoker.invoke(MapperProxy.java:152) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.binding.MapperProxy.invoke(MapperProxy.java:85) ~[mybatis-3.5.5.jar:3.5.5]
	at com.sun.proxy.$Proxy43.updateTableOptimizeRuntime(Unknown Source) ~[?:?]
	at com.netease.arctic.ams.server.optimize.TableOptimizeItem.persistTableOptimizeRuntime(TableOptimizeItem.java:930) ~[arctic-ams-server-0.3.2.jar:?]
	at com.netease.arctic.ams.server.service.impl.OptimizeQueueService$OptimizeQueueWrapper.initTableOptimizeRuntime(OptimizeQueueService.java:704) ~[arctic-ams-server-0.3.2.jar:?]
	at com.netease.arctic.ams.server.service.impl.OptimizeQueueService$OptimizeQueueWrapper.plan(OptimizeQueueService.java:589) ~[arctic-ams-server-0.3.2.jar:?]
	at com.netease.arctic.ams.server.service.impl.OptimizeQueueService$OptimizeQueueWrapper.lambda$poll$0(OptimizeQueueService.java:423) ~[arctic-ams-server-0.3.2.jar:?]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_252]
Caused by: com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException: Lock wait timeout exceeded; try restarting transaction
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:123) ~[mysql-connector-java-8.0.30.jar:8.0.30]
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122) ~[mysql-connector-java-8.0.30.jar:8.0.30]
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:916) ~[mysql-connector-java-8.0.30.jar:8.0.30]
	at com.mysql.cj.jdbc.ClientPreparedStatement.execute(ClientPreparedStatement.java:354) ~[mysql-connector-java-8.0.30.jar:8.0.30]
	at org.apache.commons.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:94) ~[commons-dbcp2-2.9.0.jar:2.9.0]
	at org.apache.commons.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:94) ~[commons-dbcp2-2.9.0.jar:2.9.0]
	at sun.reflect.GeneratedMethodAccessor9.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_252]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_252]
	at org.apache.ibatis.logging.jdbc.PreparedStatementLogger.invoke(PreparedStatementLogger.java:59) ~[mybatis-3.5.5.jar:3.5.5]
	at com.sun.proxy.$Proxy36.execute(Unknown Source) ~[?:?]
	at org.apache.ibatis.executor.statement.PreparedStatementHandler.update(PreparedStatementHandler.java:47) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.executor.statement.RoutingStatementHandler.update(RoutingStatementHandler.java:74) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.executor.SimpleExecutor.doUpdate(SimpleExecutor.java:50) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.executor.BaseExecutor.update(BaseExecutor.java:117) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.executor.CachingExecutor.update(CachingExecutor.java:76) ~[mybatis-3.5.5.jar:3.5.5]
	at org.apache.ibatis.session.defaults.DefaultSqlSession.update(DefaultSqlSession.java:197) ~[mybatis-3.5.5.jar:3.5.5]
	... 9 more
</pre>
the optimize task works well, show as below:
<img width="1042" alt="asasasas" src="https://user-images.githubusercontent.com/18043146/200573780-5ede529f-9470-4a7f-a0e5-991994983fc2.png">