### PR TITLE
[Docker]: Fix dockerfile problem of ams

### DIFF
--- a/docker/ams/Dockerfile
+++ b/docker/ams/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /usr/local/ams/arctic-${ARCTIC_VERSION}
 
 COPY config.sh  ./bin/config.sh
 RUN find ./bin -name "*.sh" | xargs dos2unix
-RUN mkdir -p ./logs && touch ams-info.log
+RUN mkdir -p ./logs && touch ./logs/ams-info.log
 
 
 EXPOSE 1630/tcp


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?

Create ams-info.log file before tail -f.  or docker container may started failed for file not exists.

*(For example: The Arctic Flink dataStream API has already supported this configuration: 'scan.startup.mode', but it is not available with Flink SQL. We should expose this configuration to users when they are using Flink SQL.)*

## Brief change log

- touch ./logs/ams-info.log before tailf it.

## How was this patch tested?

-  Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
