### PR TITLE
[Arctic][AMS] admin-configured default table properties with adding into catalog #171

### DIFF
--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/properties/CatalogMetaProperties.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/properties/CatalogMetaProperties.java
@@ -63,4 +63,6 @@ public class CatalogMetaProperties {
 
     // properties in table level set by catalog
     public static final String TABLE_PROPERTIES_PREFIX = "table.";
+    public static  final String LOG_STORE_PROPERTIES_PREFIX = "log-store.";
+    public static  final String OPTIMIZE_PROPERTIES_PREFIX = "optimize.";
 }

--- a/core/src/main/java/com/netease/arctic/catalog/BaseArcticCatalog.java
+++ b/core/src/main/java/com/netease/arctic/catalog/BaseArcticCatalog.java
@@ -44,6 +44,7 @@ import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.trace.CreateTableTransaction;
 import com.netease.arctic.utils.CatalogUtil;
 import com.netease.arctic.utils.ConvertStructUtil;
+import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
@@ -433,8 +434,8 @@ public class BaseArcticCatalog implements ArcticCatalog {
 
     @Override
     public ArcticTable create() {
-      doCreateCheck();
       ConvertStructUtil.TableMetaBuilder builder = createTableMataBuilder();
+      doCreateCheck();
       TableMeta meta = builder.build();
       ArcticTable table = doCreateTable(meta);
       createTableMeta(meta);
@@ -556,6 +557,10 @@ public class BaseArcticCatalog implements ArcticCatalog {
       ConvertStructUtil.TableMetaBuilder builder = ConvertStructUtil.newTableMetaBuilder(
           this.identifier, this.schema);
       String tableLocation = getTableLocationForCreate();
+
+      // default properties would not override user-defined properties
+      this.properties = CatalogUtil.mergeCatalogPropertiesToTable(this.properties, catalogMeta.getCatalogProperties());
+
       builder.withTableLocation(tableLocation)
           .withProperties(this.properties)
           .withPrimaryKeySpec(this.primaryKeySpec);

--- a/core/src/main/java/com/netease/arctic/utils/CatalogUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/CatalogUtil.java
@@ -27,6 +27,7 @@ import com.netease.arctic.io.ArcticFileIO;
 import com.netease.arctic.op.ArcticHadoopTableOperations;
 import com.netease.arctic.op.ArcticTableOperations;
 import com.netease.arctic.table.TableMetaStore;
+import com.netease.arctic.table.TableProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.curator.shaded.com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
@@ -186,12 +187,27 @@ public class CatalogUtil {
    */
   public static Map<String, String> mergeCatalogPropertiesToTable(Map<String, String> tableProperties,
                                                                   Map<String, String> catalogProperties) {
-    Map<String, String> mergedProperties = new HashMap<>();
-    catalogProperties.forEach((key, value) -> {
-      if (key.startsWith(CatalogMetaProperties.TABLE_PROPERTIES_PREFIX)) {
-        mergedProperties.put(key.substring(CatalogMetaProperties.TABLE_PROPERTIES_PREFIX.length()), value);
-      }
-    });
+    Map<String, String> mergedProperties = catalogProperties.entrySet().stream()
+            .filter(e -> e.getKey().startsWith(CatalogMetaProperties.TABLE_PROPERTIES_PREFIX))
+            .collect(Collectors.toMap(e ->
+                    e.getKey().substring(CatalogMetaProperties.TABLE_PROPERTIES_PREFIX.length()), Map.Entry::getValue));
+
+    if (!PropertyUtil.propertyAsBoolean(tableProperties, TableProperties.ENABLE_LOG_STORE,
+            TableProperties.ENABLE_LOG_STORE_DEFAULT)) {
+      mergedProperties = mergedProperties.entrySet().stream()
+              .filter(e -> !e.getKey().startsWith(CatalogMetaProperties.LOG_STORE_PROPERTIES_PREFIX))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    String optimizationEnabled = tableProperties.getOrDefault(TableProperties.ENABLE_OPTIMIZE,
+            mergedProperties.getOrDefault(TableProperties.ENABLE_OPTIMIZE, TableProperties.ENABLE_OPTIMIZE_DEFAULT));
+    if (!Boolean.parseBoolean(optimizationEnabled)) {
+      mergedProperties = mergedProperties.entrySet().stream()
+              .filter(e -> !e.getKey().startsWith(CatalogMetaProperties.OPTIMIZE_PROPERTIES_PREFIX))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      // maintain 'optimize.enable' flag as false in table properties
+      mergedProperties.put(TableProperties.ENABLE_OPTIMIZE, optimizationEnabled);
+    }
     mergedProperties.putAll(tableProperties);
 
     return mergedProperties;

--- a/core/src/test/java/com/netease/arctic/utils/CatalogUtilTest.java
+++ b/core/src/test/java/com/netease/arctic/utils/CatalogUtilTest.java
@@ -1,0 +1,249 @@
+package com.netease.arctic.utils;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CatalogUtilTest {
+    /**
+     * when log-store flag is on , fill up with default related props and other user-defined prop should be keep
+     */
+    @Test
+    public void testMergeCatalogPropertiesToTable() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("log-store.enable","true");
+        expected.put("log-store.address","168.0.0.1:9092");
+        expected.put("log-store.type","kafka");
+        expected.put("other.prop","10");
+        expected.put("log-store.consistency.guarantee.enable","true");
+
+        Map<String, String> userDefined = new HashMap<>();
+        userDefined.put("log-store.enable","true");
+        userDefined.put("other.prop","10");
+
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("table.log-store.enable","false");
+        catalogProperties.put("table.log-store.address","168.0.0.1:9092");
+        catalogProperties.put("table.log-store.type","kafka");
+        catalogProperties.put("table.log-store.consistency.guarantee.enable","true");
+        catalogProperties.put("ams.address","127.0.0.1");
+
+        Map<String, String> result = CatalogUtil.mergeCatalogPropertiesToTable(userDefined, catalogProperties);
+        Assert.assertEquals(expected, result);
+    }
+
+    /**
+     * when log-store flag is off, remove all related props
+     */
+    @Test
+    public void testMergeCatalogPropertiesToTable1() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("log-store.enable","false");
+
+        Map<String, String>  userDefined = new HashMap<>();
+        userDefined.put("log-store.enable","false");
+
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("table.log-store.enable","false");
+        catalogProperties.put("table.log-store.address","168.0.0.1:9092");
+        catalogProperties.put("table.log-store.type","kafka");
+        catalogProperties.put("table.log-store.consistency.guarantee.enable","true");
+        catalogProperties.put("ams.address","127.0.0.1");
+
+        Map<String, String> result = CatalogUtil.mergeCatalogPropertiesToTable(userDefined, catalogProperties);
+        Assert.assertEquals(expected, result);
+    }
+
+    /**
+     * user-defined prop should not be overwritten by default props
+     */
+    @Test
+    public void testMergeCatalogPropertiesToTable2() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("log-store.enable","true");
+        expected.put("log-store.address","168.0.0.1:9092");
+        expected.put("log-store.type","pulsar");
+        expected.put("log-store.consistency.guarantee.enable","true");
+
+        Map<String, String> userDefined = new HashMap<>();
+        userDefined.put("log-store.enable","true");
+        userDefined.put("log-store.type","pulsar");
+
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("table.log-store.enable","false");
+        catalogProperties.put("table.log-store.address","168.0.0.1:9092");
+        catalogProperties.put("table.log-store.type","kafka");
+        catalogProperties.put("table.log-store.consistency.guarantee.enable","true");
+        catalogProperties.put("ams.address","127.0.0.1");
+
+        Map<String, String> result = CatalogUtil.mergeCatalogPropertiesToTable(userDefined, catalogProperties);
+        Assert.assertEquals(expected, result);
+    }
+
+    /**
+     * Other user-defined prop should not lose
+     */
+    @Test
+    public void testMergeCatalogPropertiesToTable3() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("log-store.enable","true");
+        expected.put("log-store.address","168.0.0.1:9092");
+        expected.put("log-store.type","kafka");
+        expected.put("log-store.consistency.guarantee.enable","true");
+        expected.put("table.other-props","foo");
+
+        Map<String, String>  userDefined = new HashMap<>();
+        userDefined.put("log-store.enable","true");
+        userDefined.put("log-store.type","kafka");
+        userDefined.put("table.other-props","foo");
+
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("table.log-store.enable","false");
+        catalogProperties.put("table.log-store.address","168.0.0.1:9092");
+        catalogProperties.put("table.log-store.type","kafka");
+        catalogProperties.put("table.log-store.consistency.guarantee.enable","true");
+        catalogProperties.put("ams.address","127.0.0.1");
+
+        Map<String, String> result = CatalogUtil.mergeCatalogPropertiesToTable(userDefined, catalogProperties);
+        Assert.assertEquals(expected, result);
+    }
+
+    /**
+     * user-defined and default catalog 'optimize.enable' are both switched on,
+     * keep all related props
+     */
+    @Test
+    public void testMergeCatalogPropertiesToTable4() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("log-store.enable","true");
+        expected.put("log-store.address","168.0.0.1:9092");
+        expected.put("log-store.type","kafka");
+        expected.put("log-store.consistency.guarantee.enable","true");
+        expected.put("optimize.enable","true");
+        expected.put("optimize.quota","0.2"); // should not overwritten by default
+        expected.put("optimize.group","mygroup"); // inherit from default prop
+        expected.put("table.other-props","foo");
+
+
+        Map<String, String> userDefined = new HashMap<>();
+        userDefined.put("log-store.enable","true");
+        userDefined.put("optimize.enable","true");
+        userDefined.put("optimize.quota","0.2");
+        userDefined.put("table.other-props","foo");
+
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("table.log-store.enable","false");
+        catalogProperties.put("table.log-store.address","168.0.0.1:9092");
+        catalogProperties.put("table.log-store.type","kafka");
+        catalogProperties.put("table.log-store.consistency.guarantee.enable","true");
+        catalogProperties.put("table.optimize.enable","false");
+        catalogProperties.put("table.optimize.quota","0.1");
+        catalogProperties.put("table.optimize.group","mygroup");
+        catalogProperties.put("ams.address","127.0.0.1");
+
+        Map<String, String> result = CatalogUtil.mergeCatalogPropertiesToTable(userDefined, catalogProperties);
+        Assert.assertEquals(expected, result);
+    }
+
+    /**
+     * user-defined and default catalog prop 'optimize.enable' are both switched off,
+     * remove optimizer related props from default catalog
+     * while keep user-defined related prop and 'optimize.enable' itself.
+     */
+    @Test
+    public void testMergeCatalogPropertiesToTable5() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("log-store.enable","true");
+        expected.put("log-store.address","168.0.0.1:9092");
+        expected.put("log-store.type","kafka");
+        expected.put("log-store.consistency.guarantee.enable","true");
+        expected.put("optimize.enable","false");
+        // user-defined related prop should be kept
+        expected.put("optimize.quota","0.2");
+        expected.put("table.other-props","foo");
+
+        Map<String, String> userDefined = new HashMap<>();
+        userDefined.put("log-store.enable","true");
+        userDefined.put("optimize.enable","false");
+        userDefined.put("optimize.quota","0.2");
+        userDefined.put("table.other-props","foo");
+
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("table.log-store.enable","false");
+        catalogProperties.put("table.log-store.address","168.0.0.1:9092");
+        catalogProperties.put("table.log-store.type","kafka");
+        catalogProperties.put("table.log-store.consistency.guarantee.enable","true");
+        catalogProperties.put("table.optimize.enable","false");
+        catalogProperties.put("table.optimize.quota","0.1");
+        catalogProperties.put("table.optimize.group","mygroup");
+        catalogProperties.put("ams.address","127.0.0.1");
+
+        Map<String, String> result = CatalogUtil.mergeCatalogPropertiesToTable(userDefined, catalogProperties);
+        Assert.assertEquals(expected, result);
+    }
+
+    /**
+     * when optimized flag is off in catalog props and no user-defined value,
+     * remove optimizer related props but 'optimize.enable' itself.
+     */
+    @Test
+    public void testMergeCatalogPropertiesToTable6() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("log-store.enable","true");
+        expected.put("log-store.address","168.0.0.1:9092");
+        expected.put("log-store.type","kafka");
+        expected.put("log-store.consistency.guarantee.enable","true");
+        expected.put("optimize.enable","false");
+        expected.put("table.other-props","foo");
+
+        Map<String, String> userDefined = new HashMap<>();
+        userDefined.put("log-store.enable","true");
+        userDefined.put("table.other-props","foo");
+
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("table.log-store.enable","false");
+        catalogProperties.put("table.log-store.address","168.0.0.1:9092");
+        catalogProperties.put("table.log-store.type","kafka");
+        catalogProperties.put("table.log-store.consistency.guarantee.enable","true");
+        catalogProperties.put("table.optimize.enable","false");
+        catalogProperties.put("table.optimize.quota","0.1");
+        catalogProperties.put("table.optimize.group","mygroup");
+        catalogProperties.put("ams.address","127.0.0.1");
+
+        Map<String, String> result = CatalogUtil.mergeCatalogPropertiesToTable(userDefined, catalogProperties);
+        Assert.assertEquals(expected, result);
+    }
+
+    /**
+     * user-defined 'optimize.enable' is switched on,
+     * overwrite behavior of default catalog props
+     */
+    @Test
+    public void testMergeCatalogPropertiesToTable7() {
+        Map<String, String> expected = new HashMap<>();
+        expected.put("optimize.enable","true");
+        expected.put("optimize.quota","0.1");
+        expected.put("optimize.group","mygroup");
+        expected.put("table.other-props","foo");
+
+        Map<String, String> userDefined = new HashMap<>();
+        userDefined.put("optimize.enable","true");
+        userDefined.put("table.other-props","foo");
+
+        Map<String, String> catalogProperties = new HashMap<>();
+        catalogProperties.put("table.log-store.enable","false");
+        catalogProperties.put("table.log-store.address","168.0.0.1:9092");
+        catalogProperties.put("table.log-store.type","kafka");
+        catalogProperties.put("table.log-store.consistency.guarantee.enable","true");
+        catalogProperties.put("table.optimize.enable","false");
+        catalogProperties.put("table.optimize.quota","0.1");
+        catalogProperties.put("table.optimize.group","mygroup");
+        catalogProperties.put("ams.address","127.0.0.1");
+
+        Map<String, String> result = CatalogUtil.mergeCatalogPropertiesToTable(userDefined, catalogProperties);
+        Assert.assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
## Why are the changes needed?
Resolve #171

## Brief change log
  - *Add logical to filter  default properties for a catalog with specific prefix in `TablePropertiesUtil`.*
  - *Add logical to  set default properties into table metadata when creating tablemeta in `TableMetaBuilder`*


## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
