### PR TITLE
[ARCTIC-561] When the flink job fails over, the flink job will commit a wrong transaction id

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -26,6 +26,11 @@ import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -67,6 +72,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private transient int attemptId;
   private transient String jobId;
   private transient long checkpointId = 0;
+  private transient ListState<Long> checkpointState;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
    * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
@@ -93,7 +99,6 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   @Override
   public void open() {
-    this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     this.attemptId = getRuntimeContext().getAttemptNumber();
     this.jobId = getContainingTask().getEnvironment().getJobID().toString();
     table = ArcticUtils.loadArcticTable(tableLoader);
@@ -104,6 +109,34 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     this.writer = table.io().doAs(taskWriterFactory::create);
   }
 
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+
+    this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
+    checkpointState =
+        context.getOperatorStateStore()
+            .getListState(
+                new ListStateDescriptor<>(
+                    subTaskId + "-task-file-writer-state",
+                    LongSerializer.INSTANCE));
+    
+    if (context.isRestored()) {
+      // get last success ckp num from state when failover continuously
+      checkpointId = checkpointState.get().iterator().next();
+      // prepare for the writer init in open(). It is used for next ckpId.
+      checkpointId++;
+    }
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+
+    checkpointState.clear();
+    checkpointState.add(context.getCheckpointId());
+  }
+  
   private void initTaskWriterFactory(Long mask) {
     if (taskWriterFactory instanceof ArcticRowDataTaskWriterFactory) {
       if (mask != null) {
@@ -119,11 +152,17 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     if (table.isKeyedTable()) {
       String signature = BaseEncoding.base16().encode((jobId + checkpointId).getBytes());
       transaction = table.asKeyedTable().beginTransaction(signature);
-      LOG.info("table:{}, signature:{}, transactionId:{}", table.name(), signature, transaction);
+      LOG.info("table:{}, signature:{}, transactionId:{}. From jobId:{}, ckpId:{}", table.name(), signature,
+          transaction, jobId, checkpointId);
     } else {
       transaction = null;
     }
     return transaction;
+  }
+
+  @VisibleForTesting
+  public long getCheckpointId() {
+    return checkpointId;
   }
 
   private long getMask(int subTaskId) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
@@ -141,22 +141,6 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
   }
 
   @Override
-  public void notifyCheckpointComplete(long checkpointId) throws Exception {
-    super.notifyCheckpointComplete(checkpointId);
-    if (logWriter != null) {
-      logWriter.notifyCheckpointComplete(checkpointId);
-    }
-  }
-
-  @Override
-  public void notifyCheckpointAborted(long checkpointId) throws Exception {
-    super.notifyCheckpointAborted(checkpointId);
-    if (logWriter != null) {
-      logWriter.notifyCheckpointAborted(checkpointId);
-    }
-  }
-
-  @Override
   public void endInput() throws Exception {
     if (logWriter != null) {
       logWriter.endInput();

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Properties;
 
 import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull;
@@ -260,33 +259,6 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
     checkpointedState.clear();
     checkpointedState.add(context.getCheckpointId());
     epicNo++;
-  }
-
-  @Override
-  public void notifyCheckpointComplete(long checkpointId) throws Exception {
-    LOG.info(
-        "notifyCheckpointComplete subtaskId={}, checkpointId={}, epicNo={}.",
-        subtaskId,
-        checkpointId,
-        epicNo);
-    checkpointedState.clear();
-    checkpointedState.add(checkpointId);
-  }
-
-  @Override
-  public void notifyCheckpointAborted(long checkpointId) throws Exception {
-    LOG.info(
-        "notifyCheckpointAborted subtaskId={}, checkpointId={}.",
-        subtaskId,
-        checkpointId);
-    if (checkpointedState != null) {
-      Iterator<Long> iterator = checkpointedState.get().iterator();
-      while (iterator.hasNext()) {
-        if (iterator.next() >= checkpointId) {
-          iterator.remove();
-        }
-      }
-    }
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -26,6 +26,9 @@ import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -94,7 +97,6 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   @Override
   public void open() {
-    this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     this.attemptId = getRuntimeContext().getAttemptNumber();
     this.jobId = getContainingTask().getEnvironment().getJobID().toString();
     table = ArcticUtils.loadArcticTable(tableLoader);
@@ -103,6 +105,19 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     initTaskWriterFactory(mask);
 
     this.writer = table.io().doAs(taskWriterFactory::create);
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+
+    this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
+
+    if (context.isRestored()) {
+      checkpointId = context.getRestoredCheckpointId().getAsLong();
+      // prepare for the writer init in open(). It is used for next ckpId.
+      checkpointId++;
+    }
   }
 
   private void initTaskWriterFactory(Long mask) {
@@ -120,11 +135,17 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     if (table.isKeyedTable()) {
       String signature = BaseEncoding.base16().encode((jobId + checkpointId).getBytes());
       transaction = table.asKeyedTable().beginTransaction(signature);
-      LOG.info("table:{}, signature:{}, transactionId:{}", table.name(), signature, transaction);
+      LOG.info("table:{}, signature:{}, transactionId:{}. From jobId:{}, ckpId:{}", table.name(), signature,
+          transaction, jobId, checkpointId);
     } else {
       transaction = null;
     }
     return transaction;
+  }
+
+  @VisibleForTesting
+  public long getCheckpointId() {
+    return checkpointId;
   }
 
   private long getMask(int subTaskId) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
@@ -143,22 +143,6 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
   }
 
   @Override
-  public void notifyCheckpointComplete(long checkpointId) throws Exception {
-    super.notifyCheckpointComplete(checkpointId);
-    if (logWriter != null) {
-      logWriter.notifyCheckpointComplete(checkpointId);
-    }
-  }
-
-  @Override
-  public void notifyCheckpointAborted(long checkpointId) throws Exception {
-    super.notifyCheckpointAborted(checkpointId);
-    if (logWriter != null) {
-      logWriter.notifyCheckpointAborted(checkpointId);
-    }
-  }
-
-  @Override
   public void endInput() throws Exception {
     if (logWriter != null) {
       logWriter.endInput();

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -20,7 +20,10 @@ package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
+import com.netease.arctic.flink.util.TestGlobalAggregateManager;
 import com.netease.arctic.table.ArcticTable;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -50,7 +53,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
   @Parameterized.Parameters(name = "submitEmptySnapshots = {0}")
   public static Object[][] parameters() {
-    return new Object[][] {
+    return new Object[][]{
         {false},
         {true}
     };
@@ -62,11 +65,22 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
   public static OneInputStreamOperatorTestHarness<RowData, WriteResult> createArcticStreamWriter(
       ArcticTableLoader tableLoader) throws Exception {
-    return createArcticStreamWriter(tableLoader, true);
+    return createArcticStreamWriter(tableLoader, true, null);
   }
 
   public static OneInputStreamOperatorTestHarness<RowData, WriteResult> createArcticStreamWriter(
-      ArcticTableLoader tableLoader, boolean submitEmptySnapshots) throws Exception {
+      ArcticTableLoader tableLoader, boolean submitEmptySnapshots, Long restoredCheckpointId) throws Exception {
+    OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
+        doCreateArcticStreamWriter(tableLoader, submitEmptySnapshots, restoredCheckpointId);
+
+    harness.setup();
+    harness.open();
+
+    return harness;
+  }
+
+  public static OneInputStreamOperatorTestHarness<RowData, WriteResult> doCreateArcticStreamWriter(
+      ArcticTableLoader tableLoader, boolean submitEmptySnapshots, Long restoredCheckpointId) throws Exception {
     tableLoader.open();
     ArcticTable arcticTable = tableLoader.loadArcticTable();
     arcticTable.properties().put(SUBMIT_EMPTY_SNAPSHOTS.key(), String.valueOf(submitEmptySnapshots));
@@ -76,18 +90,16 @@ public class ArcticFileWriterTest extends FlinkTestBase {
         false,
         (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType(),
         tableLoader);
-    OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
-        new OneInputStreamOperatorTestHarness<>(
-            streamWriter, 1, 1, 0);
-
-    harness.setup();
-    harness.open();
+    OneInputStreamOperatorInternTest<RowData, WriteResult> harness =
+        new OneInputStreamOperatorInternTest<>(
+            streamWriter, 1, 1, 0, restoredCheckpointId,
+            new TestGlobalAggregateManager());
 
     return harness;
   }
 
   public static TaskWriter<RowData> createUnkeyedTaskWriter(Table table, long targetFileSize, FileFormat format,
-                                                     RowType rowType) {
+                                                            RowType rowType) {
     TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(
         SerializableTable.copyOf(table), rowType, targetFileSize, format, null);
     taskWriterFactory.initialize(1, 1);
@@ -126,6 +138,47 @@ public class ArcticFileWriterTest extends FlinkTestBase {
       List<WriteResult> completedFiles = testHarness.extractOutputValues();
       Assert.assertEquals(2, completedFiles.size());
       Assert.assertEquals(3, completedFiles.get(1).dataFiles().length);
+    }
+  }
+
+  @Test
+  public void testFailover() throws Exception {
+    tableLoader = ArcticTableLoader.of(PK_TABLE_ID, catalogBuilder);
+    long checkpointId = 1L;
+
+    OperatorSubtaskState state;
+    try (
+        OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = doCreateArcticStreamWriter(
+            tableLoader, submitEmptySnapshots, null)) {
+      testHarness.setup();
+      testHarness.initializeEmptyState();
+      testHarness.open();
+      // The first checkpoint
+      testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
+      testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
+      testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
+
+      testHarness.prepareSnapshotPreBarrier(checkpointId);
+      state = testHarness.snapshot(checkpointId, 1L);
+      testHarness.notifyOfCompletedCheckpoint(checkpointId);
+
+      testHarness.prepareSnapshotPreBarrier(checkpointId + 1);
+      testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
+      testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
+      testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
+
+      testHarness.snapshot(checkpointId + 1, 2L);
+    }
+
+    try (
+        OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = doCreateArcticStreamWriter(
+            tableLoader, submitEmptySnapshots, 1L)) {
+      testHarness.setup();
+      testHarness.initializeState(state);
+      testHarness.open();
+
+      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
+      Assert.assertEquals(checkpointId + 1, fileWriter.getCheckpointId());
     }
   }
 
@@ -266,7 +319,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
     long excepted = submitEmptySnapshots ? 1 : 0;
     try (
         OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = createArcticStreamWriter(
-            tableLoader, submitEmptySnapshots)) {
+            tableLoader, submitEmptySnapshots, null)) {
       // The first checkpoint
 
       testHarness.prepareSnapshotPreBarrier(checkpointId);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticWriter.java
@@ -143,22 +143,6 @@ public class ArcticWriter<OUT> extends AbstractStreamOperator<OUT>
   }
 
   @Override
-  public void notifyCheckpointComplete(long checkpointId) throws Exception {
-    super.notifyCheckpointComplete(checkpointId);
-    if (logWriter != null) {
-      logWriter.notifyCheckpointComplete(checkpointId);
-    }
-  }
-
-  @Override
-  public void notifyCheckpointAborted(long checkpointId) throws Exception {
-    super.notifyCheckpointAborted(checkpointId);
-    if (logWriter != null) {
-      logWriter.notifyCheckpointAborted(checkpointId);
-    }
-  }
-
-  @Override
   public void endInput() throws Exception {
     if (logWriter != null) {
       logWriter.endInput();

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterTest.java
@@ -20,7 +20,10 @@ package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
+import com.netease.arctic.flink.util.TestGlobalAggregateManager;
 import com.netease.arctic.table.ArcticTable;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -62,11 +65,22 @@ public class ArcticFileWriterTest extends FlinkTestBase {
 
   public static OneInputStreamOperatorTestHarness<RowData, WriteResult> createArcticStreamWriter(
       ArcticTableLoader tableLoader) throws Exception {
-    return createArcticStreamWriter(tableLoader, true);
+    return createArcticStreamWriter(tableLoader, true, null);
   }
 
   public static OneInputStreamOperatorTestHarness<RowData, WriteResult> createArcticStreamWriter(
-      ArcticTableLoader tableLoader, boolean submitEmptySnapshots) throws Exception {
+      ArcticTableLoader tableLoader, boolean submitEmptySnapshots, Long restoredCheckpointId) throws Exception {
+    OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
+        doCreateArcticStreamWriter(tableLoader, submitEmptySnapshots, restoredCheckpointId);
+
+    harness.setup();
+    harness.open();
+
+    return harness;
+  }
+
+  public static OneInputStreamOperatorTestHarness<RowData, WriteResult> doCreateArcticStreamWriter(
+      ArcticTableLoader tableLoader, boolean submitEmptySnapshots, Long restoredCheckpointId) throws Exception {
     tableLoader.open();
     ArcticTable arcticTable = tableLoader.loadArcticTable();
     arcticTable.properties().put(SUBMIT_EMPTY_SNAPSHOTS.key(), String.valueOf(submitEmptySnapshots));
@@ -75,14 +89,11 @@ public class ArcticFileWriterTest extends FlinkTestBase {
         null,
         false,
         (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType(),
-
         tableLoader);
-    OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
-        new OneInputStreamOperatorTestHarness<>(
-            streamWriter, 1, 1, 0);
-
-    harness.setup();
-    harness.open();
+    OneInputStreamOperatorInternTest<RowData, WriteResult> harness =
+        new OneInputStreamOperatorInternTest<>(
+            streamWriter, 1, 1, 0, restoredCheckpointId,
+            new TestGlobalAggregateManager());
 
     return harness;
   }
@@ -127,6 +138,47 @@ public class ArcticFileWriterTest extends FlinkTestBase {
       List<WriteResult> completedFiles = testHarness.extractOutputValues();
       Assert.assertEquals(2, completedFiles.size());
       Assert.assertEquals(3, completedFiles.get(1).dataFiles().length);
+    }
+  }
+
+  @Test
+  public void testFailover() throws Exception {
+    tableLoader = ArcticTableLoader.of(PK_TABLE_ID, catalogBuilder);
+    long checkpointId = 1L;
+
+    OperatorSubtaskState state;
+    try (
+        OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = doCreateArcticStreamWriter(
+            tableLoader, submitEmptySnapshots, null)) {
+      testHarness.setup();
+      testHarness.initializeEmptyState();
+      testHarness.open();
+      // The first checkpoint
+      testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
+      testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
+      testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
+
+      testHarness.prepareSnapshotPreBarrier(checkpointId);
+      state = testHarness.snapshot(checkpointId, 1L);
+      testHarness.notifyOfCompletedCheckpoint(checkpointId);
+
+      testHarness.prepareSnapshotPreBarrier(checkpointId + 1);
+      testHarness.processElement(createRowData(1, "hello", "2020-10-11T10:10:11.0"), 1);
+      testHarness.processElement(createRowData(2, "hello", "2020-10-12T10:10:11.0"), 1);
+      testHarness.processElement(createRowData(3, "hello", "2020-10-13T10:10:11.0"), 1);
+
+      testHarness.snapshot(checkpointId + 1, 2L);
+    }
+
+    try (
+        OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = doCreateArcticStreamWriter(
+            tableLoader, submitEmptySnapshots, 1L)) {
+      testHarness.setup();
+      testHarness.initializeState(state);
+      testHarness.open();
+
+      ArcticFileWriter fileWriter = (ArcticFileWriter) testHarness.getOneInputOperator();
+      Assert.assertEquals(checkpointId + 1, fileWriter.getCheckpointId());
     }
   }
 
@@ -267,7 +319,7 @@ public class ArcticFileWriterTest extends FlinkTestBase {
     long excepted = submitEmptySnapshots ? 1 : 0;
     try (
         OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = createArcticStreamWriter(
-            tableLoader, submitEmptySnapshots)) {
+            tableLoader, submitEmptySnapshots, null)) {
       // The first checkpoint
 
       testHarness.prepareSnapshotPreBarrier(checkpointId);


### PR DESCRIPTION
… transaction id (#568)

(cherry picked from commit 3ccffa4fa2c3693bf5dacaf071581b20bd43287e)

## Why are the changes needed?
Fix #561 to 0.3.x

## Brief change log
  - *The flink 1.12 and 1.14 , 1.15versions are affected.*

## How was this patch tested?
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
