### PR TITLE
[ARCTIC-814] Fix optimize can't stop when the change store only has eq-delete files and the base store has no files

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
@@ -207,11 +207,11 @@ public class BaseOptimizeCommit {
       overwriteBaseFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
       overwriteBaseFiles.validateNoConflictingAppends(Expressions.alwaysFalse());
       AtomicInteger addedPosDeleteFile = new AtomicInteger(0);
+      StructLikeMap<Long> oldPartitionMaxIds =
+          TablePropertyUtil.getPartitionMaxTransactionId(arcticTable.asKeyedTable());
       minorAddFiles.forEach(contentFile -> {
         // if partition min transactionId isn't bigger than max transactionId in partitionProperty,
         // the partition files is expired
-        StructLikeMap<Long> oldPartitionMaxIds =
-            TablePropertyUtil.getPartitionMaxTransactionId(arcticTable.asKeyedTable());
         Long oldTransactionId = oldPartitionMaxIds.getOrDefault(contentFile.partition(), -1L);
         Long newMinTransactionId = minTransactionIds.getOrDefault(contentFile.partition(), Long.MAX_VALUE);
         if (oldTransactionId >= newMinTransactionId) {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
@@ -202,8 +202,6 @@ public class BaseOptimizeCommit {
       baseArcticTable = arcticTable.asUnkeyedTable();
     }
 
-    StructLikeMap<Long> oldPartitionMaxIds =
-        TablePropertyUtil.getPartitionMaxTransactionId(arcticTable.asKeyedTable());
     if (CollectionUtils.isNotEmpty(minorAddFiles) || CollectionUtils.isNotEmpty(minorDeleteFiles)) {
       OverwriteBaseFiles overwriteBaseFiles = new OverwriteBaseFiles(arcticTable.asKeyedTable());
       overwriteBaseFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
@@ -212,6 +210,8 @@ public class BaseOptimizeCommit {
       minorAddFiles.forEach(contentFile -> {
         // if partition min transactionId isn't bigger than max transactionId in partitionProperty,
         // the partition files is expired
+        StructLikeMap<Long> oldPartitionMaxIds =
+            TablePropertyUtil.getPartitionMaxTransactionId(arcticTable.asKeyedTable());
         Long oldTransactionId = oldPartitionMaxIds.getOrDefault(contentFile.partition(), -1L);
         Long newMinTransactionId = minTransactionIds.getOrDefault(contentFile.partition(), Long.MAX_VALUE);
         if (oldTransactionId >= newMinTransactionId) {
@@ -264,6 +264,8 @@ public class BaseOptimizeCommit {
           addedPosDeleteFile.get());
     } else {
       if (MapUtils.isNotEmpty(maxTransactionIds)) {
+        StructLikeMap<Long> oldPartitionMaxIds =
+            TablePropertyUtil.getPartitionMaxTransactionId(arcticTable.asKeyedTable());
         UpdatePartitionProperties updatePartitionProperties =
             baseArcticTable.updatePartitionProperties(null);
         maxTransactionIds.forEach((partition, txId) -> {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
@@ -530,9 +530,12 @@ public class TableOptimizeItem extends IJDBCService {
         optimizeTaskItem.persistOptimizeTask();
         addedOptimizeTaskIds.add(optimizeTask.getTaskId());
         LOG.info("{} add new task {}", tableIdentifier, optimizeTask);
-        // when minor optimize, there is no need to execute task not contains deleteFiles,
-        // but the inertFiles need to commit to base table
-        if (optimizeTask.getTaskId().getType().equals(OptimizeType.Minor) && optimizeTask.getDeleteFiles().isEmpty() &&
+        // when minor optimize, there is no need to execute task not contains deleteFiles or not contains any dataFiles,
+        // for no deleteFiles the inertFiles need to commit to base table
+        // for no dataFiles the txId in base properties need to update
+        boolean minorNotNeedExecute = optimizeTask.getDeleteFiles().isEmpty() ||
+            (optimizeTask.getBaseFiles().isEmpty() && optimizeTask.getInsertFiles().isEmpty());
+        if (minorNotNeedExecute && optimizeTask.getTaskId().getType().equals(OptimizeType.Minor) &&
             !com.netease.arctic.utils.TableTypeUtil.isIcebergTableFormat(arcticTable)) {
           optimizeTaskItem.onPrepared(System.currentTimeMillis(),
               optimizeTask.getInsertFiles(), optimizeTask.getInsertFileSize(), 0L);

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMinorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMinorOptimizePlan.java
@@ -84,7 +84,7 @@ public class TestMinorOptimizePlan extends TestBaseOptimizeBase {
     Assert.assertEquals(10, tasks.get(0).getDeleteFileCnt());
   }
 
-  protected void insertChangeDeleteFiles(ArcticTable arcticTable, long transactionId) throws IOException {
+  protected List<DataFile> insertChangeDeleteFiles(ArcticTable arcticTable, long transactionId) throws IOException {
     TaskWriter<Record> writer = AdaptHiveGenericTaskWriterBuilder.builderFor(arcticTable)
         .withChangeAction(ChangeAction.DELETE)
         .withTransactionId(transactionId)
@@ -109,6 +109,7 @@ public class TestMinorOptimizePlan extends TestBaseOptimizeBase {
     changeDeleteFilesInfo = changeDeleteFiles.stream()
         .map(deleteFile -> DataFileInfoUtils.convertToDatafileInfo(deleteFile, snapshot, arcticTable))
         .collect(Collectors.toList());
+    return changeDeleteFiles;
   }
 
   protected List<DataFile> insertChangeDataFiles(ArcticTable arcticTable, long transactionId) throws IOException {


### PR DESCRIPTION
## Why are the changes needed?
fix #814 

## Brief change log

  - *Even if the minor optimize output is nothing, the commit still updates "max-txId" in partition properties*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
