### PR TITLE
refactor spark module

### DIFF
--- a/ams/ams-server/pom.xml
+++ b/ams/ams-server/pom.xml
@@ -167,7 +167,7 @@
 
         <dependency>
             <groupId>com.netease.arctic</groupId>
-            <artifactId>arctic-spark_3.1</artifactId>
+            <artifactId>arctic-spark-3.1</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/spark/v2.3/spark-runtime/pom.xml
+++ b/spark/v2.3/spark-runtime/pom.xml
@@ -27,13 +27,13 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>arctic-spark_2.3-runtime</artifactId>
+    <artifactId>arctic-spark-2.3-runtime</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>com.netease.arctic</groupId>
-            <artifactId>arctic-spark_2.3</artifactId>
+            <artifactId>arctic-spark-2.3</artifactId>
             <version>${parent.version}</version>
         </dependency>
     </dependencies>

--- a/spark/v2.3/spark/pom.xml
+++ b/spark/v2.3/spark/pom.xml
@@ -28,7 +28,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>arctic-spark_2.3</artifactId>
+    <artifactId>arctic-spark-2.3</artifactId>
     <packaging>jar</packaging>
 
     <properties>

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -28,13 +28,13 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>arctic-spark_3.1-runtime</artifactId>
+    <artifactId>arctic-spark-3.1-runtime</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>com.netease.arctic</groupId>
-            <artifactId>arctic-spark_3.1</artifactId>
+            <artifactId>arctic-spark-3.1</artifactId>
             <version>${parent.version}</version>
         </dependency>
     </dependencies>

--- a/spark/v3.1/spark/pom.xml
+++ b/spark/v3.1/spark/pom.xml
@@ -28,7 +28,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>arctic-spark_3.1</artifactId>
+    <artifactId>arctic-spark-3.1</artifactId>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION

## Why are the changes needed?
spark module name format is arctic-spark_{SPARK_VERSION} , this maybe conflict with spark binary version suffix e.g. spark-sql_2.12

so change the module name to format arctic-spark-{SPARK_VERSION}
 
## Brief change log

- change spark module name format

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? ( no)
  - If yes, how is the feature documented? (not documented)
