### PR TITLE
[ARCTIC-585][Hive][Flink][Spark]FIX: Adapt hive column name with "$"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -228,6 +228,8 @@ This product includes code from Apache Iceberg.
 * org.apache.iceberg.parquet.ParquetMetricsRowGroupFilter copied and modified to org.apache.iceberg.parquet.AdaptHiveParquetMetricsRowGroupFilter
 * org.apache.iceberg.parquet.ParquetReader copied and modified to org.apache.iceberg.parquet.AdaptHiveParquetReader
 * org.apache.iceberg.parquet.ReadConf copied and modified to org.apache.iceberg.parquet.AdaptHiveReadConf
+* org.apache.iceberg.spark.data.ParquetWithSparkSchemaVisitor copied and modified to org.apache.iceberg.spark.data.AdaptHiveParquetWithSparkSchemaVisitor
+* org.apache.iceberg.flink.data.ParquetWithFlinkSchemaVisitor copied and modified to org.apache.iceberg.flink.data.AdaptHiveParquetWithFlinkSchemaVisitor
 
 
 Copyright: 2011-2019 The Apache Software Foundation

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/AdaptHiveFlinkAppenderFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/AdaptHiveFlinkAppenderFactory.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.data.AdaptHiveFlinkParquetWriters;
 import org.apache.iceberg.flink.data.FlinkAvroWriter;
 import org.apache.iceberg.flink.data.FlinkOrcWriter;
 import org.apache.iceberg.io.DataWriter;
@@ -40,7 +41,6 @@ import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.AdaptHiveParquet;
-import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 import java.io.IOException;

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.write;
+package org.apache.iceberg.flink.data;
 
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
@@ -32,7 +32,6 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
-import org.apache.iceberg.flink.data.ParquetWithFlinkSchemaVisitor;
 import org.apache.iceberg.parquet.AdaptHivePrimitiveWriter;
 import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.parquet.ParquetValueWriter;
