### PR TITLE
[Bug][ARCTIC-669]Wrong optimizer resource allocation display for local optimizer in Arctic Dashboard

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/controller/OptimizerController.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/controller/OptimizerController.java
@@ -239,7 +239,7 @@ public class OptimizerController extends RestBaseController {
         optimizerService.insertOptimizer(optimizerName, optimizerGroupInfo.getId(), optimizerGroupInfo.getName(),
             TableTaskStatus.STARTING,
             new SimpleDateFormat("yyyy-MM-dd-HH:mm:ss").format(new Date()),
-            parallelism + 1, Long.parseLong(memory), parallelism, container);
+            parallelism, Long.parseLong(memory), parallelism, container);
       } else if (containerType.equals("flink")) {
         int tmMemory = Integer.parseInt(optimizerGroupInfo.getProperties().get("taskmanager.memory"));
         int jmMemory = Integer.parseInt(optimizerGroupInfo.getProperties().get("jobmanager.memory"));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix https://github.com/NetEase/arctic/issues/669

## Brief change log

when the container type of optimizer is local, the core number equals parallelism.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
