### PR TITLE
[ARCTIC-583][Core]Insert overwrite a table select * from another empty table failed

### DIFF
--- a/core/src/main/java/com/netease/arctic/op/OverwriteBaseFiles.java
+++ b/core/src/main/java/com/netease/arctic/op/OverwriteBaseFiles.java
@@ -197,7 +197,10 @@ public class OverwriteBaseFiles extends PartitionTransactionOperation {
 
     // step3: set max transaction id
     if (keyedTable.spec().isUnpartitioned()) {
-      long maxTransactionId = partitionMaxTxId.get(partitionData);
+      long maxTransactionId = 0L;
+      if (partitionMaxTxId.get(partitionData) != null) {
+        maxTransactionId = partitionMaxTxId.get(partitionData);
+      }
       partitionMaxTxId.put(partitionData, Math.max(maxTransactionId,
           this.maxTransactionId.getOrDefault(partitionData, 0L)));
     } else {


### PR DESCRIPTION
fix #583 
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

* If table is empty partitionMaxTxId.get(partitionData) will return null and an NullPointerExectption is reported when a null value is assigned to long

## Brief change log

  -  If  partitionMaxTxId.get(partitionData) retrun null, set maxTransactionId = 0L;

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)