@@ -67,11 +66,11 @@ public class AdaptHiveFlinkParquetWriters {
 
   @SuppressWarnings("unchecked")
   public static <T> ParquetValueWriter<T> buildWriter(LogicalType schema, MessageType type) {
-    return (ParquetValueWriter<T>) ParquetWithFlinkSchemaVisitor.visit(schema, type,
+    return (ParquetValueWriter<T>) AdaptHiveParquetWithFlinkSchemaVisitor.visit(schema, type,
         new AdaptHiveFlinkParquetWriters.WriteBuilder(type));
   }
 
-  private static class WriteBuilder extends ParquetWithFlinkSchemaVisitor<ParquetValueWriter<?>> {
+  private static class WriteBuilder extends AdaptHiveParquetWithFlinkSchemaVisitor<ParquetValueWriter<?>> {
     private final MessageType type;
 
     WriteBuilder(MessageType type) {

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
@@ -60,6 +60,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.flink.data.FlinkParquetWriters} to support int96 type
+ * and use  {@link org.apache.iceberg.flink.data.AdaptHiveParquetWithFlinkSchemaVisitor}.
+ */
 public class AdaptHiveFlinkParquetWriters {
   private AdaptHiveFlinkParquetWriters() {
   }

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
@@ -35,6 +35,10 @@ import org.apache.parquet.schema.Type;
 import java.util.Deque;
 import java.util.List;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.flink.data.ParquetWithFlinkSchemaVisitor}.
+ * see annotation "Change For Arctic"
+ */
 public class AdaptHiveParquetWithFlinkSchemaVisitor<T> {
   private final Deque<String> fieldNames = Lists.newLinkedList();
 

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.data;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+import java.util.Deque;
+import java.util.List;
+
+public class AdaptHiveParquetWithFlinkSchemaVisitor<T> {
+  private final Deque<String> fieldNames = Lists.newLinkedList();
+
+  public static <T> T visit(LogicalType sType, Type type, AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    Preconditions.checkArgument(sType != null, "Invalid DataType: null");
+    if (type instanceof MessageType) {
+      Preconditions.checkArgument(sType instanceof RowType, "Invalid struct: %s is not a struct", sType);
+      RowType struct = (RowType) sType;
+      return visitor.message(struct, (MessageType) type, visitFields(struct, type.asGroupType(), visitor));
+    } else if (type.isPrimitive()) {
+      return visitor.primitive(sType, type.asPrimitiveType());
+    } else {
+      // if not a primitive, the typeId must be a group
+      GroupType group = type.asGroupType();
+      OriginalType annotation = group.getOriginalType();
+      if (annotation != null) {
+        switch (annotation) {
+          case LIST:
+            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+                "Invalid list: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid list: does not contain single repeated field: %s", group);
+
+            GroupType repeatedElement = group.getFields().get(0).asGroupType();
+            Preconditions.checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
+                "Invalid list: inner group is not repeated");
+            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+                "Invalid list: repeated group is not a single field: %s", group);
+
+            Preconditions.checkArgument(sType instanceof ArrayType, "Invalid list: %s is not an array", sType);
+            ArrayType array = (ArrayType) sType;
+            RowField element = new RowField(
+                "element", array.getElementType(), "element of " + array.asSummaryString());
+
+            visitor.fieldNames.push(repeatedElement.getName());
+            try {
+              T elementResult = null;
+              if (repeatedElement.getFieldCount() > 0) {
+                elementResult = visitField(element, repeatedElement.getType(0), visitor);
+              }
+
+              return visitor.list(array, group, elementResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          case MAP:
+            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+                "Invalid map: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid map: does not contain single repeated field: %s", group);
+
+            GroupType repeatedKeyValue = group.getType(0).asGroupType();
+            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
+                "Invalid map: inner group is not repeated");
+            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+                "Invalid map: repeated group does not have 2 fields");
+
+            Preconditions.checkArgument(sType instanceof MapType, "Invalid map: %s is not a map", sType);
+            MapType map = (MapType) sType;
+            RowField keyField = new RowField("key", map.getKeyType(), "key of " + map.asSummaryString());
+            RowField valueField = new RowField(
+                "value", map.getValueType(), "value of " + map.asSummaryString());
+
+            visitor.fieldNames.push(repeatedKeyValue.getName());
+            try {
+              T keyResult = null;
+              T valueResult = null;
+              switch (repeatedKeyValue.getFieldCount()) {
+                case 2:
+                  // if there are 2 fields, both key and value are projected
+                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
+                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
+                  break;
+                case 1:
+                  // if there is just one, use the name to determine what it is
+                  Type keyOrValue = repeatedKeyValue.getType(0);
+                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
+                    keyResult = visitField(keyField, keyOrValue, visitor);
+                    // value result remains null
+                  } else {
+                    valueResult = visitField(valueField, keyOrValue, visitor);
+                    // key result remains null
+                  }
+                  break;
+                default:
+                  // both results will remain null
+              }
+
+              return visitor.map(map, group, keyResult, valueResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          default:
+        }
+      }
+      Preconditions.checkArgument(sType instanceof RowType, "Invalid struct: %s is not a struct", sType);
+      RowType struct = (RowType) sType;
+      return visitor.struct(struct, group, visitFields(struct, group, visitor));
+    }
+  }
+
+  private static <T> T visitField(RowField sField, Type field, AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    visitor.fieldNames.push(field.getName());
+    try {
+      return visit(sField.getType(), field, visitor);
+    } finally {
+      visitor.fieldNames.pop();
+    }
+  }
+
+  private static <T> List<T> visitFields(RowType struct, GroupType group,
+      AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    List<RowField> sFields = struct.getFields();
+    Preconditions.checkArgument(sFields.size() == group.getFieldCount(),
+        "Structs do not match: %s and %s", struct, group);
+    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
+    for (int i = 0; i < sFields.size(); i += 1) {
+      Type field = group.getFields().get(i);
+      RowField sField = sFields.get(i);
+
+      //Change For Arctic ⬇
+      // Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.getName())),
+      //     "Structs do not match: field %s != %s", field.getName(), sField.getName());
+      Preconditions.checkArgument(field.getName().equals(sField.getName()),
+          "Structs do not match: field %s != %s", field.getName(), sField.getName());
+      //Change For Arctic ⬆
+
+      results.add(visitField(sField, field, visitor));
+    }
+
+    return results;
+  }
+
+  public T message(RowType sStruct, MessageType message, List<T> fields) {
+    return null;
+  }
+
+  public T struct(RowType sStruct, GroupType struct, List<T> fields) {
+    return null;
+  }
+
+  public T list(ArrayType sArray, GroupType array, T element) {
+    return null;
+  }
+
+  public T map(MapType sMap, GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T primitive(LogicalType sPrimitive, PrimitiveType primitive) {
+    return null;
+  }
+
+  protected String[] currentPath() {
+    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
+  }
+
+  protected String[] path(String name) {
+    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
+    list.add(name);
+    return list.toArray(new String[0]);
+  }
+
+}

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/AdaptHiveFlinkAppenderFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/AdaptHiveFlinkAppenderFactory.java
@@ -31,9 +31,9 @@ import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.data.AdaptHiveFlinkParquetWriters;
 import org.apache.iceberg.flink.data.FlinkAvroWriter;
 import org.apache.iceberg.flink.data.FlinkOrcWriter;
-import org.apache.iceberg.flink.data.FlinkParquetWriters;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.FileAppender;
@@ -41,7 +41,6 @@ import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.AdaptHiveParquet;
-import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 import java.io.IOException;

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.write;
+package org.apache.iceberg.flink.data;
 
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
@@ -67,11 +67,11 @@ public class AdaptHiveFlinkParquetWriters {
 
   @SuppressWarnings("unchecked")
   public static <T> ParquetValueWriter<T> buildWriter(LogicalType schema, MessageType type) {
-    return (ParquetValueWriter<T>) ParquetWithFlinkSchemaVisitor.visit(schema, type,
+    return (ParquetValueWriter<T>) AdaptHiveParquetWithFlinkSchemaVisitor.visit(schema, type,
         new WriteBuilder(type));
   }
 
-  private static class WriteBuilder extends ParquetWithFlinkSchemaVisitor<ParquetValueWriter<?>> {
+  private static class WriteBuilder extends AdaptHiveParquetWithFlinkSchemaVisitor<ParquetValueWriter<?>> {
     private final MessageType type;
 
     WriteBuilder(MessageType type) {

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
@@ -61,6 +61,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.flink.data.FlinkParquetWriters} to support int96 type
+ * and use  {@link org.apache.iceberg.flink.data.AdaptHiveParquetWithFlinkSchemaVisitor}.
+ */
 public class AdaptHiveFlinkParquetWriters {
   private AdaptHiveFlinkParquetWriters() {
   }

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
@@ -35,6 +35,10 @@ import org.apache.parquet.schema.Type;
 import java.util.Deque;
 import java.util.List;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.flink.data.ParquetWithFlinkSchemaVisitor}.
+ * see annotation "Change For Arctic"
+ */
 public class AdaptHiveParquetWithFlinkSchemaVisitor<T> {
   private final Deque<String> fieldNames = Lists.newLinkedList();
 

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.data;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+import java.util.Deque;
+import java.util.List;
+
+public class AdaptHiveParquetWithFlinkSchemaVisitor<T> {
+  private final Deque<String> fieldNames = Lists.newLinkedList();
+
+  public static <T> T visit(LogicalType sType, Type type, AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    Preconditions.checkArgument(sType != null, "Invalid DataType: null");
+    if (type instanceof MessageType) {
+      Preconditions.checkArgument(sType instanceof RowType, "Invalid struct: %s is not a struct", sType);
+      RowType struct = (RowType) sType;
+      return visitor.message(struct, (MessageType) type, visitFields(struct, type.asGroupType(), visitor));
+    } else if (type.isPrimitive()) {
+      return visitor.primitive(sType, type.asPrimitiveType());
+    } else {
+      // if not a primitive, the typeId must be a group
+      GroupType group = type.asGroupType();
+      OriginalType annotation = group.getOriginalType();
+      if (annotation != null) {
+        switch (annotation) {
+          case LIST:
+            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+                "Invalid list: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid list: does not contain single repeated field: %s", group);
+
+            GroupType repeatedElement = group.getFields().get(0).asGroupType();
+            Preconditions.checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
+                "Invalid list: inner group is not repeated");
+            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+                "Invalid list: repeated group is not a single field: %s", group);
+
+            Preconditions.checkArgument(sType instanceof ArrayType, "Invalid list: %s is not an array", sType);
+            ArrayType array = (ArrayType) sType;
+            RowField element = new RowField(
+                "element", array.getElementType(), "element of " + array.asSummaryString());
+
+            visitor.fieldNames.push(repeatedElement.getName());
+            try {
+              T elementResult = null;
+              if (repeatedElement.getFieldCount() > 0) {
+                elementResult = visitField(element, repeatedElement.getType(0), visitor);
+              }
+
+              return visitor.list(array, group, elementResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          case MAP:
+            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+                "Invalid map: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid map: does not contain single repeated field: %s", group);
+
+            GroupType repeatedKeyValue = group.getType(0).asGroupType();
+            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
+                "Invalid map: inner group is not repeated");
+            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+                "Invalid map: repeated group does not have 2 fields");
+
+            Preconditions.checkArgument(sType instanceof MapType, "Invalid map: %s is not a map", sType);
+            MapType map = (MapType) sType;
+            RowField keyField = new RowField("key", map.getKeyType(), "key of " + map.asSummaryString());
+            RowField valueField = new RowField(
+                "value", map.getValueType(), "value of " + map.asSummaryString());
+
+            visitor.fieldNames.push(repeatedKeyValue.getName());
+            try {
+              T keyResult = null;
+              T valueResult = null;
+              switch (repeatedKeyValue.getFieldCount()) {
+                case 2:
+                  // if there are 2 fields, both key and value are projected
+                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
+                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
+                  break;
+                case 1:
+                  // if there is just one, use the name to determine what it is
+                  Type keyOrValue = repeatedKeyValue.getType(0);
+                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
+                    keyResult = visitField(keyField, keyOrValue, visitor);
+                    // value result remains null
+                  } else {
+                    valueResult = visitField(valueField, keyOrValue, visitor);
+                    // key result remains null
+                  }
+                  break;
+                default:
+                  // both results will remain null
+              }
+
+              return visitor.map(map, group, keyResult, valueResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          default:
+        }
+      }
+      Preconditions.checkArgument(sType instanceof RowType, "Invalid struct: %s is not a struct", sType);
+      RowType struct = (RowType) sType;
+      return visitor.struct(struct, group, visitFields(struct, group, visitor));
+    }
+  }
+
+  private static <T> T visitField(RowField sField, Type field, AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    visitor.fieldNames.push(field.getName());
+    try {
+      return visit(sField.getType(), field, visitor);
+    } finally {
+      visitor.fieldNames.pop();
+    }
+  }
+
+  private static <T> List<T> visitFields(RowType struct, GroupType group,
+      AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    List<RowField> sFields = struct.getFields();
+    Preconditions.checkArgument(sFields.size() == group.getFieldCount(),
+        "Structs do not match: %s and %s", struct, group);
+    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
+    for (int i = 0; i < sFields.size(); i += 1) {
+      Type field = group.getFields().get(i);
+      RowField sField = sFields.get(i);
+
+      //Change For Arctic ⬇
+      // Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.getName())),
+      //     "Structs do not match: field %s != %s", field.getName(), sField.getName());
+      Preconditions.checkArgument(field.getName().equals(sField.getName()),
+          "Structs do not match: field %s != %s", field.getName(), sField.getName());
+      //Change For Arctic ⬆
+
+      results.add(visitField(sField, field, visitor));
+    }
+
+    return results;
+  }
+
+  public T message(RowType sStruct, MessageType message, List<T> fields) {
+    return null;
+  }
+
+  public T struct(RowType sStruct, GroupType struct, List<T> fields) {
+    return null;
+  }
+
+  public T list(ArrayType sArray, GroupType array, T element) {
+    return null;
+  }
+
+  public T map(MapType sMap, GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T primitive(LogicalType sPrimitive, PrimitiveType primitive) {
+    return null;
+  }
+
+  protected String[] currentPath() {
+    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
+  }
+
+  protected String[] path(String name) {
+    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
+    list.add(name);
+    return list.toArray(new String[0]);
+  }
+
+}

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/AdaptHiveFlinkAppenderFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/AdaptHiveFlinkAppenderFactory.java
@@ -31,9 +31,9 @@ import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.data.AdaptHiveFlinkParquetWriters;
 import org.apache.iceberg.flink.data.FlinkAvroWriter;
 import org.apache.iceberg.flink.data.FlinkOrcWriter;
-import org.apache.iceberg.flink.data.FlinkParquetWriters;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.FileAppender;
@@ -41,7 +41,6 @@ import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.AdaptHiveParquet;
-import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 import java.io.IOException;

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.write;
+package org.apache.iceberg.flink.data;
 
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
@@ -32,7 +32,6 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
-import org.apache.iceberg.flink.data.ParquetWithFlinkSchemaVisitor;
 import org.apache.iceberg.parquet.AdaptHivePrimitiveWriter;
 import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.parquet.ParquetValueWriter;
@@ -67,11 +66,11 @@ public class AdaptHiveFlinkParquetWriters {
 
   @SuppressWarnings("unchecked")
   public static <T> ParquetValueWriter<T> buildWriter(LogicalType schema, MessageType type) {
-    return (ParquetValueWriter<T>) ParquetWithFlinkSchemaVisitor.visit(schema, type,
+    return (ParquetValueWriter<T>) AdaptHiveParquetWithFlinkSchemaVisitor.visit(schema, type,
         new WriteBuilder(type));
   }
 
-  private static class WriteBuilder extends ParquetWithFlinkSchemaVisitor<ParquetValueWriter<?>> {
+  private static class WriteBuilder extends AdaptHiveParquetWithFlinkSchemaVisitor<ParquetValueWriter<?>> {
     private final MessageType type;
 
     WriteBuilder(MessageType type) {

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveFlinkParquetWriters.java
@@ -60,6 +60,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.flink.data.FlinkParquetWriters} to support int96 type
+ * and use  {@link org.apache.iceberg.flink.data.AdaptHiveParquetWithFlinkSchemaVisitor}.
+ */
 public class AdaptHiveFlinkParquetWriters {
   private AdaptHiveFlinkParquetWriters() {
   }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
@@ -35,6 +35,10 @@ import org.apache.parquet.schema.Type;
 import java.util.Deque;
 import java.util.List;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.flink.data.ParquetWithFlinkSchemaVisitor}.
+ * see annotation "Change For Arctic"
+ */
 public class AdaptHiveParquetWithFlinkSchemaVisitor<T> {
   private final Deque<String> fieldNames = Lists.newLinkedList();
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/AdaptHiveParquetWithFlinkSchemaVisitor.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.data;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+import java.util.Deque;
+import java.util.List;
+
+public class AdaptHiveParquetWithFlinkSchemaVisitor<T> {
+  private final Deque<String> fieldNames = Lists.newLinkedList();
+
+  public static <T> T visit(LogicalType sType, Type type, AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    Preconditions.checkArgument(sType != null, "Invalid DataType: null");
+    if (type instanceof MessageType) {
+      Preconditions.checkArgument(sType instanceof RowType, "Invalid struct: %s is not a struct", sType);
+      RowType struct = (RowType) sType;
+      return visitor.message(struct, (MessageType) type, visitFields(struct, type.asGroupType(), visitor));
+    } else if (type.isPrimitive()) {
+      return visitor.primitive(sType, type.asPrimitiveType());
+    } else {
+      // if not a primitive, the typeId must be a group
+      GroupType group = type.asGroupType();
+      OriginalType annotation = group.getOriginalType();
+      if (annotation != null) {
+        switch (annotation) {
+          case LIST:
+            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+                "Invalid list: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid list: does not contain single repeated field: %s", group);
+
+            GroupType repeatedElement = group.getFields().get(0).asGroupType();
+            Preconditions.checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
+                "Invalid list: inner group is not repeated");
+            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+                "Invalid list: repeated group is not a single field: %s", group);
+
+            Preconditions.checkArgument(sType instanceof ArrayType, "Invalid list: %s is not an array", sType);
+            ArrayType array = (ArrayType) sType;
+            RowType.RowField element = new RowField(
+                "element", array.getElementType(), "element of " + array.asSummaryString());
+
+            visitor.fieldNames.push(repeatedElement.getName());
+            try {
+              T elementResult = null;
+              if (repeatedElement.getFieldCount() > 0) {
+                elementResult = visitField(element, repeatedElement.getType(0), visitor);
+              }
+
+              return visitor.list(array, group, elementResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          case MAP:
+            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+                "Invalid map: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid map: does not contain single repeated field: %s", group);
+
+            GroupType repeatedKeyValue = group.getType(0).asGroupType();
+            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
+                "Invalid map: inner group is not repeated");
+            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+                "Invalid map: repeated group does not have 2 fields");
+
+            Preconditions.checkArgument(sType instanceof MapType, "Invalid map: %s is not a map", sType);
+            MapType map = (MapType) sType;
+            RowField keyField = new RowField("key", map.getKeyType(), "key of " + map.asSummaryString());
+            RowField valueField = new RowField(
+                "value", map.getValueType(), "value of " + map.asSummaryString());
+
+            visitor.fieldNames.push(repeatedKeyValue.getName());
+            try {
+              T keyResult = null;
+              T valueResult = null;
+              switch (repeatedKeyValue.getFieldCount()) {
+                case 2:
+                  // if there are 2 fields, both key and value are projected
+                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
+                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
+                  break;
+                case 1:
+                  // if there is just one, use the name to determine what it is
+                  Type keyOrValue = repeatedKeyValue.getType(0);
+                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
+                    keyResult = visitField(keyField, keyOrValue, visitor);
+                    // value result remains null
+                  } else {
+                    valueResult = visitField(valueField, keyOrValue, visitor);
+                    // key result remains null
+                  }
+                  break;
+                default:
+                  // both results will remain null
+              }
+
+              return visitor.map(map, group, keyResult, valueResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          default:
+        }
+      }
+      Preconditions.checkArgument(sType instanceof RowType, "Invalid struct: %s is not a struct", sType);
+      RowType struct = (RowType) sType;
+      return visitor.struct(struct, group, visitFields(struct, group, visitor));
+    }
+  }
+
+  private static <T> T visitField(RowType.RowField sField, Type field,
+      AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    visitor.fieldNames.push(field.getName());
+    try {
+      return visit(sField.getType(), field, visitor);
+    } finally {
+      visitor.fieldNames.pop();
+    }
+  }
+
+  private static <T> List<T> visitFields(RowType struct, GroupType group,
+      AdaptHiveParquetWithFlinkSchemaVisitor<T> visitor) {
+    List<RowType.RowField> sFields = struct.getFields();
+    Preconditions.checkArgument(sFields.size() == group.getFieldCount(),
+        "Structs do not match: %s and %s", struct, group);
+    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
+    for (int i = 0; i < sFields.size(); i += 1) {
+      Type field = group.getFields().get(i);
+      RowType.RowField sField = sFields.get(i);
+
+      //Change For Arctic ⬇
+      // Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.getName())),
+      //     "Structs do not match: field %s != %s", field.getName(), sField.getName());
+      Preconditions.checkArgument(field.getName().equals(sField.getName()),
+          "Structs do not match: field %s != %s", field.getName(), sField.getName());
+      //Change For Arctic ⬆
+
+      results.add(visitField(sField, field, visitor));
+    }
+
+    return results;
+  }
+
+  public T message(RowType sStruct, MessageType message, List<T> fields) {
+    return null;
+  }
+
+  public T struct(RowType sStruct, GroupType struct, List<T> fields) {
+    return null;
+  }
+
+  public T list(ArrayType sArray, GroupType array, T element) {
+    return null;
+  }
+
+  public T map(MapType sMap, GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T primitive(LogicalType sPrimitive, PrimitiveType primitive) {
+    return null;
+  }
+
+  protected String[] currentPath() {
+    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
+  }
+
+  protected String[] path(String name) {
+    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
+    list.add(name);
+    return list.toArray(new String[0]);
+  }
+
+}

--- a/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveTypeToMessageType.java
+++ b/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveTypeToMessageType.java
@@ -55,7 +55,7 @@ public class AdaptHiveTypeToMessageType {
       builder.addField(field(field));
     }
 
-    return builder.named(AvroSchemaUtil.makeCompatibleName(name));
+    return builder.named(name);
   }
 
   public GroupType struct(org.apache.iceberg.types.Types.StructType struct,
@@ -66,7 +66,7 @@ public class AdaptHiveTypeToMessageType {
       builder.addField(field(field));
     }
 
-    return builder.id(id).named(AvroSchemaUtil.makeCompatibleName(name));
+    return builder.id(id).named(name);
   }
 
   public Type field(org.apache.iceberg.types.Types.NestedField field) {
@@ -96,7 +96,7 @@ public class AdaptHiveTypeToMessageType {
     return Types.list(repetition)
         .element(field(elementField))
         .id(id)
-        .named(AvroSchemaUtil.makeCompatibleName(name));
+        .named(name);
   }
 
   public GroupType map(org.apache.iceberg.types.Types.MapType map, Type.Repetition repetition, int id, String name) {
@@ -106,7 +106,7 @@ public class AdaptHiveTypeToMessageType {
         .key(field(keyField))
         .value(field(valueField))
         .id(id)
-        .named(AvroSchemaUtil.makeCompatibleName(name));
+        .named(name);
   }
 
   public Type primitive(org.apache.iceberg.types.Type.PrimitiveType primitive,

--- a/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveTypeToMessageType.java
+++ b/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveTypeToMessageType.java
@@ -36,6 +36,11 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.parquet.TypeToMessageType} for follow reason:
+ * 1. Make timestamp to int96.
+ * 2. remove {@link AvroSchemaUtil#makeCompatibleName(String)} of name.
+ */
 public class AdaptHiveTypeToMessageType {
   public static final int DECIMAL_INT32_MAX_DIGITS = 9;
   public static final int DECIMAL_INT64_MAX_DIGITS = 18;

--- a/spark/v2.3/spark/src/main/java/com/netease/arctic/spark/io/InternalRowFileAppenderFactory.java
+++ b/spark/v2.3/spark/src/main/java/com/netease/arctic/spark/io/InternalRowFileAppenderFactory.java
@@ -18,7 +18,6 @@
 
 package com.netease.arctic.spark.io;
 
-import com.netease.arctic.spark.parquet.AdaptHiveSparkParquetWriters;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
@@ -39,6 +38,7 @@ import org.apache.iceberg.parquet.AdaptHiveParquet;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.data.AdaptHiveSparkParquetWriters;
 import org.apache.iceberg.spark.data.SparkAvroWriter;
 import org.apache.iceberg.spark.data.SparkOrcWriter;
 import org.apache.iceberg.spark.data.SparkParquetWriters;

--- a/spark/v2.3/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveParquetWithSparkSchemaVisitor.java
+++ b/spark/v2.3/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveParquetWithSparkSchemaVisitor.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Type.Repetition;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Visitor for traversing a Parquet type with a companion Spark type.
+ *
+ * @param <T> the Java class returned by the visitor
+ */
+public class AdaptHiveParquetWithSparkSchemaVisitor<T> {
+  private final Deque<String> fieldNames = Lists.newLinkedList();
+
+  public static <T> T visit(DataType sType, Type type, AdaptHiveParquetWithSparkSchemaVisitor<T> visitor) {
+    Preconditions.checkArgument(sType != null, "Invalid DataType: null");
+    if (type instanceof MessageType) {
+      Preconditions.checkArgument(sType instanceof StructType, "Invalid struct: %s is not a struct", sType);
+      StructType struct = (StructType) sType;
+      return visitor.message(struct, (MessageType) type, visitFields(struct, type.asGroupType(), visitor));
+
+    } else if (type.isPrimitive()) {
+      return visitor.primitive(sType, type.asPrimitiveType());
+
+    } else {
+      // if not a primitive, the typeId must be a group
+      GroupType group = type.asGroupType();
+      OriginalType annotation = group.getOriginalType();
+      if (annotation != null) {
+        switch (annotation) {
+          case LIST:
+            Preconditions.checkArgument(!group.isRepetition(Repetition.REPEATED),
+                "Invalid list: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid list: does not contain single repeated field: %s", group);
+
+            GroupType repeatedElement = group.getFields().get(0).asGroupType();
+            Preconditions.checkArgument(repeatedElement.isRepetition(Repetition.REPEATED),
+                "Invalid list: inner group is not repeated");
+            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+                "Invalid list: repeated group is not a single field: %s", group);
+
+            Preconditions.checkArgument(sType instanceof ArrayType, "Invalid list: %s is not an array", sType);
+            ArrayType array = (ArrayType) sType;
+            StructField element = new StructField(
+                "element", array.elementType(), array.containsNull(), Metadata.empty());
+
+            visitor.fieldNames.push(repeatedElement.getName());
+            try {
+              T elementResult = null;
+              if (repeatedElement.getFieldCount() > 0) {
+                elementResult = visitField(element, repeatedElement.getType(0), visitor);
+              }
+
+              return visitor.list(array, group, elementResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          case MAP:
+            Preconditions.checkArgument(!group.isRepetition(Repetition.REPEATED),
+                "Invalid map: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid map: does not contain single repeated field: %s", group);
+
+            GroupType repeatedKeyValue = group.getType(0).asGroupType();
+            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Repetition.REPEATED),
+                "Invalid map: inner group is not repeated");
+            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+                "Invalid map: repeated group does not have 2 fields");
+
+            Preconditions.checkArgument(sType instanceof MapType, "Invalid map: %s is not a map", sType);
+            MapType map = (MapType) sType;
+            StructField keyField = new StructField("key", map.keyType(), false, Metadata.empty());
+            StructField valueField = new StructField(
+                "value", map.valueType(), map.valueContainsNull(), Metadata.empty());
+
+            visitor.fieldNames.push(repeatedKeyValue.getName());
+            try {
+              T keyResult = null;
+              T valueResult = null;
+              switch (repeatedKeyValue.getFieldCount()) {
+                case 2:
+                  // if there are 2 fields, both key and value are projected
+                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
+                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
+                  break;
+                case 1:
+                  // if there is just one, use the name to determine what it is
+                  Type keyOrValue = repeatedKeyValue.getType(0);
+                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
+                    keyResult = visitField(keyField, keyOrValue, visitor);
+                    // value result remains null
+                  } else {
+                    valueResult = visitField(valueField, keyOrValue, visitor);
+                    // key result remains null
+                  }
+                  break;
+                default:
+                  // both results will remain null
+              }
+
+              return visitor.map(map, group, keyResult, valueResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          default:
+        }
+      }
+
+      Preconditions.checkArgument(sType instanceof StructType, "Invalid struct: %s is not a struct", sType);
+      StructType struct = (StructType) sType;
+      return visitor.struct(struct, group, visitFields(struct, group, visitor));
+    }
+  }
+
+  private static <T> T visitField(StructField sField, Type field, AdaptHiveParquetWithSparkSchemaVisitor<T> visitor) {
+    visitor.fieldNames.push(field.getName());
+    try {
+      return visit(sField.dataType(), field, visitor);
+    } finally {
+      visitor.fieldNames.pop();
+    }
+  }
+
+  private static <T> List<T> visitFields(StructType struct, GroupType group,
+      AdaptHiveParquetWithSparkSchemaVisitor<T> visitor) {
+    StructField[] sFields = struct.fields();
+    Preconditions.checkArgument(sFields.length == group.getFieldCount(),
+        "Structs do not match: %s and %s", struct, group);
+    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
+    for (int i = 0; i < sFields.length; i += 1) {
+      Type field = group.getFields().get(i);
+      StructField sField = sFields[i];
+
+      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+          "Structs do not match: field %s != %s", field.getName(), sField.name());
+
+      //Change For Arctic ⬇
+      // Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+      //     "Structs do not match: field %s != %s", field.getName(), sField.name());
+      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+          "Structs do not match: field %s != %s", field.getName(), sField.name());
+      //Change For Arctic ⬆
+      results.add(visitField(sField, field, visitor));
+    }
+
+    return results;
+  }
+
+  public T message(StructType sStruct, MessageType message, List<T> fields) {
+    return null;
+  }
+
+  public T struct(StructType sStruct, GroupType struct, List<T> fields) {
+    return null;
+  }
+
+  public T list(ArrayType sArray, GroupType array, T element) {
+    return null;
+  }
+
+  public T map(MapType sMap, GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T primitive(DataType sPrimitive, PrimitiveType primitive) {
+    return null;
+  }
+
+  protected String[] currentPath() {
+    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
+  }
+
+  protected String[] path(String name) {
+    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
+    list.add(name);
+    return list.toArray(new String[0]);
+  }
+}

--- a/spark/v2.3/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveParquetWithSparkSchemaVisitor.java
+++ b/spark/v2.3/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveParquetWithSparkSchemaVisitor.java
@@ -39,9 +39,8 @@ import java.util.Deque;
 import java.util.List;
 
 /**
- * Visitor for traversing a Parquet type with a companion Spark type.
- *
- * @param <T> the Java class returned by the visitor
+ * Copy from iceberg {@link org.apache.iceberg.spark.data.ParquetWithSparkSchemaVisitor} to change some code, see
+ * annotation "Change For Arctic"
  */
 public class AdaptHiveParquetWithSparkSchemaVisitor<T> {
   private final Deque<String> fieldNames = Lists.newLinkedList();
@@ -170,13 +169,10 @@ public class AdaptHiveParquetWithSparkSchemaVisitor<T> {
       Type field = group.getFields().get(i);
       StructField sField = sFields[i];
 
-      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
-          "Structs do not match: field %s != %s", field.getName(), sField.name());
-
       //Change For Arctic ⬇
       // Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
       //     "Structs do not match: field %s != %s", field.getName(), sField.name());
-      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+      Preconditions.checkArgument(field.getName().equals(sField.name()),
           "Structs do not match: field %s != %s", field.getName(), sField.name());
       //Change For Arctic ⬆
       results.add(visitField(sField, field, visitor));

--- a/spark/v2.3/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveSparkParquetWriters.java
+++ b/spark/v2.3/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveSparkParquetWriters.java
@@ -56,6 +56,9 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.spark.data.SparkParquetWriters} to support int96 type.
+ */
 public class AdaptHiveSparkParquetWriters {
 
   private AdaptHiveSparkParquetWriters() {

--- a/spark/v2.3/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveSparkParquetWriters.java
+++ b/spark/v2.3/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveSparkParquetWriters.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.spark.hive;
+package org.apache.iceberg.spark.data;
 
 import org.apache.iceberg.parquet.AdaptHivePrimitiveWriter;
 import org.apache.iceberg.parquet.ParquetValueReaders;
@@ -24,7 +24,6 @@ import org.apache.iceberg.parquet.ParquetValueWriter;
 import org.apache.iceberg.parquet.ParquetValueWriters;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.data.ParquetWithSparkSchemaVisitor;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.DecimalUtil;
 import org.apache.parquet.column.ColumnDescriptor;
@@ -64,11 +63,11 @@ public class AdaptHiveSparkParquetWriters {
 
   @SuppressWarnings("unchecked")
   public static <T> ParquetValueWriter<T> buildWriter(StructType dfSchema, MessageType type) {
-    return (ParquetValueWriter<T>) ParquetWithSparkSchemaVisitor.visit(dfSchema, type,
-        new AdaptHiveSparkParquetWriters.WriteBuilder(type));
+    return (ParquetValueWriter<T>) AdaptHiveParquetWithSparkSchemaVisitor.visit(dfSchema, type,
+        new WriteBuilder(type));
   }
 
-  private static class WriteBuilder extends ParquetWithSparkSchemaVisitor<ParquetValueWriter<?>> {
+  private static class WriteBuilder extends AdaptHiveParquetWithSparkSchemaVisitor<ParquetValueWriter<?>> {
     private final MessageType type;
 
     WriteBuilder(MessageType type) {
@@ -93,7 +92,7 @@ public class AdaptHiveSparkParquetWriters {
         sparkTypes.add(sparkFields[i].dataType());
       }
 
-      return new AdaptHiveSparkParquetWriters.InternalRowWriter(writers, sparkTypes);
+      return new InternalRowWriter(writers, sparkTypes);
     }
 
     @Override
@@ -104,7 +103,7 @@ public class AdaptHiveSparkParquetWriters {
       int repeatedD = type.getMaxDefinitionLevel(repeatedPath);
       int repeatedR = type.getMaxRepetitionLevel(repeatedPath);
 
-      return new AdaptHiveSparkParquetWriters.ArrayDataWriter<>(repeatedD, repeatedR,
+      return new ArrayDataWriter<>(repeatedD, repeatedR,
           newOption(repeated.getType(0), elementWriter),
           arrayType.elementType());
     }
@@ -119,13 +118,13 @@ public class AdaptHiveSparkParquetWriters {
       int repeatedD = type.getMaxDefinitionLevel(repeatedPath);
       int repeatedR = type.getMaxRepetitionLevel(repeatedPath);
 
-      return new AdaptHiveSparkParquetWriters.MapDataWriter<>(repeatedD, repeatedR,
+      return new MapDataWriter<>(repeatedD, repeatedR,
           newOption(repeatedKeyValue.getType(0), keyWriter),
           newOption(repeatedKeyValue.getType(1), valueWriter),
           mapType.keyType(), mapType.valueType());
     }
 
-    private ParquetValueWriter<?> newOption(org.apache.parquet.schema.Type fieldType, ParquetValueWriter<?> writer) {
+    private ParquetValueWriter<?> newOption(Type fieldType, ParquetValueWriter<?> writer) {
       int maxD = type.getMaxDefinitionLevel(path(fieldType.getName()));
       return ParquetValueWriters.option(fieldType, maxD, writer);
     }
@@ -244,26 +243,26 @@ public class AdaptHiveSparkParquetWriters {
   }
 
   private static ParquetValueWriters.PrimitiveWriter<UTF8String> utf8Strings(ColumnDescriptor desc) {
-    return new AdaptHiveSparkParquetWriters.UTF8StringWriter(desc);
+    return new UTF8StringWriter(desc);
   }
 
   private static ParquetValueWriters.PrimitiveWriter<Decimal> decimalAsInteger(ColumnDescriptor desc,
       int precision, int scale) {
-    return new AdaptHiveSparkParquetWriters.IntegerDecimalWriter(desc, precision, scale);
+    return new IntegerDecimalWriter(desc, precision, scale);
   }
 
   private static ParquetValueWriters.PrimitiveWriter<Decimal> decimalAsLong(ColumnDescriptor desc,
       int precision, int scale) {
-    return new AdaptHiveSparkParquetWriters.LongDecimalWriter(desc, precision, scale);
+    return new LongDecimalWriter(desc, precision, scale);
   }
 
   private static ParquetValueWriters.PrimitiveWriter<Decimal> decimalAsFixed(ColumnDescriptor desc,
       int precision, int scale) {
-    return new AdaptHiveSparkParquetWriters.FixedDecimalWriter(desc, precision, scale);
+    return new FixedDecimalWriter(desc, precision, scale);
   }
 
   private static ParquetValueWriters.PrimitiveWriter<byte[]> byteArrays(ColumnDescriptor desc) {
-    return new AdaptHiveSparkParquetWriters.ByteArrayWriter(desc);
+    return new ByteArrayWriter(desc);
   }
 
   private static class UTF8StringWriter extends ParquetValueWriters.PrimitiveWriter<UTF8String> {

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/io/InternalRowFileAppenderFactory.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/io/InternalRowFileAppenderFactory.java
@@ -18,7 +18,6 @@
 
 package com.netease.arctic.spark.io;
 
-import com.netease.arctic.spark.hive.AdaptHiveSparkParquetWriters;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
@@ -37,9 +36,9 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.AdaptHiveParquet;
 import org.apache.iceberg.parquet.Parquet;
-import org.apache.iceberg.parquet.ParquetValueWriter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.data.AdaptHiveSparkParquetWriters;
 import org.apache.iceberg.spark.data.SparkAvroWriter;
 import org.apache.iceberg.spark.data.SparkOrcWriter;
 import org.apache.iceberg.spark.data.SparkParquetWriters;

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveParquetWithSparkSchemaVisitor.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveParquetWithSparkSchemaVisitor.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Type.Repetition;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Visitor for traversing a Parquet type with a companion Spark type.
+ *
+ * @param <T> the Java class returned by the visitor
+ */
+public class AdaptHiveParquetWithSparkSchemaVisitor<T> {
+  private final Deque<String> fieldNames = Lists.newLinkedList();
+
+  public static <T> T visit(DataType sType, Type type, AdaptHiveParquetWithSparkSchemaVisitor<T> visitor) {
+    Preconditions.checkArgument(sType != null, "Invalid DataType: null");
+    if (type instanceof MessageType) {
+      Preconditions.checkArgument(sType instanceof StructType, "Invalid struct: %s is not a struct", sType);
+      StructType struct = (StructType) sType;
+      return visitor.message(struct, (MessageType) type, visitFields(struct, type.asGroupType(), visitor));
+
+    } else if (type.isPrimitive()) {
+      return visitor.primitive(sType, type.asPrimitiveType());
+
+    } else {
+      // if not a primitive, the typeId must be a group
+      GroupType group = type.asGroupType();
+      OriginalType annotation = group.getOriginalType();
+      if (annotation != null) {
+        switch (annotation) {
+          case LIST:
+            Preconditions.checkArgument(!group.isRepetition(Repetition.REPEATED),
+                "Invalid list: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid list: does not contain single repeated field: %s", group);
+
+            GroupType repeatedElement = group.getFields().get(0).asGroupType();
+            Preconditions.checkArgument(repeatedElement.isRepetition(Repetition.REPEATED),
+                "Invalid list: inner group is not repeated");
+            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+                "Invalid list: repeated group is not a single field: %s", group);
+
+            Preconditions.checkArgument(sType instanceof ArrayType, "Invalid list: %s is not an array", sType);
+            ArrayType array = (ArrayType) sType;
+            StructField element = new StructField(
+                "element", array.elementType(), array.containsNull(), Metadata.empty());
+
+            visitor.fieldNames.push(repeatedElement.getName());
+            try {
+              T elementResult = null;
+              if (repeatedElement.getFieldCount() > 0) {
+                elementResult = visitField(element, repeatedElement.getType(0), visitor);
+              }
+
+              return visitor.list(array, group, elementResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          case MAP:
+            Preconditions.checkArgument(!group.isRepetition(Repetition.REPEATED),
+                "Invalid map: top-level group is repeated: %s", group);
+            Preconditions.checkArgument(group.getFieldCount() == 1,
+                "Invalid map: does not contain single repeated field: %s", group);
+
+            GroupType repeatedKeyValue = group.getType(0).asGroupType();
+            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Repetition.REPEATED),
+                "Invalid map: inner group is not repeated");
+            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+                "Invalid map: repeated group does not have 2 fields");
+
+            Preconditions.checkArgument(sType instanceof MapType, "Invalid map: %s is not a map", sType);
+            MapType map = (MapType) sType;
+            StructField keyField = new StructField("key", map.keyType(), false, Metadata.empty());
+            StructField valueField = new StructField(
+                "value", map.valueType(), map.valueContainsNull(), Metadata.empty());
+
+            visitor.fieldNames.push(repeatedKeyValue.getName());
+            try {
+              T keyResult = null;
+              T valueResult = null;
+              switch (repeatedKeyValue.getFieldCount()) {
+                case 2:
+                  // if there are 2 fields, both key and value are projected
+                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
+                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
+                  break;
+                case 1:
+                  // if there is just one, use the name to determine what it is
+                  Type keyOrValue = repeatedKeyValue.getType(0);
+                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
+                    keyResult = visitField(keyField, keyOrValue, visitor);
+                    // value result remains null
+                  } else {
+                    valueResult = visitField(valueField, keyOrValue, visitor);
+                    // key result remains null
+                  }
+                  break;
+                default:
+                  // both results will remain null
+              }
+
+              return visitor.map(map, group, keyResult, valueResult);
+
+            } finally {
+              visitor.fieldNames.pop();
+            }
+
+          default:
+        }
+      }
+
+      Preconditions.checkArgument(sType instanceof StructType, "Invalid struct: %s is not a struct", sType);
+      StructType struct = (StructType) sType;
+      return visitor.struct(struct, group, visitFields(struct, group, visitor));
+    }
+  }
+
+  private static <T> T visitField(StructField sField, Type field, AdaptHiveParquetWithSparkSchemaVisitor<T> visitor) {
+    visitor.fieldNames.push(field.getName());
+    try {
+      return visit(sField.dataType(), field, visitor);
+    } finally {
+      visitor.fieldNames.pop();
+    }
+  }
+
+  private static <T> List<T> visitFields(StructType struct, GroupType group,
+      AdaptHiveParquetWithSparkSchemaVisitor<T> visitor) {
+    StructField[] sFields = struct.fields();
+    Preconditions.checkArgument(sFields.length == group.getFieldCount(),
+        "Structs do not match: %s and %s", struct, group);
+    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
+    for (int i = 0; i < sFields.length; i += 1) {
+      Type field = group.getFields().get(i);
+      StructField sField = sFields[i];
+
+      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+          "Structs do not match: field %s != %s", field.getName(), sField.name());
+
+      //Change For Arctic ⬇
+      // Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+      //     "Structs do not match: field %s != %s", field.getName(), sField.name());
+      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+          "Structs do not match: field %s != %s", field.getName(), sField.name());
+      //Change For Arctic ⬆
+      results.add(visitField(sField, field, visitor));
+    }
+
+    return results;
+  }
+
+  public T message(StructType sStruct, MessageType message, List<T> fields) {
+    return null;
+  }
+
+  public T struct(StructType sStruct, GroupType struct, List<T> fields) {
+    return null;
+  }
+
+  public T list(ArrayType sArray, GroupType array, T element) {
+    return null;
+  }
+
+  public T map(MapType sMap, GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T primitive(DataType sPrimitive, PrimitiveType primitive) {
+    return null;
+  }
+
+  protected String[] currentPath() {
+    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
+  }
+
+  protected String[] path(String name) {
+    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
+    list.add(name);
+    return list.toArray(new String[0]);
+  }
+}

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveParquetWithSparkSchemaVisitor.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveParquetWithSparkSchemaVisitor.java
@@ -39,9 +39,8 @@ import java.util.Deque;
 import java.util.List;
 
 /**
- * Visitor for traversing a Parquet type with a companion Spark type.
- *
- * @param <T> the Java class returned by the visitor
+ * Copy from iceberg {@link org.apache.iceberg.spark.data.ParquetWithSparkSchemaVisitor} to change some code, see
+ * annotation "Change For Arctic"
  */
 public class AdaptHiveParquetWithSparkSchemaVisitor<T> {
   private final Deque<String> fieldNames = Lists.newLinkedList();
@@ -170,13 +169,10 @@ public class AdaptHiveParquetWithSparkSchemaVisitor<T> {
       Type field = group.getFields().get(i);
       StructField sField = sFields[i];
 
-      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
-          "Structs do not match: field %s != %s", field.getName(), sField.name());
-
       //Change For Arctic ⬇
       // Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
       //     "Structs do not match: field %s != %s", field.getName(), sField.name());
-      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
+      Preconditions.checkArgument(field.getName().equals(sField.name()),
           "Structs do not match: field %s != %s", field.getName(), sField.name());
       //Change For Arctic ⬆
       results.add(visitField(sField, field, visitor));

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveSparkParquetWriters.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/AdaptHiveSparkParquetWriters.java
@@ -56,6 +56,9 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
+/**
+ * Copy from iceberg {@link org.apache.iceberg.spark.data.SparkParquetWriters} to support int96 type.
+ */
 public class AdaptHiveSparkParquetWriters {
 
   private AdaptHiveSparkParquetWriters() {

--- a/style/arctic-checkstyle.xml
+++ b/style/arctic-checkstyle.xml
@@ -186,26 +186,26 @@
             <message key="name.invalidPattern"
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
-<!--        <module name="ParameterName">-->
-<!--            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>-->
-<!--            <message key="name.invalidPattern"-->
-<!--                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>-->
-<!--        </module>-->
-<!--        <module name="LambdaParameterName">-->
-<!--            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>-->
-<!--            <message key="name.invalidPattern"-->
-<!--                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>-->
-<!--        </module>-->
-<!--        <module name="CatchParameterName">-->
-<!--            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>-->
-<!--            <message key="name.invalidPattern"-->
-<!--                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>-->
-<!--        </module>-->
-<!--        <module name="LocalVariableName">-->
-<!--            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>-->
-<!--            <message key="name.invalidPattern"-->
-<!--                     value="Local variable name ''{0}'' must match pattern ''{1}''."/>-->
-<!--        </module>-->
+        <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LambdaParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
         <module name="ClassTypeParameterName">
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
             <message key="name.invalidPattern"

--- a/style/arctic-checkstyle.xml
+++ b/style/arctic-checkstyle.xml
@@ -186,26 +186,26 @@
             <message key="name.invalidPattern"
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        <module name="ParameterName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
-            <message key="name.invalidPattern"
-                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>
-        </module>
-        <module name="LambdaParameterName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
-            <message key="name.invalidPattern"
-                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
-        </module>
-        <module name="CatchParameterName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
-            <message key="name.invalidPattern"
-                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
-        </module>
-        <module name="LocalVariableName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
-            <message key="name.invalidPattern"
-                     value="Local variable name ''{0}'' must match pattern ''{1}''."/>
-        </module>
+<!--        <module name="ParameterName">-->
+<!--            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>-->
+<!--            <message key="name.invalidPattern"-->
+<!--                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>-->
+<!--        </module>-->
+<!--        <module name="LambdaParameterName">-->
+<!--            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>-->
+<!--            <message key="name.invalidPattern"-->
+<!--                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>-->
+<!--        </module>-->
+<!--        <module name="CatchParameterName">-->
+<!--            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>-->
+<!--            <message key="name.invalidPattern"-->
+<!--                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>-->
+<!--        </module>-->
+<!--        <module name="LocalVariableName">-->
+<!--            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>-->
+<!--            <message key="name.invalidPattern"-->
+<!--                     value="Local variable name ''{0}'' must match pattern ''{1}''."/>-->
+<!--        </module>-->
         <module name="ClassTypeParameterName">
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
             <message key="name.invalidPattern"

--- a/style/suppressions.xml
+++ b/style/suppressions.xml
@@ -28,5 +28,7 @@
     <suppress checks="naming" files="ArcticIndexHBaseWriter"/>
     <suppress checks="naming" files="ArcticRowDataHBaseLookupFunction"/>
     <suppress checks="naming" files="ShuffleRulePolicy"/>
+    <suppress checks="naming" files="AdaptHiveParquetWithFlinkSchemaVisitor"/>
+    <suppress checks="naming" files="AdaptHiveParquetWithSparkSchemaVisitor"/>
 </suppressions>
 


### PR DESCRIPTION
## Why are the changes needed?
see #585 

## Brief change log
- Remove column name compatible logic with avro  in `AdaptHiveTypeToMessageType` to avoid transfroming "$" to "_X24"
- Use new `AdaptHiveTypeToMessageType` in Flink/Spark
- Copy  `org.apache.iceberg.flink.data.AdaptHiveParquetWithFlinkSchemaVisitor` from iceberg  `org.apache.iceberg.flink.data.ParquetWithFlinkSchemaVisitor` to avoid checking name compatible
- Copy  `org.apache.iceberg.flink.data.AdaptHiveParquetWithSparkSchemaVisitor` from iceberg  `org.apache.iceberg.flink.data.ParquetWithSparkSchemaVisitor`  to avoid checking name compatible



## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
