### PR TITLE
[ARCTIC-660][AMS] Derby does not support the `limit` syntax

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/derby/DerbyPlatformFileInfoMapper.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/derby/DerbyPlatformFileInfoMapper.java
@@ -4,6 +4,7 @@ import com.netease.arctic.ams.server.mapper.PlatformFileInfoMapper;
 import com.netease.arctic.ams.server.model.PlatformFileInfo;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
 
 /**
  * @Auth: hzwangtao6
@@ -18,4 +19,8 @@ public interface DerbyPlatformFileInfoMapper extends PlatformFileInfoMapper {
   @Insert("insert into " + TABLE_NAME + "(file_name,file_content_b64)" +
           "values(#{fileInfo.fileName},#{fileInfo.fileContent})")
   void addFile(@Param("fileInfo") PlatformFileInfo platformFileInfo);
+
+  // get fileId by content which is encoded with base64. ** caution: for derby only
+  @Select("select id from " + TABLE_NAME + " where file_content_b64=#{content} fetch first 1 rows only")
+  Integer getFileId(@Param("content") String content);
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?

Fix #660 

## Brief change log

`fetch first 1 rows only` instead `limit 1`

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
