### PR TITLE
[ARCTIC-846] Fix checking conflict commit with the legacy `TransactionId` before `Minor Optimize` commit

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/OptimizeTasksMapper.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/OptimizeTasksMapper.java
@@ -36,7 +36,7 @@ public interface OptimizeTasksMapper {
   String TABLE_NAME = "optimize_task";
 
   @Select("select trace_id, optimize_type, catalog_name, db_name, table_name, `partition`," +
-      " task_commit_group, task_plan_group, max_change_transaction_id," +
+      " task_commit_group, task_plan_group, max_change_transaction_id, min_change_transaction_id, " +
       " source_nodes, create_time, properties, queue_id," +
       " insert_file_size, delete_file_size, base_file_size, pos_delete_file_size," +
       " insert_files, delete_files, base_files, pos_delete_files" +
@@ -51,6 +51,7 @@ public interface OptimizeTasksMapper {
       @Result(property = "taskCommitGroup", column = "task_commit_group"),
       @Result(property = "taskPlanGroup", column = "task_plan_group"),
       @Result(property = "maxChangeTransactionId", column = "max_change_transaction_id"),
+      @Result(property = "minChangeTransactionId", column = "min_change_transaction_id"),
       @Result(property = "queueId", column = "queue_id"),
       @Result(property = "insertFileSize", column = "insert_file_size"),
       @Result(property = "deleteFileSize", column = "delete_file_size"),
@@ -71,7 +72,7 @@ public interface OptimizeTasksMapper {
 
   @Insert("insert into " + TABLE_NAME + " (" +
       " trace_id, optimize_type, catalog_name, db_name, table_name, `partition`," +
-      " task_commit_group, task_plan_group, max_change_transaction_id," +
+      " task_commit_group, task_plan_group, max_change_transaction_id, min_change_transaction_id," +
       " source_nodes, create_time, properties, queue_id," +
       " insert_file_size, delete_file_size, base_file_size, pos_delete_file_size," +
       " insert_files, delete_files, base_files, pos_delete_files," +
@@ -88,6 +89,7 @@ public interface OptimizeTasksMapper {
       " #{optimizeTask.taskCommitGroup}," +
       " #{optimizeTask.taskPlanGroup}," +
       " #{optimizeTask.maxChangeTransactionId}," +
+      " #{optimizeTask.minChangeTransactionId}," +
       " #{optimizeTask.sourceNodes, " +
       "typeHandler=com.netease.arctic.ams.server.mybatis.ListOfTreeNode2StringConverter}," +
       " #{optimizeTask.createTime, " +

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/derby/DerbyOptimizeTasksMapper.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/derby/DerbyOptimizeTasksMapper.java
@@ -36,7 +36,7 @@ public interface DerbyOptimizeTasksMapper extends OptimizeTasksMapper {
   String TABLE_NAME = "optimize_task";
 
   @Select("select trace_id, optimize_type, catalog_name, db_name, table_name, partition," +
-      " task_commit_group, task_plan_group, max_change_transaction_id," +
+      " task_commit_group, task_plan_group, max_change_transaction_id, min_change_transaction_id," +
       " source_nodes, create_time, properties, queue_id," +
       " insert_file_size, delete_file_size, base_file_size, pos_delete_file_size" +
       " insert_files, delete_files, base_files, pos_delete_files from " + TABLE_NAME)
@@ -50,6 +50,7 @@ public interface DerbyOptimizeTasksMapper extends OptimizeTasksMapper {
       @Result(property = "taskCommitGroup", column = "task_commit_group"),
       @Result(property = "taskPlanGroup", column = "task_plan_group"),
       @Result(property = "maxChangeTransactionId", column = "max_change_transaction_id"),
+      @Result(property = "minChangeTransactionId", column = "min_change_transaction_id"),
       @Result(property = "queueId", column = "queue_id"),
       @Result(property = "insertFileSize", column = "insert_file_size"),
       @Result(property = "deleteFileSize", column = "delete_file_size"),
@@ -70,7 +71,7 @@ public interface DerbyOptimizeTasksMapper extends OptimizeTasksMapper {
 
   @Insert("insert into " + TABLE_NAME + " (" +
           " trace_id, optimize_type, catalog_name, db_name, table_name, partition," +
-          " task_commit_group, task_plan_group, max_change_transaction_id," +
+          " task_commit_group, task_plan_group, max_change_transaction_id, min_change_transaction_id," +
           " source_nodes, create_time, properties, queue_id," +
           " insert_file_size, delete_file_size, base_file_size, pos_delete_file_size," +
           " insert_files, delete_files, base_files, pos_delete_files," +
@@ -87,6 +88,7 @@ public interface DerbyOptimizeTasksMapper extends OptimizeTasksMapper {
           " #{optimizeTask.taskCommitGroup, jdbcType=VARCHAR}," +
           " #{optimizeTask.taskPlanGroup, jdbcType=VARCHAR}," +
           " #{optimizeTask.maxChangeTransactionId}," +
+          " #{optimizeTask.minChangeTransactionId}," +
           " #{optimizeTask.sourceNodes, " +
           "typeHandler=com.netease.arctic.ams.server.mybatis.ListOfTreeNode2StringConverter}," +
           " #{optimizeTask.createTime, " +

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/BaseOptimizeTask.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/BaseOptimizeTask.java
@@ -41,6 +41,7 @@ public class BaseOptimizeTask extends OptimizeTask {
   protected long createTime;
 
   private long maxChangeTransactionId = INVALID_TRANSACTION_ID;
+  private long minChangeTransactionId = INVALID_TRANSACTION_ID;
 
   public BaseOptimizeTask() {
   }
@@ -67,6 +68,14 @@ public class BaseOptimizeTask extends OptimizeTask {
 
   public void setMaxChangeTransactionId(long maxChangeTransactionId) {
     this.maxChangeTransactionId = maxChangeTransactionId;
+  }
+
+  public long getMinChangeTransactionId() {
+    return minChangeTransactionId;
+  }
+
+  public void setMinChangeTransactionId(long minChangeTransactionId) {
+    this.minChangeTransactionId = minChangeTransactionId;
   }
 
   public String getPartition() {
@@ -174,6 +183,7 @@ public class BaseOptimizeTask extends OptimizeTask {
         ", queueId=" + queueId +
         ", createTime=" + createTime +
         ", maxChangeTransactionId=" + maxChangeTransactionId +
+        ", minChangeTransactionId=" + minChangeTransactionId +
         "} " + superToString();
   }
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TaskConfig.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TaskConfig.java
@@ -27,18 +27,21 @@ public class TaskConfig {
   private final String partition;
   @Nullable
   private final Long maxTransactionId;
+  private final Long minTransactionId;
   private final String commitGroup;
   private final String planGroup;
   private final long createTime;
   private final String customHiveSubdirectory;
 
   public TaskConfig(String partition, @Nullable Long maxTransactionId,
+                    @Nullable Long minTransactionId,
                     String commitGroup, String planGroup,
                     OptimizeType optimizeType, long createTime,
                     @Nullable String customHiveSubdirectory) {
     this.optimizeType = optimizeType;
     this.partition = partition;
     this.maxTransactionId = maxTransactionId;
+    this.minTransactionId = minTransactionId;
     this.commitGroup = commitGroup;
     this.planGroup = planGroup;
     this.createTime = createTime;
@@ -53,9 +56,14 @@ public class TaskConfig {
     return partition;
   }
 
-  @org.jetbrains.annotations.Nullable
+  @javax.annotation.Nullable
   public Long getMaxTransactionId() {
     return maxTransactionId;
+  }
+
+  @javax.annotation.Nullable
+  public Long getMinTransactionId() {
+    return minTransactionId;
   }
 
   public String getCommitGroup() {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseArcticOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseArcticOptimizePlan.java
@@ -168,6 +168,10 @@ public abstract class BaseArcticOptimizePlan extends BaseOptimizePlan {
       optimizeTask.setMaxChangeTransactionId(taskConfig.getMaxTransactionId());
     }
 
+    if (taskConfig.getMinTransactionId() != null) {
+      optimizeTask.setMinChangeTransactionId(taskConfig.getMinTransactionId());
+    }
+
     // table ams url
     Map<String, String> properties = new HashMap<>();
     properties.put(OptimizeTaskProperties.ALL_FILE_COUNT, (optimizeTask.getBaseFiles().size() +

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
@@ -175,7 +175,7 @@ public class FullOptimizePlan extends BaseArcticOptimizePlan {
     if (nodeTaskNeedBuild(posDeleteFiles, fileList)) {
       String commitGroup = UUID.randomUUID().toString();
       long createTime = System.currentTimeMillis();
-      TaskConfig taskPartitionConfig = new TaskConfig(partition,
+      TaskConfig taskPartitionConfig = new TaskConfig(partition, null,
           null, commitGroup, planGroup, partitionOptimizeType.get(partition), createTime,
           constructCustomHiveSubdirectory(arcticTable.isKeyedTable() ?
               getMaxTransactionId(fileList) : IdGenerator.randomId()));
@@ -206,7 +206,7 @@ public class FullOptimizePlan extends BaseArcticOptimizePlan {
     treeRoot.completeTree(false);
     List<DataFile> allBaseFiles = new ArrayList<>();
     treeRoot.collectBaseFiles(allBaseFiles);
-    TaskConfig taskPartitionConfig = new TaskConfig(partition,
+    TaskConfig taskPartitionConfig = new TaskConfig(partition, null,
         null, commitGroup, planGroup, partitionOptimizeType.get(partition), createTime,
         constructCustomHiveSubdirectory(arcticTable.isKeyedTable() ?
             getMaxTransactionId(allBaseFiles) : IdGenerator.randomId()));

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergFullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergFullOptimizePlan.java
@@ -125,7 +125,7 @@ public class IcebergFullOptimizePlan extends BaseIcebergOptimizePlan {
     String commitGroup = UUID.randomUUID().toString();
     long createTime = System.currentTimeMillis();
 
-    TaskConfig taskPartitionConfig = new TaskConfig(partition, null,
+    TaskConfig taskPartitionConfig = new TaskConfig(partition, null, null,
         commitGroup, planGroup, getOptimizeType(), createTime, "");
     List<FileScanTask> fileScanTasks = partitionFileList.get(partition);
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergMinorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergMinorOptimizePlan.java
@@ -146,7 +146,7 @@ public class IcebergMinorOptimizePlan extends BaseIcebergOptimizePlan {
     String commitGroup = UUID.randomUUID().toString();
     long createTime = System.currentTimeMillis();
 
-    TaskConfig taskPartitionConfig = new TaskConfig(partition, null,
+    TaskConfig taskPartitionConfig = new TaskConfig(partition, null, null,
         commitGroup, planGroup, OptimizeType.Minor, createTime, "");
 
     collector.addAll(collectSmallDataFileTask(partition, taskPartitionConfig));

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/MajorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/MajorOptimizePlan.java
@@ -219,7 +219,7 @@ public class MajorOptimizePlan extends BaseArcticOptimizePlan {
     List<BaseOptimizeTask> collector = new ArrayList<>();
     String commitGroup = UUID.randomUUID().toString();
     long createTime = System.currentTimeMillis();
-    TaskConfig taskPartitionConfig = new TaskConfig(partition,
+    TaskConfig taskPartitionConfig = new TaskConfig(partition, null,
         null, commitGroup, planGroup, partitionOptimizeType.get(partition), createTime, "");
 
     List<DeleteFile> posDeleteFiles = partitionPosDeleteFiles.getOrDefault(partition, Collections.emptyList());
@@ -246,7 +246,7 @@ public class MajorOptimizePlan extends BaseArcticOptimizePlan {
     List<BaseOptimizeTask> collector = new ArrayList<>();
     String commitGroup = UUID.randomUUID().toString();
     long createTime = System.currentTimeMillis();
-    TaskConfig taskPartitionConfig = new TaskConfig(partition,
+    TaskConfig taskPartitionConfig = new TaskConfig(partition, null,
         null, commitGroup, planGroup, partitionOptimizeType.get(partition), createTime, "");
     treeRoot.completeTree(false);
     List<FileTree> subTrees = new ArrayList<>();

--- a/ams/ams-server/src/main/resources/sql/derby/ams-init.sql
+++ b/ams/ams-server/src/main/resources/sql/derby/ams-init.sql
@@ -66,6 +66,7 @@ CREATE TABLE optimize_task (
     partition varchar(128) DEFAULT NULL,
     task_commit_group varchar(40) DEFAULT NULL,
     max_change_transaction_id bigint NOT NULL WITH DEFAULT -1,
+    min_change_transaction_id bigint NOT NULL WITH DEFAULT -1,
     create_time timestamp DEFAULT NULL,
     properties clob(64m),
     queue_id bigint NOT NULL,

--- a/ams/ams-server/src/main/resources/sql/mysql/0.4.0-init.sql
+++ b/ams/ams-server/src/main/resources/sql/mysql/0.4.0-init.sql
@@ -145,6 +145,7 @@ CREATE TABLE `optimize_task`
     `partition`                 varchar(128)  DEFAULT NULL COMMENT 'Partition',
     `task_commit_group`         varchar(40)   DEFAULT NULL COMMENT 'UUID. Commit group of task, task of one commit group should commit together',
     `max_change_transaction_id` bigint(20) NOT NULL DEFAULT '-1' COMMENT 'Max change transaction id',
+    `min_change_transaction_id` bigint(20) NOT NULL DEFAULT '-1' COMMENT 'Min change transaction id',
     `create_time`               datetime(3) DEFAULT NULL COMMENT 'Task create time',
     `properties`                text COMMENT 'Task properties',
     `queue_id`                  int(11) NOT NULL COMMENT 'Task group id',

--- a/ams/ams-server/src/main/resources/sql/mysql/upgrade-0.3.2-to-0.4.0.sql
+++ b/ams/ams-server/src/main/resources/sql/mysql/upgrade-0.3.2-to-0.4.0.sql
@@ -29,3 +29,4 @@ ALTER TABLE `optimize_table_runtime` MODIFY COLUMN `db_name` varchar(128) NOT NU
 ALTER TABLE `optimize_table_runtime` MODIFY COLUMN `table_name` varchar(128) NOT NULL COMMENT 'Table name';
 ALTER TABLE `optimize_task_history` MODIFY COLUMN `db_name` varchar(128) NOT NULL COMMENT 'Database name';
 ALTER TABLE `optimize_task_history` MODIFY COLUMN `table_name` varchar(128) NOT NULL COMMENT 'Table name';
+ALTER TABLE `optimize_task` ADD COLUMN `min_change_transaction_id` bigint(20) NOT NULL DEFAULT '-1' COMMENT 'Min change transaction id' after `max_change_transaction_id`;

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsEnvironment.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsEnvironment.java
@@ -138,6 +138,10 @@ public class AmsEnvironment {
     return ServiceContainer.getOptimizeService().refreshAndListTables();
   }
 
+  public void syncTableFileCache(TableIdentifier tableIdentifier, String tableType) {
+    ServiceContainer.getFileInfoCacheService().syncTableFileInfo(tableIdentifier.buildTableIdentifier(), tableType);
+  }
+
   public void createIcebergCatalog(String catalogName, String warehouseDir) {
     CatalogMeta icebergCatalog = new CatalogMeta();
     icebergCatalog.setCatalogName(catalogName);
@@ -186,7 +190,7 @@ public class AmsEnvironment {
       throw new RuntimeException(e);
     }
     properties.put("warehouse", warehouseDir);
-    properties.put("table-formats", "ICEBERG");
+    properties.put("table-formats", "MIXED_ICEBERG");
     localCatalog.setCatalogProperties(properties);
     ServiceContainer.getCatalogMetadataService().addCatalog(localCatalog);
   }
@@ -227,8 +231,8 @@ public class AmsEnvironment {
     return "ams:\n" +
         "  arctic.ams.server-host.prefix: \"127.\"\n" +
         // "  arctic.ams.server-host: 127.0.0.1\n" +
-        "  arctic.ams.thrift.port: 1260 # useless in test, System.getProperty(\"arctic.ams.thrift.port\") is used\n" +
-        "  arctic.ams.http.port: 1630\n" +
+        "  arctic.ams.thrift.port: 1360 # useless in test, System.getProperty(\"arctic.ams.thrift.port\") is used\n" +
+        "  arctic.ams.http.port: 1730\n" +
         "  arctic.ams.optimize.check.thread.pool-size: 1\n" +
         "  arctic.ams.optimize.commit.thread.pool-size: 1\n" +
         "  arctic.ams.expire.thread.pool-size: 1\n" +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix #846.

When `Minor Optimize` commit, we check if there is any conflict commit on BaseStore during the execution of tasks, using the minTransactionId of these tasks.

However, we use the legacy TransactionId. We have to fix it by using the right TransactionId.

## Brief change log

  - add minTransactionId for optimize_task
  - minor optimize plan set minTransactionId into optimizeTask
  - use the right minTransactionId to check if there is any conflict commit

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
