### PR TITLE
[ARCTIC-636][optimizer] Clear useless data files produced by failed full optimize which support hive

### DIFF
--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/properties/OptimizeTaskProperties.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/properties/OptimizeTaskProperties.java
@@ -4,4 +4,5 @@ public class OptimizeTaskProperties {
   // optimize task properties
   public static final String ALL_FILE_COUNT = "all-file-cnt";
   public static final String CUSTOM_HIVE_SUB_DIRECTORY = "custom-hive-sub-directory";
+  public static final String MAX_EXECUTE_TIME = "max-execute-time";
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
@@ -753,18 +753,12 @@ public class TableOptimizeItem extends IJDBCService {
    * If task execute timeout, set it to be Failed.
    */
   public void checkTaskExecuteTimeout() {
-    optimizeTasks.values().stream().filter(task -> task.executeTimeout(this::maxExecuteTime))
+    optimizeTasks.values().stream().filter(task -> task.executeTimeout())
         .forEach(task -> {
           task.onFailed(new ErrorMessage(System.currentTimeMillis(), "execute expired"),
               System.currentTimeMillis() - task.getOptimizeRuntime().getExecuteTime());
           LOG.error("{} execute timeout, change to Failed", task.getTaskId());
         });
-  }
-
-  private long maxExecuteTime() {
-    return PropertyUtil
-        .propertyAsLong(getArcticTable(false).properties(), TableProperties.OPTIMIZE_EXECUTE_TIMEOUT,
-            TableProperties.OPTIMIZE_EXECUTE_TIMEOUT_DEFAULT);
   }
 
   /**

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
@@ -26,6 +26,7 @@ import com.netease.arctic.ams.api.NoSuchObjectException;
 import com.netease.arctic.ams.api.OptimizeStatus;
 import com.netease.arctic.ams.api.OptimizeTask;
 import com.netease.arctic.ams.api.OptimizeType;
+import com.netease.arctic.ams.api.properties.OptimizeTaskProperties;
 import com.netease.arctic.ams.server.mapper.ContainerMetadataMapper;
 import com.netease.arctic.ams.server.mapper.OptimizeQueueMapper;
 import com.netease.arctic.ams.server.model.BaseOptimizeTask;
@@ -41,10 +42,12 @@ import com.netease.arctic.ams.server.service.IJDBCService;
 import com.netease.arctic.ams.server.service.ITableTaskHistoryService;
 import com.netease.arctic.ams.server.service.ServiceContainer;
 import com.netease.arctic.ams.server.utils.OptimizeStatusUtil;
+import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
@@ -68,6 +71,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class OptimizeQueueService extends IJDBCService {
@@ -368,6 +372,34 @@ public class OptimizeQueueService extends IJDBCService {
           throw new InvalidObjectException(
               queueName() + " not allow task of table " + task.getTableIdentifier());
         }
+        // clear useless files produced by failed full optimize task support hive
+        if (task.getOptimizeRuntime().getStatus() == OptimizeStatus.Failed) {
+          String location =
+              task.getOptimizeTask().getProperties().get(OptimizeTaskProperties.CUSTOM_HIVE_SUB_DIRECTORY);
+
+          if (location != null) {
+            try {
+              ArcticTable arcticTable = ServiceContainer.getOptimizeService()
+                  .getTableOptimizeItem(task.getTableIdentifier()).getArcticTable();
+              if (arcticTable.io().exists(location)) {
+                for (FileStatus fileStatus : arcticTable.io().list(location)) {
+                  String fileLocation = fileStatus.getPath().toUri().getPath();
+                  // now file naming rule is nodeId-fileType-txId-partitionId-taskId-fileCount(%d-%s-%d-%05d-%d-%010d)
+                  // for files produced by optimize, the taskId is attemptId
+                  String pattern = ".*(\\d{5}-)" + task.getOptimizeRuntime().getAttemptId() + "(-\\d{10}).*";
+                  if (Pattern.matches(pattern, fileLocation)) {
+                    arcticTable.io().deleteFile(fileLocation);
+                    LOG.debug("delete file {} by produced failed optimize task.", fileLocation);
+                  }
+                }
+              }
+            } catch (Exception e) {
+              LOG.error("delete files failed", e);
+              return;
+            }
+          }
+        }
+
         if (tasks.offer(task)) {
           if (!OptimizeStatusUtil.in(task.getOptimizeStatus(), OptimizeStatus.Pending) ||
               task.getOptimizeTask().getQueueId() != optimizeQueue.getOptimizeQueueMeta()
@@ -484,6 +516,8 @@ public class OptimizeQueueService extends IJDBCService {
                 task.onFailed(new ErrorMessage(System.currentTimeMillis(), "failed to put task back into queue"), 0);
               }
             }
+            // update max execute time
+            task.setMaxExecuteTime();
             TableTaskHistory tableTaskHistory = task.onExecuting(jobId, attemptId);
             try {
               insertTableTaskHistory(tableTaskHistory);

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/exception/TimeoutException.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/exception/TimeoutException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.optimizer.exception;
+
+public class TimeoutException extends RuntimeException {
+  public TimeoutException(String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/BaseTaskExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/BaseTaskExecutor.java
@@ -34,17 +34,20 @@ import com.netease.arctic.data.DataFileType;
 import com.netease.arctic.data.DataTreeNode;
 import com.netease.arctic.optimizer.OptimizerConfig;
 import com.netease.arctic.optimizer.TaskWrapper;
+import com.netease.arctic.optimizer.exception.TimeoutException;
 import com.netease.arctic.optimizer.operator.executor.Executor;
 import com.netease.arctic.optimizer.operator.executor.ExecutorFactory;
 import com.netease.arctic.optimizer.operator.executor.NodeTask;
 import com.netease.arctic.optimizer.operator.executor.OptimizeTaskResult;
 import com.netease.arctic.optimizer.operator.executor.TableIdentificationInfo;
 import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.SerializationUtil;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,6 +127,10 @@ public class BaseTaskExecutor implements Serializable {
       OptimizeTaskResult<?> result = optimize.execute();
       onTaskFinish(result.getTargetFiles());
       return result.getOptimizeTaskStat();
+    } catch (TimeoutException timeoutException) {
+      LOG.error("execute task timeout {}", task.getTaskId());
+      onTaskFailed(timeoutException);
+      return constructFailedResult(task, timeoutException);
     } catch (Throwable t) {
       LOG.error("failed to execute task {}", task.getTaskId(), t);
       onTaskFailed(t);
@@ -262,6 +269,10 @@ public class BaseTaskExecutor implements Serializable {
 
       String customHiveSubdirectory = properties.get(OptimizeTaskProperties.CUSTOM_HIVE_SUB_DIRECTORY);
       nodeTask.setCustomHiveSubdirectory(customHiveSubdirectory);
+
+      Long maxExecuteTime = PropertyUtil.propertyAsLong(properties,
+          OptimizeTaskProperties.MAX_EXECUTE_TIME, TableProperties.OPTIMIZE_EXECUTE_TIMEOUT_DEFAULT);
+      nodeTask.setMaxExecuteTime(maxExecuteTime);
     }
 
     return nodeTask;

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/BaseExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/BaseExecutor.java
@@ -19,11 +19,18 @@
 package com.netease.arctic.optimizer.operator.executor;
 
 import com.netease.arctic.data.DataTreeNode;
+import com.netease.arctic.optimizer.OptimizerConfig;
+import com.netease.arctic.optimizer.exception.TimeoutException;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.FileUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +38,24 @@ import java.util.OptionalLong;
 import java.util.stream.Collectors;
 
 public abstract class BaseExecutor<F extends ContentFile<F>> implements Executor<F> {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseExecutor.class);
+
+  protected final NodeTask task;
+  protected final ArcticTable table;
+  protected final OptimizerConfig config;
+  protected final long startTime;
+  protected double factor = 0.9;
+
+  public BaseExecutor(NodeTask nodeTask,
+                      ArcticTable table,
+                      long startTime,
+                      OptimizerConfig config) {
+    this.startTime = startTime;
+    this.task = nodeTask;
+    this.table = table;
+    this.config = config;
+  }
+
   protected Map<DataTreeNode, List<DataFile>> groupDataFilesByNode(List<DataFile> dataFiles) {
     return new HashMap<>(dataFiles.stream().collect(Collectors.groupingBy(dataFile ->
         FileUtil.parseFileNodeFromFileName(dataFile.path().toString()))));
@@ -49,5 +74,19 @@ public abstract class BaseExecutor<F extends ContentFile<F>> implements Executor
     }
 
     return 0;
+  }
+
+  protected void checkIfTimeout(Closeable writer) throws Exception {
+    long maxExecuteTime = task.getMaxExecuteTime() != null ?
+        task.getMaxExecuteTime() : TableProperties.OPTIMIZE_EXECUTE_TIMEOUT_DEFAULT;
+    long actualExecuteTime = System.currentTimeMillis() - startTime;
+    if (actualExecuteTime > maxExecuteTime * factor) {
+      writer.close();
+      LOG.error("table {} execute task {} timeout, actual execute time is {}ms, max execute time is {}ms",
+          table.id(), task.getTaskId(), actualExecuteTime, task.getMaxExecuteTime());
+      throw new TimeoutException(String.format("optimizer execute timeout, " +
+          "actual execute time is %sms, max execute time is %sms, factor is %s",
+          actualExecuteTime, task.getMaxExecuteTime(), factor));
+    }
   }
 }

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MajorExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MajorExecutor.java
@@ -62,16 +62,11 @@ import java.util.stream.Collectors;
 public class MajorExecutor extends BaseExecutor<DataFile> {
   private static final Logger LOG = LoggerFactory.getLogger(MajorExecutor.class);
 
-  private final NodeTask task;
-  private final ArcticTable table;
-  private final long startTime;
-  private final OptimizerConfig config;
-
-  public MajorExecutor(NodeTask nodeTask, ArcticTable table, long startTime, OptimizerConfig config) {
-    this.task = nodeTask;
-    this.table = table;
-    this.startTime = startTime;
-    this.config = config;
+  public MajorExecutor(NodeTask nodeTask,
+                       ArcticTable table,
+                       long startTime,
+                       OptimizerConfig config) {
+    super(nodeTask, table, startTime, config);
   }
 
   @Override
@@ -136,6 +131,8 @@ public class MajorExecutor extends BaseExecutor<DataFile> {
             WriteOperationKind.MAJOR_OPTIMIZE : WriteOperationKind.FULL_OPTIMIZE);
     long insertCount = 0;
     while (recordIterator.hasNext()) {
+      checkIfTimeout(writer);
+
       Record baseRecord = recordIterator.next();
       writer.write(baseRecord);
       insertCount++;

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MinorExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MinorExecutor.java
@@ -63,16 +63,11 @@ import java.util.stream.Collectors;
 public class MinorExecutor extends BaseExecutor<DeleteFile> {
   private static final Logger LOG = LoggerFactory.getLogger(MinorExecutor.class);
 
-  private final NodeTask task;
-  private final ArcticTable table;
-  private final long startTime;
-  private final OptimizerConfig config;
-
-  public MinorExecutor(NodeTask nodeTask, ArcticTable table, long startTime, OptimizerConfig config) {
-    this.task = nodeTask;
-    this.table = table;
-    this.startTime = startTime;
-    this.config = config;
+  public MinorExecutor(NodeTask nodeTask,
+                       ArcticTable table,
+                       long startTime,
+                       OptimizerConfig config) {
+    super(nodeTask, table, startTime, config);
   }
 
   @Override
@@ -103,6 +98,8 @@ public class MinorExecutor extends BaseExecutor<DeleteFile> {
             openTask(dataFiles, posDeleteList, requiredSchema, task.getSourceNodes());
 
         while (iterator.hasNext()) {
+          checkIfTimeout(posDeleteWriter);
+
           Record record = iterator.next();
           String filePath = (String) record.get(recordStruct.fields()
               .indexOf(recordStruct.field(MetadataColumns.FILE_PATH.name())));
@@ -125,6 +122,8 @@ public class MinorExecutor extends BaseExecutor<DeleteFile> {
           CloseableIterable<Record> posDeleteIterable = posDeleteReader.readDeletes();
           CloseableIterator<Record> posDeleteIterator = posDeleteIterable.iterator();
           while (posDeleteIterator.hasNext()) {
+            checkIfTimeout(posDeleteWriter);
+
             Record record = posDeleteIterator.next();
             String filePath = posDeleteReader.readPath(record);
             Long rowPosition = posDeleteReader.readPos(record);

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/NodeTask.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/NodeTask.java
@@ -50,6 +50,7 @@ public class NodeTask {
   private TableIdentifier tableIdentifier;
   private int attemptId;
   private String customHiveSubdirectory;
+  private Long maxExecuteTime;
 
   public NodeTask() {
   }
@@ -159,6 +160,14 @@ public class NodeTask {
     this.customHiveSubdirectory = customHiveSubdirectory;
   }
 
+  public Long getMaxExecuteTime() {
+    return maxExecuteTime;
+  }
+
+  public void setMaxExecuteTime(Long maxExecuteTime) {
+    this.maxExecuteTime = maxExecuteTime;
+  }
+
   public OptimizeType getOptimizeType() {
     return taskId.getType();
   }
@@ -174,6 +183,7 @@ public class NodeTask {
         .add("deleteFiles", deleteFiles.size())
         .add("posDeleteFiles", posDeleteFiles.size())
         .add("customHiveSubdirectory", customHiveSubdirectory)
+        .add("maxExecuteTime", maxExecuteTime)
         .toString();
   }
 }


### PR DESCRIPTION
## Why are the changes needed?
fix #636 
Failed full optimization that supports Hive produced useless data files in the partition location, which is unclear.

## Brief change log

  - *before retrying failed full optimize support Hive, try to clear useless data files*
  - *optimizer add max execute time to avoid producing useless data files and throw timeout exception*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run the test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
