### PR TITLE
[SPARK]Feature set the nullable is false to the primary key field

### DIFF
--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/analysis/ResolveArcticCommand.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/analysis/ResolveArcticCommand.scala
@@ -40,6 +40,7 @@ case class ResolveArcticCommand(spark: SparkSession) extends Rule[LogicalPlan] {
         .withTarget(seqAsJavaList(target))
         .build()
       plans.MigrateToArcticLogicalPlan(command)
+    // set the nullable is false to the primary key field
     case i@InsertIntoStatement(r: DataSourceV2Relation,
     partition, cols, query, overwrite, ifPartitionNotExists) =>
       val output = query.output.map(f =>

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
@@ -78,7 +78,7 @@ public class TestKeyedTableDml extends SparkTestBase {
     sql(createTableInsert, database, insertTable);
     rows = sql("select * from {0}.{1} ", database, notUpsertTable);
     Assert.assertEquals(3, rows.size());
-    sql("insert overwrite " + database + "." + insertTable + " select * from {0}.{1} ", database, notUpsertTable);
+    sql("insert into " + database + "." + insertTable + " select * from {0}.{1} ", database, notUpsertTable);
 
     rows = sql("select * from {0}.{1} ", database, notUpsertTable);
     Assert.assertEquals(3, rows.size());


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
when insert into/overwrite select , source table is unkeyed table or hive table, will throw exception cause the schema attribute does not correspond

Now set the property nullable is false to the primary key field, let target schema and source schema  correspond


## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request


