### PR TITLE
[ARCTIC-707] split optimize task for native iceberg by all file size

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergMajorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergMajorOptimizePlan.java
@@ -103,7 +103,13 @@ public class IcebergMajorOptimizePlan extends BaseIcebergOptimizePlan {
     TaskConfig taskPartitionConfig = new TaskConfig(partition, null,
         commitGroup, planGroup, OptimizeType.Major, createTime, "");
     List<FileScanTask> fileScanTasks = partitionFileList.get(partition);
-    collector.add(buildOptimizeTask(fileScanTasks, taskPartitionConfig));
+
+    List<List<FileScanTask>> binPackFileScanTasks = binPackFileScanTask(fileScanTasks);
+    for (List<FileScanTask> fileScanTask : binPackFileScanTasks) {
+      if (CollectionUtils.isNotEmpty(fileScanTask)) {
+        collector.add(buildOptimizeTask(fileScanTask, taskPartitionConfig));
+      }
+    }
 
     return collector;
   }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergMinorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergMinorOptimizePlan.java
@@ -100,7 +100,13 @@ public class IcebergMinorOptimizePlan extends BaseIcebergOptimizePlan {
     List<FileScanTask> fileScanTasks = partitionFileList.get(partition);
     List<FileScanTask> smallFileScanTasks = fileScanTasks.stream()
         .filter(fileScanTask -> fileScanTask.file().fileSizeInBytes() <= smallFileSize).collect(Collectors.toList());
-    collector.add(buildOptimizeTask(smallFileScanTasks, taskPartitionConfig));
+
+    List<List<FileScanTask>> binPackFileScanTasks = binPackFileScanTask(smallFileScanTasks);
+    for (List<FileScanTask> fileScanTask : binPackFileScanTasks) {
+      if (CollectionUtils.isNotEmpty(fileScanTask)) {
+        collector.add(buildOptimizeTask(fileScanTask, taskPartitionConfig));
+      }
+    }
 
     return collector;
   }

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergMajorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergMajorOptimizePlan.java
@@ -5,6 +5,7 @@ import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.TableProperties;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,5 +29,23 @@ public class TestIcebergMajorOptimizePlan extends TestIcebergBase {
     List<BaseOptimizeTask> tasks = optimizePlan.plan();
     Assert.assertEquals(1, tasks.size());
     Assert.assertEquals(dataFiles.size(), tasks.get(0).getIcebergFileScanTasksSize());
+  }
+
+  @Test
+  public void testBinPackPlan() throws Exception {
+    icebergTable.asUnkeyedTable().updateProperties()
+        .set(com.netease.arctic.table.TableProperties.OPTIMIZE_SMALL_FILE_SIZE_BYTES_THRESHOLD, "1000")
+        .set(com.netease.arctic.table.TableProperties.MAJOR_OPTIMIZE_TRIGGER_DUPLICATE_SIZE_BYTES_THRESHOLD, "10")
+        .set(TableProperties.SPLIT_SIZE, "1500")
+        .commit();
+    List<DataFile> dataFiles = insertDataFiles(icebergTable.asUnkeyedTable(), 10);
+    insertEqDeleteFiles(icebergTable.asUnkeyedTable(), 5);
+    insertPosDeleteFiles(icebergTable.asUnkeyedTable(), dataFiles);
+    List<FileScanTask> fileScanTasks = IteratorUtils.toList(icebergTable.asUnkeyedTable().newScan().planFiles().iterator());
+    IcebergMajorOptimizePlan optimizePlan = new IcebergMajorOptimizePlan(icebergTable,
+        new TableOptimizeRuntime(icebergTable.id()), fileScanTasks,
+        new HashMap<>(), 1, System.currentTimeMillis());
+    List<BaseOptimizeTask> tasks = optimizePlan.plan();
+    Assert.assertEquals(50, tasks.size());
   }
 }


### PR DESCRIPTION
## Why are the changes needed?
resolve #707 

## Brief change log

  - *split optimize task for native iceberg by file size in bytes of data files and delete files*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
