### PR TITLE
[Flink][bugfix] Fixed the problem of duplicate primary key data in Arctic table with upsert feature enabled

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -91,7 +91,7 @@ public class FlinkSink {
     private Properties producerConfig;
     private String topic;
     private boolean overwrite = false;
-    private DistributionHashMode distributionMode = DistributionHashMode.NONE;
+    private DistributionHashMode distributionMode = null;
 
     private Builder() {
     }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -380,6 +380,68 @@ public class TestKeyed extends FlinkTestBase {
   }
 
   @Test
+  public void testFileUpsertWithSamePrimaryKey() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000004, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000011, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000011, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
+        InternalTypeInfo.ofFields(
+            DataTypes.INT().getLogicalType(),
+            DataTypes.VARCHAR(100).getLogicalType(),
+            DataTypes.TIMESTAMP().getLogicalType()
+        ));
+
+    getEnv().setParallelism(4);
+    Table input = getTableEnv().fromDataStream(source, $("id"), $("name"), $("op_time"));
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+        ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE +
+        "/*+ OPTIONS(" +
+        "'arctic.emit.mode'='file'" +
+        ")*/" + " select * from input");
+
+    TableResult result = exec("select * from arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+        "'streaming'='false'" +
+        ") */");
+    LinkedList<Row> actual = new LinkedList<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      while (iterator.hasNext()) {
+          Row row = iterator.next();
+          actual.add(row);
+      }
+    }
+
+    LinkedList<Object[]> expected = new LinkedList<>();
+
+    expected.add(new Object[]{RowKind.DELETE, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000004, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000004, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000011, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000011, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000011, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000011, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+
+    Map<Object, List<Row>> actualMap = DataUtil.groupByPrimaryKey(actual, 0);
+    Map<Object, List<Row>> expectedMap = DataUtil.groupByPrimaryKey(DataUtil.toRowList(expected), 0);
+
+    for (Object key : actualMap.keySet()) {
+      Assert.assertTrue(CollectionUtils.isEqualCollection(actualMap.get(key),expectedMap.get(key)));
+    }
+  }
+
+  @Test
   public void testPartitionLogSinkSource() throws Exception {
     String topic = this.topic + "testPartitionLogSinkSource";
     kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/util/DataUtil.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/util/DataUtil.java
@@ -36,9 +36,12 @@ import org.junit.Assert;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -123,6 +126,17 @@ public class DataUtil {
       throw new RuntimeException(e);
     }
     return records;
+  }
+
+  public static Map<Object, List<Row>> groupByPrimaryKey(List<Row> rowList, int pkIdx) {
+    Map<Object, List<Row>> result = new HashMap<>();
+    for (Row row : rowList) {
+      Object pk = row.getField(pkIdx);
+      List<Row> list = result.getOrDefault(pk, new LinkedList<>());
+      list.add(row);
+      result.put(pk, list);
+    }
+    return result;
   }
 
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -91,7 +91,7 @@ public class FlinkSink {
     private Properties producerConfig;
     private String topic;
     private boolean overwrite = false;
-    private DistributionHashMode distributionMode = DistributionHashMode.NONE;
+    private DistributionHashMode distributionMode = null;
 
     private Builder() {
     }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/DataUtil.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/DataUtil.java
@@ -36,9 +36,12 @@ import org.junit.Assert;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -124,6 +127,17 @@ public class DataUtil {
       throw new RuntimeException(e);
     }
     return records;
+  }
+
+  public static Map<Object, List<Row>> groupByPrimaryKey(List<Row> rowList, int pkIdx) {
+    Map<Object, List<Row>> result = new HashMap<>();
+    for (Row row : rowList) {
+      Object pk = row.getField(pkIdx);
+      List<Row> list = result.getOrDefault(pk, new LinkedList<>());
+      list.add(row);
+      result.put(pk, list);
+    }
+    return result;
   }
 
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -93,7 +93,7 @@ public class FlinkSink {
     private Properties producerConfig;
     private String topic;
     private boolean overwrite = false;
-    private DistributionHashMode distributionMode = DistributionHashMode.NONE;
+    private DistributionHashMode distributionMode = null;
 
     private Builder() {
     }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/util/DataUtil.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/util/DataUtil.java
@@ -36,9 +36,12 @@ import org.junit.Assert;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -124,6 +127,17 @@ public class DataUtil {
       throw new RuntimeException(e);
     }
     return records;
+  }
+
+  public static Map<Object, List<Row>> groupByPrimaryKey(List<Row> rowList, int pkIdx) {
+    Map<Object, List<Row>> result = new HashMap<>();
+    for (Row row : rowList) {
+      Object pk = row.getField(pkIdx);
+      List<Row> list = result.getOrDefault(pk, new LinkedList<>());
+      list.add(row);
+      result.put(pk, list);
+    }
+    return result;
   }
 
 }

--- a/site/docs/ch/flink/flink-get-started.md
+++ b/site/docs/ch/flink/flink-get-started.md
@@ -98,3 +98,7 @@ Arctic 0.3.1 版本开始支持 Hive 兼容的功能，可以通过 Flink 读取
 ## 常见问题
 ### 写 Arctic 表 File 数据不可见
 需要打开 Flink checkpoint，修改 Flink conf 中的 [Flink checkpoint 配置](https://nightlies.apache.org/flink/flink-docs-release-1.12/deployment/config.html#execution-checkpointing-interval)，数据只有在 checkpoint 时才会提交。
+### 通过 Flink SQL-Client 读取开启了 write.upsert 特性的 Arctic 表时，仍存在重复主键的数据
+通过 Flink SQL-Client 得到的查询结果不能提供基于主键的 MOR 语义，如果需要通过 Flink 引擎查询得到合并后的结果，可以将 Arctic 表的内容通过 JDBC connector 写入到 MySQL 表中进行查看
+### Flink 1.15 版本下通过 SQL-Client 写入开启了 write.upsert 特性的 Arctic 表时，仍存在重复主键的数据
+需要在 SQL-Client 中执行命令 set table.exec.sink.upsert-materialize = none，以关闭 upsert materialize 算子生成的 upsert 视图。该算子会影响 ArcticWriter 在 write.upsert 特性开启时生成 delete 数据，导致重复主键的数据无法合并


### PR DESCRIPTION
fixed #592 

## Why are the changes needed?

*When an Arctic table with the write.upsert feature enabled is read, data with the same primary key will exist, which should be fixed*

## Brief change log

  - *replace the shuffle policy involved in write operations*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request
