### PR TITLE
[ARCTIC-617][Improvement]: do some initialization when add catalog

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/controller/CatalogController.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/controller/CatalogController.java
@@ -223,7 +223,7 @@ public class CatalogController extends RestBaseController {
             STORAGE_CONFIGS_KEY_CORE_SITE,
             STORAGE_CONFIGS_KEY_HIVE_SITE);
 
-    // when update catalog, fileId won't be post when config doesn't been changed!
+    // when update catalog, fileId won't be post when file doesn't been changed!
     Integer idx = 0;
     boolean fillUseOld = oldCatalogMeta != null;
     for (idx = 0; idx < metaKeyList.size(); idx++) {
@@ -239,9 +239,17 @@ public class CatalogController extends RestBaseController {
         }
       }
     }
-    // if hive.site is not present, we give a default value!
+    // if site.xml is not present, we give a default value!
     if (StringUtils.isEmpty(metaStorageConfig.get(STORAGE_CONFIGS_KEY_HIVE_SITE))) {
       metaStorageConfig.put(STORAGE_CONFIGS_KEY_HIVE_SITE, EMPTY_XML_BASE64);
+    }
+
+    if (StringUtils.isEmpty(metaStorageConfig.get(STORAGE_CONFIGS_KEY_HDFS_SITE))) {
+      metaStorageConfig.put(STORAGE_CONFIGS_KEY_HDFS_SITE, EMPTY_XML_BASE64);
+    }
+
+    if (StringUtils.isEmpty(metaStorageConfig.get(STORAGE_CONFIGS_KEY_CORE_SITE))) {
+      metaStorageConfig.put(STORAGE_CONFIGS_KEY_CORE_SITE, EMPTY_XML_BASE64);
     }
     catalogMeta.setStorageConfigs(metaStorageConfig);
     return catalogMeta;

--- a/ams/ams-server/src/main/resources/sql/derby/ams-init.sql
+++ b/ams/ams-server/src/main/resources/sql/derby/ams-init.sql
@@ -266,4 +266,4 @@ CREATE TABLE platform_file_info (
   PRIMARY KEY (id)
 );
 
-INSERT INTO catalog_metadata(catalog_name,display_name,catalog_type,storage_configs,auth_configs, catalog_properties) VALUES ('local_catalog',NULL,'hadoop','{"storage.type":"hdfs","hive.site":"","hadoop.core.site":"","hadoop.hdfs.site":""}','{"auth.type":"SIMPLE","auth.simple.hadoop_username":"root"}','{"warehouse.dir":"/tmp/arctic/warehouse","table-formats":"HIVE"}');
+INSERT INTO catalog_metadata(catalog_name,catalog_type,storage_configs,auth_configs, catalog_properties) VALUES ('local_catalog','ams','{"storage.type":"hdfs","hive.site":"","hadoop.core.site":"","hadoop.hdfs.site":""}','{"auth.type":"simple","auth.simple.hadoop_username":"root"}','{"warehouse.dir":"/tmp/arctic/warehouse","table-formats":"ICEBERG"}');

--- a/ams/ams-server/src/main/resources/sql/derby/ams-init.sql
+++ b/ams/ams-server/src/main/resources/sql/derby/ams-init.sql
@@ -266,4 +266,4 @@ CREATE TABLE platform_file_info (
   PRIMARY KEY (id)
 );
 
-INSERT INTO catalog_metadata(catalog_name,catalog_type,storage_configs,auth_configs, catalog_properties) VALUES ('local_catalog','ams','{"storage.type":"hdfs","hive.site":"","hadoop.core.site":"","hadoop.hdfs.site":""}','{"auth.type":"simple","auth.simple.hadoop_username":"root"}','{"warehouse.dir":"/tmp/arctic/warehouse","table-formats":"ICEBERG"}');
+INSERT INTO catalog_metadata(catalog_name,catalog_type,storage_configs,auth_configs, catalog_properties) VALUES ('local_catalog','ams','{"storage.type":"hdfs","hive.site":"PGNvbmZpZ3VyYXRpb24+PC9jb25maWd1cmF0aW9uPg==","hadoop.core.site":"PGNvbmZpZ3VyYXRpb24+PC9jb25maWd1cmF0aW9uPg==","hadoop.hdfs.site":"PGNvbmZpZ3VyYXRpb24+PC9jb25maWd1cmF0aW9uPg=="}','{"auth.type":"simple","auth.simple.hadoop_username":"root"}','{"warehouse.dir":"/tmp/arctic/warehouse","table-formats":"ICEBERG"}');

