### PR TITLE
[Flink][bugfix] Fixed the ClassNotFoundException problem about Flink Kafka Connector under Flink 1.15

### DIFF
--- a/flink/v1.15/flink-runtime/pom.xml
+++ b/flink/v1.15/flink-runtime/pom.xml
@@ -179,7 +179,7 @@
                             </excludes>
                         </filter>
                         <filter>
-                            <artifact>org.apache.flink:flink-connector-kafka_${scala.binary.version}</artifact>
+                            <artifact>org.apache.flink:flink-connector-kafka</artifact>
                             <excludes>
                                 <exclude>META-INF/**</exclude>
                                 <exclude>org/apache/flink/table/descriptors/**</exclude>
@@ -214,7 +214,7 @@
                             <include>cglib:*</include>
                             <include>com.google.guava:*</include>
                             <include>asm:*</include>
-                            <include>org.apache.flink:flink-connector-kafka_${scala.binary.version}</include>
+                            <include>org.apache.flink:flink-connector-kafka</include>
                             <include>org.apache.kafka:*</include>
                         </includes>
                     </artifactSet>


### PR DESCRIPTION
## Why are the changes needed?

*when use Arctic-flink 1.15, we will get the ClassNotFoundException about flink-connector-kafka dependency*

## Brief change log

  - *Replaced dependency names for flink-connector-kafka in the pom file*
 
## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request
