### PR TITLE
[Arctic-479][MOR]: fix getting null sequence from manifest entry when plan change table

### DIFF
--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestKeyedTableDMLInsertOverwriteDynamic.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestKeyedTableDMLInsertOverwriteDynamic.java
@@ -93,6 +93,18 @@ public class TestKeyedTableDMLInsertOverwriteDynamic extends SparkTestBase {
     Assert.assertEquals(6, rows.size());
 
     assertContainIdSet(rows, 0, 7, 8, 9, 3, 6, 1024);
+
+    writeChange(identifier, ChangeAction.INSERT, Lists.newArrayList(
+        newRecord(keyedTable, 1, "ddd", quickDateWithZone(1)),
+        newRecord(keyedTable, 3, "eee", quickDateWithZone(2)),
+        newRecord(keyedTable, 5, "666", quickDateWithZone(3)),
+        newRecord(keyedTable, 2004, "1024", quickDateWithZone(4))
+    ));
+
+    rows = sql("select id, data, ts from {0}.{1} order by id", database, table);
+    Assert.assertEquals(10, rows.size());
+
+    assertContainIdSet(rows, 0, 1, 3, 5, 7, 8, 9, 3, 6, 1024, 2004);
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To fix #479 , Iceberg EntriesTables return Entry from manifest with null sequence, the right sequence should be inherited from manifest metadata (in manifest list).

## Brief change log

  - use the `rows` API of `org.apache.iceberg.DataTask` which uses the inherited sequence number

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
