### PR TITLE
[ARCTIC-652][Trino]Reconstruct Trino type to Iceberg type

### DIFF
--- a/trino/src/main/java/com/netease/arctic/trino/keyed/KeyedDeleteFilter.java
+++ b/trino/src/main/java/com/netease/arctic/trino/keyed/KeyedDeleteFilter.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
 import java.util.List;
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.iceberg.TypeConverter.toIcebergType;
 
 /**
  * KeyedDeleteFilter is used to do MOR for Keyed Table
@@ -67,41 +69,33 @@ public class KeyedDeleteFilter extends ArcticDeleteFilter<TrinoRow> {
   }
 
   private static Schema filterSchema(Schema tableSchema, List<IcebergColumnHandle> requestedColumns) {
-    Set<Integer> requestedFieldIds = requestedColumns.stream()
-        .map(IcebergColumnHandle::getId)
-        .collect(toImmutableSet());
-    return new Schema(filterFieldList(tableSchema.columns(), requestedFieldIds));
+    return new Schema(filterFieldList(tableSchema.columns(), requestedColumns));
   }
 
   private static List<Types.NestedField> filterFieldList(
       List<Types.NestedField> fields,
-      Set<Integer> requestedFieldIds) {
-    return fields.stream()
-        .map(field -> filterField(field, requestedFieldIds))
+      List<IcebergColumnHandle> requestedSchemas) {
+    return requestedSchemas.stream()
+        .map(id -> filterField(id, fields))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .collect(toImmutableList());
   }
 
-  private static Optional<Types.NestedField> filterField(Types.NestedField field, Set<Integer> requestedFieldIds) {
-    Type fieldType = field.type();
-    if (requestedFieldIds.contains(field.fieldId())) {
-      return Optional.of(field);
-    }
-
-    if (fieldType.isStructType()) {
-      List<Types.NestedField> requiredChildren = filterFieldList(fieldType.asStructType().fields(), requestedFieldIds);
-      if (requiredChildren.isEmpty()) {
-        return Optional.empty();
+  private static Optional<Types.NestedField> filterField(
+      IcebergColumnHandle requestedSchema, List<Types.NestedField> fields) {
+    for (Types.NestedField nestedField: fields) {
+      if (nestedField.fieldId() == requestedSchema.getId()) {
+        return Optional.of(nestedField);
       }
-      return Optional.of(Types.NestedField.of(
-          field.fieldId(),
-          field.isOptional(),
-          field.name(),
-          Types.StructType.of(requiredChildren),
-          field.doc()));
+      if (nestedField.type().isStructType()) {
+        Optional<Types.NestedField> optional = filterField(requestedSchema, nestedField.type().asStructType().fields());
+        if (optional.isPresent()) {
+          return optional;
+        }
+      }
     }
-
-    return Optional.empty();
+    return Optional.of(Types.NestedField.optional(requestedSchema.getId(), requestedSchema.getName(),
+        toIcebergType(requestedSchema.getType())));
   }
 }

--- a/trino/src/test/java/com/netease/arctic/trino/arctic/HiveTestRecords.java
+++ b/trino/src/test/java/com/netease/arctic/trino/arctic/HiveTestRecords.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.trino.arctic;
+
+import com.netease.arctic.hive.HiveTableTestBase;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_ARRAY;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_D;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_ID;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_MAP;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_NAME;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_OP_TIME;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_OP_TIME_WITH_ZONE;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_STRUCT;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_STRUCT_SUB1;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.COLUMN_NAME_STRUCT_SUB2;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.HIVE_TABLE_SCHEMA;
+import static com.netease.arctic.trino.arctic.TestHiveTableBaseForTrino.STRUCT_SUB_SCHEMA;
+
+public class HiveTestRecords {
+
+  public static List<Record> baseRecords() {
+    GenericRecord record = GenericRecord.create(HIVE_TABLE_SCHEMA);
+    GenericRecord structRecord = GenericRecord.create(STRUCT_SUB_SCHEMA);
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+          COLUMN_NAME_ID, 3
+      ).put(
+          COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 3, 12, 0, 0)
+      ).put(
+          COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+                  LocalDateTime.of(2022, 1, 3, 12, 0, 0), ZoneOffset.UTC)
+      )
+      .put(
+          COLUMN_NAME_D, new BigDecimal("102")
+      ).put(
+          COLUMN_NAME_NAME, "jake"
+      ).put(
+          COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+      ).put(
+          COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+      ).put(
+          COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+              "struct_sub2")
+      ).build();
+      builder.add(record.copy(columns));
+    }
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+          COLUMN_NAME_ID, 4
+      ).put(
+          COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 4, 12, 0, 0)
+      ).put(
+          COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+              LocalDateTime.of(2022, 1, 4, 12, 0, 0), ZoneOffset.UTC)
+      )
+      .put(
+          COLUMN_NAME_D, new BigDecimal("103")
+      ).put(
+          COLUMN_NAME_NAME, "sam"
+      ).put(
+          COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+      ).put(
+          COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+      ).put(
+          COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+              "struct_sub2")
+      ).build();
+
+      builder.add(record.copy(columns));
+    }
+    return builder.build();
+  }
+
+  public static List<Record> hiveRecords() {
+    GenericRecord record = GenericRecord.create(HIVE_TABLE_SCHEMA);
+    GenericRecord structRecord = GenericRecord.create(STRUCT_SUB_SCHEMA);
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+              COLUMN_NAME_ID, 1
+          ).put(
+              COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 1, 12, 0, 0)
+          ).put(
+              COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+                  LocalDateTime.of(2022, 1, 1, 12, 0, 0), ZoneOffset.UTC)
+          )
+          .put(
+              COLUMN_NAME_D, new BigDecimal("100")
+          ).put(
+              COLUMN_NAME_NAME, "john"
+          ).put(
+              COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+          ).put(
+              COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+          ).put(
+              COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+                  "struct_sub2")
+          ).build();
+      builder.add(record.copy(columns));
+    }
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+              COLUMN_NAME_ID, 2
+          ).put(
+              COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 2, 12, 0, 0)
+          ).put(
+              COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+                  LocalDateTime.of(2022, 1, 2, 12, 0, 0), ZoneOffset.UTC)
+          )
+          .put(
+              COLUMN_NAME_D, new BigDecimal("101")
+          ).put(
+              COLUMN_NAME_NAME, "lily"
+          ).put(
+              COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+          ).put(
+              COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+          ).put(
+              COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+                  "struct_sub2")
+          ).build();
+      builder.add(record.copy(columns));
+    }
+
+    return builder.build();
+  }
+
+  public static List<Record> changeInsertRecords() {
+    GenericRecord record = GenericRecord.create(HIVE_TABLE_SCHEMA);
+    GenericRecord structRecord = GenericRecord.create(STRUCT_SUB_SCHEMA);
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+              COLUMN_NAME_ID, 5
+          ).put(
+              COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 1, 12, 0, 0)
+          ).put(
+              COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+                  LocalDateTime.of(2022, 1, 1, 12, 0, 0), ZoneOffset.UTC)
+          )
+          .put(
+              COLUMN_NAME_D, new BigDecimal("104")
+          ).put(
+              COLUMN_NAME_NAME, "mary"
+          ).put(
+              COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+          ).put(
+              COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+          ).put(
+              COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+                  "struct_sub2")
+          ).build();
+      builder.add(record.copy(columns));
+    }
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+              COLUMN_NAME_ID, 6
+          ).put(
+              COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 1, 12, 0, 0)
+          ).put(
+              COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+                  LocalDateTime.of(2022, 1, 1, 12, 0, 0), ZoneOffset.UTC)
+          )
+          .put(
+              COLUMN_NAME_D, new BigDecimal("105")
+          ).put(
+              COLUMN_NAME_NAME, "mack"
+          ).put(
+              COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+          ).put(
+              COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+          ).put(
+              COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+                  "struct_sub2")
+          ).build();
+      builder.add(record.copy(columns));
+    }
+
+    return builder.build();
+  }
+
+  public static List<Record> changeDeleteRecords() {
+    GenericRecord record = GenericRecord.create(HIVE_TABLE_SCHEMA);
+    GenericRecord structRecord = GenericRecord.create(STRUCT_SUB_SCHEMA);
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+              COLUMN_NAME_ID, 5
+          ).put(
+              COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 1, 12, 0, 0)
+          ).put(
+              COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+                  LocalDateTime.of(2022, 1, 1, 12, 0, 0), ZoneOffset.UTC)
+          )
+          .put(
+              COLUMN_NAME_D, new BigDecimal("104")
+          ).put(
+              COLUMN_NAME_NAME, "mary"
+          ).put(
+              COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+          ).put(
+              COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+          ).put(
+              COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+                  "struct_sub2")
+          ).build();
+      builder.add(record.copy(columns));
+    }
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+              COLUMN_NAME_ID, 1
+          ).put(
+              COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 1, 12, 0, 0)
+          ).put(
+              COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+                  LocalDateTime.of(2022, 1, 1, 12, 0, 0), ZoneOffset.UTC)
+          )
+          .put(
+              COLUMN_NAME_D, new BigDecimal("100")
+          ).put(
+              COLUMN_NAME_NAME, "john"
+          ).put(
+              COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+          ).put(
+              COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+          ).put(
+              COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+                  "struct_sub2")
+          ).build();
+      builder.add(record.copy(columns));
+    }
+
+    {
+      ImmutableMap columns = ImmutableMap.builder().put(
+              COLUMN_NAME_ID, 3
+          ).put(
+              COLUMN_NAME_OP_TIME, LocalDateTime.of(2022, 1, 3, 12, 0, 0)
+          ).put(
+              COLUMN_NAME_OP_TIME_WITH_ZONE, OffsetDateTime.of(
+                  LocalDateTime.of(2022, 1, 3, 12, 0, 0), ZoneOffset.UTC)
+          )
+          .put(
+              COLUMN_NAME_D, new BigDecimal("102")
+          ).put(
+              COLUMN_NAME_NAME, "jake"
+          ).put(
+              COLUMN_NAME_MAP, ImmutableMap.of("map_key", "map_value")
+          ).put(
+              COLUMN_NAME_ARRAY, ImmutableList.of("array_element")
+          ).put(
+              COLUMN_NAME_STRUCT, structRecord.copy(COLUMN_NAME_STRUCT_SUB1, "struct_sub1", COLUMN_NAME_STRUCT_SUB2,
+                  "struct_sub2")
+          ).build();
+      builder.add(record.copy(columns));
+    }
+
+    return builder.build();
+  }
+}

--- a/trino/src/test/java/com/netease/arctic/trino/arctic/TestBaseArcticPrimaryTable.java
+++ b/trino/src/test/java/com/netease/arctic/trino/arctic/TestBaseArcticPrimaryTable.java
@@ -36,7 +36,6 @@ public class TestBaseArcticPrimaryTable extends TableTestBaseWithInitDataForTrin
     setupTables();
     initData();
     return ArcticQueryRunner.builder()
-        .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
         .setIcebergProperties(ImmutableMap.of("arctic.url",
             String.format("thrift://localhost:%s/%s",AMS.port(), TEST_CATALOG_NAME)))
         .build();

--- a/trino/src/test/java/com/netease/arctic/trino/arctic/TestBaseArcticPrimaryTable.java
+++ b/trino/src/test/java/com/netease/arctic/trino/arctic/TestBaseArcticPrimaryTable.java
@@ -36,6 +36,7 @@ public class TestBaseArcticPrimaryTable extends TableTestBaseWithInitDataForTrin
     setupTables();
     initData();
     return ArcticQueryRunner.builder()
+        .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
         .setIcebergProperties(ImmutableMap.of("arctic.url",
             String.format("thrift://localhost:%s/%s",AMS.port(), TEST_CATALOG_NAME)))
         .build();

--- a/trino/src/test/java/com/netease/arctic/trino/arctic/TestHiveTable.java
+++ b/trino/src/test/java/com/netease/arctic/trino/arctic/TestHiveTable.java
@@ -19,20 +19,23 @@
 package com.netease.arctic.trino.arctic;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.netease.arctic.data.ChangeAction;
-import com.netease.arctic.hive.io.HiveTestRecords;
 import com.netease.arctic.hive.io.writer.AdaptHiveGenericTaskWriterBuilder;
 import com.netease.arctic.hive.table.HiveLocationKind;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.BaseLocationKind;
 import com.netease.arctic.table.ChangeLocationKind;
 import com.netease.arctic.table.LocationKind;
+import io.trino.sql.query.QueryAssertions;
 import io.trino.testing.QueryRunner;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.OverwriteFiles;
@@ -43,8 +46,11 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.parquet.AdaptHiveParquet;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHiveTable extends TestHiveTableBaseForTrino{
 
@@ -100,61 +106,49 @@ public class TestHiveTable extends TestHiveTableBaseForTrino{
   }
 
   @Test
-  public void testHiveTableMOR() {
-    //H2 unsupported timestamp with time zone, timestamp with time zone need test manually
-    assertQuery("select id, name, op_time, \"d$d\" from " + TEST_HIVE_TABLE_FULL_NAME, "VALUES" +
-        "(1, 'john', TIMESTAMP'2022-01-01 12:00:00.000000', 100)," +
-        "(2, 'lily', TIMESTAMP'2022-01-02 12:00:00.000000', 101)," +
-        "(3, 'jake', TIMESTAMP'2022-01-03 12:00:00.000000', 102)," +
-        "(4, 'sam', TIMESTAMP'2022-01-04 12:00:00.000000', 103)");
+  public void testHiveTableMOR() throws InterruptedException {
+    assertCommon("select id, name, op_time, \"d$d\", map_name, array_name, struct_name from "
+        + TEST_HIVE_TABLE_FULL_NAME, ImmutableList.of(v1, v2, v3, v4));
   }
 
   @Test
   public void testKeyedHiveTableMOR() {
-    //H2 unsupported timestamp with time zone, timestamp with time zone need test manually
-    assertQuery("select id, name, op_time, \"d$d\" from " + TEST_HIVE_PK_TABLE_FULL_NAME, "VALUES" +
-        "(2, 'lily', TIMESTAMP'2022-01-02 12:00:00.000000', 101)," +
-        "(4, 'sam', TIMESTAMP'2022-01-04 12:00:00.000000', 103)," +
-        "(6, 'mack', TIMESTAMP'2022-01-01 12:00:00.000000', 105)");
+    assertCommon("select id, name, op_time, \"d$d\", map_name, array_name, struct_name from " + TEST_HIVE_PK_TABLE_FULL_NAME,
+        ImmutableList.of(v2, v4, v6));
   }
 
   @Test
   public void testKeyedHiveTableBase() {
-    //H2 unsupported timestamp with time zone, timestamp with time zone need test manually
-    assertQuery("select id, name, op_time, \"d$d\" from " + TEST_HIVE_PK_TABLE_FULL_NAME_BASE, "VALUES" +
-        "(1, 'john', TIMESTAMP'2022-01-01 12:00:00.000000', 100)," +
-        "(2, 'lily', TIMESTAMP'2022-01-02 12:00:00.000000', 101)," +
-        "(3, 'jake', TIMESTAMP'2022-01-03 12:00:00.000000', 102)," +
-        "(4, 'sam', TIMESTAMP'2022-01-04 12:00:00.000000', 103)");
+    assertCommon("select id, name, op_time, \"d$d\", map_name, array_name, struct_name from "
+        + TEST_HIVE_PK_TABLE_FULL_NAME_BASE, ImmutableList.of(v1, v2, v3, v4));
   }
 
   @Test
   public void testNoPartitionHiveTableMOR() {
-    //H2 unsupported timestamp with time zone, timestamp with time zone need test manually
-    assertQuery("select id, name, op_time, \"d$d\" from " + TEST_UN_PARTITION_HIVE_TABLE_FULL_NAME, "VALUES" +
-        "(1, 'john', TIMESTAMP'2022-01-01 12:00:00.000000', 100)," +
-        "(2, 'lily', TIMESTAMP'2022-01-02 12:00:00.000000', 101)," +
-        "(3, 'jake', TIMESTAMP'2022-01-03 12:00:00.000000', 102)," +
-        "(4, 'sam', TIMESTAMP'2022-01-04 12:00:00.000000', 103)");
+    assertCommon("select id, name, op_time, \"d$d\", map_name, array_name, struct_name from "
+        + TEST_HIVE_PK_TABLE_FULL_NAME_BASE, ImmutableList.of(v1, v2, v3, v4));
   }
 
   @Test
   public void testNoPartitionKeyedHiveTableMOR() {
-    //H2 unsupported timestamp with time zone, timestamp with time zone need test manually
-    assertQuery("select id, name, op_time, \"d$d\" from " + TEST_UN_PARTITION_HIVE_PK_TABLE_FULL_NAME, "VALUES" +
-        "(2, 'lily', TIMESTAMP'2022-01-02 12:00:00.000000', 101)," +
-        "(4, 'sam', TIMESTAMP'2022-01-04 12:00:00.000000', 103)," +
-        "(6, 'mack', TIMESTAMP'2022-01-01 12:00:00.000000', 105)");
+    assertCommon("select id, name, op_time, \"d$d\", map_name, array_name, struct_name from "
+        + TEST_UN_PARTITION_HIVE_PK_TABLE_FULL_NAME, ImmutableList.of(v2, v4, v6));
   }
 
   @Test
   public void testNoPartitionKeyedHiveTableBase() {
-    //H2 unsupported timestamp with time zone, timestamp with time zone need test manually
-    assertQuery("select id, name, op_time, \"d$d\" from " + TEST_UN_PARTITION_HIVE_PK_TABLE_FULL_NAME_BASE, "VALUES" +
-        "(1, 'john', TIMESTAMP'2022-01-01 12:00:00.000000', 100)," +
-        "(2, 'lily', TIMESTAMP'2022-01-02 12:00:00.000000', 101)," +
-        "(3, 'jake', TIMESTAMP'2022-01-03 12:00:00.000000', 102)," +
-        "(4, 'sam', TIMESTAMP'2022-01-04 12:00:00.000000', 103)");
+    assertCommon("select id, name, op_time, \"d$d\", map_name, array_name, struct_name from "
+        + TEST_UN_PARTITION_HIVE_PK_TABLE_FULL_NAME_BASE, ImmutableList.of(v1, v2, v3, v4));
+  }
+
+
+  private void assertCommon(String query, List<List<String>> values) {
+    QueryAssertions.QueryAssert queryAssert = assertThat(query(query));
+    StringJoiner stringJoiner = new StringJoiner(",", "VALUES", "");
+    for (List<String> value: values) {
+      stringJoiner.add(value.stream().collect(Collectors.joining(",", "(", ")")));
+    }
+    queryAssert.skippingTypesCheck().matches(stringJoiner.toString());
   }
 
   @AfterClass
@@ -211,4 +205,59 @@ public class TestHiveTable extends TestHiveTableBaseForTrino{
   private String base(String table) {
     return "\"" + table + "#base\"";
   }
+
+  List<String> v1 = ImmutableList.of(
+      "1",
+      "varchar 'john'",
+      "TIMESTAMP'2022-01-01 12:00:00.000000'",
+      "CAST(100 AS decimal(10,0))",
+      "map(ARRAY[varchar 'map_key'],ARRAY[varchar 'map_value'])",
+      "ARRAY[varchar 'array_element']",
+      "CAST(ROW(varchar 'struct_sub1', varchar 'struct_sub2') " +
+          "AS ROW(struct_name_sub_1 varchar, struct_name_sub_2 varchar))"
+  );
+
+  List<String> v2 = ImmutableList.of(
+      "2",
+      "varchar 'lily'",
+      "TIMESTAMP'2022-01-02 12:00:00.000000'",
+      "CAST(101 AS decimal(10,0))",
+      "map(ARRAY[varchar 'map_key'],ARRAY[varchar 'map_value'])",
+      "ARRAY[varchar 'array_element']",
+      "CAST(ROW(varchar 'struct_sub1', varchar 'struct_sub2') " +
+          "AS ROW(struct_name_sub_1 varchar, struct_name_sub_2 varchar))"
+  );
+
+  List<String> v3 = ImmutableList.of(
+      "3",
+      "varchar 'jake'",
+      "TIMESTAMP'2022-01-03 12:00:00.000000'",
+      "CAST(102 AS decimal(10,0))",
+      "map(ARRAY[varchar 'map_key'],ARRAY[varchar 'map_value'])",
+      "ARRAY[varchar 'array_element']",
+      "CAST(ROW(varchar 'struct_sub1', varchar 'struct_sub2') " +
+          "AS ROW(struct_name_sub_1 varchar, struct_name_sub_2 varchar))"
+  );
+
+  List<String> v4 = ImmutableList.of(
+      "4",
+      "varchar 'sam'",
+      "TIMESTAMP'2022-01-04 12:00:00.000000'",
+      "CAST(103 AS decimal(10,0))",
+      "map(ARRAY[varchar 'map_key'],ARRAY[varchar 'map_value'])",
+      "ARRAY[varchar 'array_element']",
+      "CAST(ROW(varchar 'struct_sub1', varchar 'struct_sub2') " +
+          "AS ROW(struct_name_sub_1 varchar, struct_name_sub_2 varchar))"
+  );
+
+  List<String> v6 = ImmutableList.of(
+      "6",
+      "varchar 'mack'",
+      "TIMESTAMP'2022-01-01 12:00:00.000000'",
+      "CAST(105 AS decimal(10,0))",
+      "map(ARRAY[varchar 'map_key'],ARRAY[varchar 'map_value'])",
+      "ARRAY[varchar 'array_element']",
+      "CAST(ROW(varchar 'struct_sub1', varchar 'struct_sub2') " +
+          "AS ROW(struct_name_sub_1 varchar, struct_name_sub_2 varchar))"
+  );
 }

--- a/trino/src/test/java/com/netease/arctic/trino/arctic/TestHiveTableBaseForTrino.java
+++ b/trino/src/test/java/com/netease/arctic/trino/arctic/TestHiveTableBaseForTrino.java
@@ -83,17 +83,32 @@ public abstract class TestHiveTableBaseForTrino extends TableTestBaseForTrino {
   public static final String COLUMN_NAME_OP_TIME_WITH_ZONE = "op_time_with_zone";
   public static final String COLUMN_NAME_D = "d$d";
   public static final String COLUMN_NAME_NAME = "name";
+  public static final String COLUMN_NAME_MAP = "map_name";
+  public static final String COLUMN_NAME_ARRAY = "array_name";
+  public static final String COLUMN_NAME_STRUCT = "struct_name";
+  public static final String COLUMN_NAME_STRUCT_SUB1 = "struct_name_sub_1";
+  public static final String COLUMN_NAME_STRUCT_SUB2 = "struct_name_sub_2";
 
+  public static final Schema STRUCT_SUB_SCHEMA = new Schema(
+      Types.NestedField.required(12, COLUMN_NAME_STRUCT_SUB1, Types.StringType.get()),
+      Types.NestedField.required(13, COLUMN_NAME_STRUCT_SUB2, Types.StringType.get())
+  );
+
+  private static int i = 0;
   public static final Schema HIVE_TABLE_SCHEMA = new Schema(
-      Types.NestedField.required(1, COLUMN_NAME_ID, Types.IntegerType.get()),
-      Types.NestedField.required(2, COLUMN_NAME_OP_TIME, Types.TimestampType.withoutZone()),
-      Types.NestedField.required(3, COLUMN_NAME_OP_TIME_WITH_ZONE, Types.TimestampType.withZone()),
-      Types.NestedField.required(4, COLUMN_NAME_D, Types.DecimalType.of(10, 0)),
-      Types.NestedField.required(5, COLUMN_NAME_NAME, Types.StringType.get())
+      Types.NestedField.required(++i, COLUMN_NAME_ID, Types.IntegerType.get()),
+      Types.NestedField.required(++i, COLUMN_NAME_OP_TIME, Types.TimestampType.withoutZone()),
+      Types.NestedField.required(++i, COLUMN_NAME_OP_TIME_WITH_ZONE, Types.TimestampType.withZone()),
+      Types.NestedField.required(++i, COLUMN_NAME_D, Types.DecimalType.of(10, 0)),
+      Types.NestedField.required(++i, COLUMN_NAME_MAP, Types.MapType.ofOptional(++i,++i, Types.StringType.get(),
+          Types.StringType.get())),
+      Types.NestedField.required(++i, COLUMN_NAME_ARRAY, Types.ListType.ofOptional(++i, Types.StringType.get())),
+      Types.NestedField.required(++i, COLUMN_NAME_STRUCT, Types.StructType.of(STRUCT_SUB_SCHEMA.columns())),
+      Types.NestedField.required(++i, COLUMN_NAME_NAME, Types.StringType.get())
   );
 
   protected static final PartitionSpec HIVE_SPEC =
-      PartitionSpec.builderFor(HIVE_TABLE_SCHEMA).identity("name").build();
+      PartitionSpec.builderFor(HIVE_TABLE_SCHEMA).identity(COLUMN_NAME_NAME).build();
 
   protected ArcticHiveCatalog hiveCatalog;
   protected UnkeyedHiveTable testHiveTable;


### PR DESCRIPTION
## Why are the changes needed?
Fix: #652 

## Brief change log
Reconstruct Trino type to Iceberg type in com.netease.arctic.trino.keyed.KeyedDeleteFilter

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
