### PR TITLE
[ARCTIC-820] Remove table configuration `self-optimizing.max-task-file-size`

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
@@ -181,8 +181,8 @@ public class FullOptimizePlan extends BaseArcticOptimizePlan {
               getMaxTransactionId(fileList) : IdGenerator.randomId()));
 
       long taskSize = CompatiblePropertyUtil.propertyAsLong(arcticTable.properties(),
-              TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE,
-              TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE_DEFAULT);
+              TableProperties.SELF_OPTIMIZING_TARGET_SIZE,
+              TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT);
       Long sum = fileList.stream().map(DataFile::fileSizeInBytes).reduce(0L, Long::sum);
       int taskCnt = (int) (sum / taskSize) + 1;
       List<List<DataFile>> packed = new BinPacking.ListPacker<DataFile>(taskSize, taskCnt, true)

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/MajorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/MajorOptimizePlan.java
@@ -225,8 +225,8 @@ public class MajorOptimizePlan extends BaseArcticOptimizePlan {
     List<DeleteFile> posDeleteFiles = partitionPosDeleteFiles.getOrDefault(partition, Collections.emptyList());
     if (nodeTaskNeedBuild(posDeleteFiles, fileList)) {
       long taskSize = CompatiblePropertyUtil.propertyAsLong(arcticTable.properties(),
-          TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE,
-          TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE_DEFAULT);
+          TableProperties.SELF_OPTIMIZING_TARGET_SIZE,
+          TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT);
       Long sum = fileList.stream().map(DataFile::fileSizeInBytes).reduce(0L, Long::sum);
       int taskCnt = (int) (sum / taskSize) + 1;
       List<List<DataFile>> packed = new BinPacking.ListPacker<DataFile>(taskSize, taskCnt, true)

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -90,9 +90,6 @@ public class TableProperties {
   public static final String SELF_OPTIMIZING_MAX_FILE_CNT = "self-optimizing.max-file-count";
   public static final int SELF_OPTIMIZING_MAX_FILE_CNT_DEFAULT = 100000;
 
-  public static final String SELF_OPTIMIZING_MAX_TASK_FILE_SIZE = "self-optimizing.max-task-file-size";
-  public static final long SELF_OPTIMIZING_MAX_TASK_FILE_SIZE_DEFAULT = 1073741824L; // 1 GB
-  
   public static final String SELF_OPTIMIZING_FRAGMENT_RATIO = "self-optimizing.fragment-ratio";
   public static final int SELF_OPTIMIZING_FRAGMENT_RATIO_DEFAULT = 8;
 
@@ -158,9 +155,6 @@ public class TableProperties {
 
   @Deprecated
   public static final String OPTIMIZE_QUOTA = "optimize.quota";
-
-  @Deprecated
-  public static final String MAJOR_OPTIMIZE_MAX_TASK_FILE_SIZE = "optimize.major.max-task-file-size-bytes";
 
   /**
    * table clean related properties

--- a/core/src/main/java/com/netease/arctic/utils/CompatiblePropertyUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/CompatiblePropertyUtil.java
@@ -82,8 +82,6 @@ public class CompatiblePropertyUtil {
         return TableProperties.OPTIMIZE_EXECUTE_TIMEOUT;
       case TableProperties.SELF_OPTIMIZING_MAX_FILE_CNT:
         return TableProperties.OPTIMIZE_MAX_FILE_COUNT;
-      case TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE:
-        return TableProperties.MAJOR_OPTIMIZE_MAX_TASK_FILE_SIZE;
       case TableProperties.SELF_OPTIMIZING_MINOR_TRIGGER_FILE_CNT:
         return TableProperties.MINOR_OPTIMIZE_TRIGGER_DELETE_FILE_COUNT;
       case TableProperties.SELF_OPTIMIZING_MINOR_TRIGGER_INTERVAL:

--- a/site/docs/ch/meta-service/table-properties.md
+++ b/site/docs/ch/meta-service/table-properties.md
@@ -37,7 +37,6 @@
 | self-optimizing.execute.timeout                     | 1800000（30分钟） | 结构优化执行超时时间                                  |
 | self-optimizing.target-size                         | 134217728（128MB）| 结构优化的目标文件大小                                |
 | self-optimizing.max-file-count                      | 100000           | 一次结构优化最多处理的文件个数                           |
-| self-optimizing.max-task-file-size                  | 1073741824（1GB） | 一次结构优化最大的任务大小                          |
 | self-optimizing.fragment-ratio                      | 8                | 处理的 fragment 文件阈值                             |
 | self-optimizing.minor.trigger.file-count            | 12               | 触发 minor optimize 的 fragment 文件数量             |
 | self-optimizing.minor.trigger.interval              | 3600000（1小时）  | 触发 minor optimize 的时间间隔                        |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #820 

## Brief change log

  - remove `self-optimizing.max-task-file-size`
  - `BinPacking` of full-optimize/major-optimize use `self-optimizing.target-size` now

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