--- a/ams/ams-server/src/main/resources/sql/mysql/0.4.0-init.sql
+++ b/ams/ams-server/src/main/resources/sql/mysql/0.4.0-init.sql
@@ -277,4 +277,14 @@ CREATE TABLE `ddl_record`
     `commit_time`      timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'ddl commit time'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'ddl record of table';
 
-INSERT INTO catalog_metadata(catalog_name,display_name,catalog_type,storage_configs,auth_configs, catalog_properties) VALUES ('local_catalog',NULL,'hadoop','{"storage.type":"hdfs","hive.site":"","hadoop.core.site":"","hadoop.hdfs.site":""}','{"auth.type":"SIMPLE","auth.simple.hadoop_username":"root"}','{"warehouse.dir":"/tmp/arctic/warehouse","table-formats":"HIVE"}');
+
+CREATE TABLE `platform_file_info` (
+  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'file id',
+  `file_name` varchar(100) NOT NULL COMMENT 'file name',
+  `file_content_b64` text NOT NULL COMMENT 'file content encoded with base64',
+  `file_path` varchar(100) DEFAULT NULL COMMENT 'may be hdfs path , not be used now',
+  `add_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'add timestamp',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COMMENT='store files info saved in the platform';
+
+INSERT INTO catalog_metadata(catalog_name,display_name,catalog_type,storage_configs,auth_configs, catalog_properties) VALUES ('local_catalog',NULL,'ams','{"storage.type":"hdfs","hive.site":"","hadoop.core.site":"","hadoop.hdfs.site":""}','{"auth.type":"simple","auth.simple.hadoop_username":"root"}','{"warehouse.dir":"/tmp/arctic/warehouse","table-formats":"ICEBERG"}');

--- a/ams/ams-server/src/main/resources/sql/mysql/0.4.0-init.sql
+++ b/ams/ams-server/src/main/resources/sql/mysql/0.4.0-init.sql
@@ -287,4 +287,4 @@ CREATE TABLE `platform_file_info` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COMMENT='store files info saved in the platform';
 
-INSERT INTO catalog_metadata(catalog_name,display_name,catalog_type,storage_configs,auth_configs, catalog_properties) VALUES ('local_catalog',NULL,'ams','{"storage.type":"hdfs","hive.site":"","hadoop.core.site":"","hadoop.hdfs.site":""}','{"auth.type":"simple","auth.simple.hadoop_username":"root"}','{"warehouse.dir":"/tmp/arctic/warehouse","table-formats":"ICEBERG"}');
+INSERT INTO catalog_metadata(catalog_name,display_name,catalog_type,storage_configs,auth_configs, catalog_properties) VALUES ('local_catalog',NULL,'ams','{"storage.type":"hdfs","hive.site":"PGNvbmZpZ3VyYXRpb24+PC9jb25maWd1cmF0aW9uPg==","hadoop.core.site":"PGNvbmZpZ3VyYXRpb24+PC9jb25maWd1cmF0aW9uPg==","hadoop.hdfs.site":"PGNvbmZpZ3VyYXRpb24+PC9jb25maWd1cmF0aW9uPg=="}','{"auth.type":"simple","auth.simple.hadoop_username":"root"}','{"warehouse.dir":"/tmp/arctic/warehouse","table-formats":"ICEBERG"}');


### PR DESCRIPTION
resolve https://github.com/NetEase/arctic/issues/617



## Brief change log
we set table-format ICEBERG , catalog type ams in local catalog,
add paltform_file_info ddl in init sql.
add storage.type with value hdfs add storage_configs of Catalog object when adding catalog.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
