### PR TITLE
[ISSUE-561][Flink] Fix flink cannot fetch right ckpId after failover

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -71,7 +71,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private transient int subTaskId;
   private transient int attemptId;
   private transient String jobId;
-  private transient long checkpointId = 0;
+  private transient long checkpointId = 1;
   private transient ListState<Long> checkpointState;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
@@ -184,7 +184,8 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-    this.checkpointId = checkpointId;
+    // get ckpId for next cp writer
+    this.checkpointId = checkpointId + 1;
 
     table.io().doAs(() -> {
       completeAndEmitFiles();

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterITCase.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterITCase.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Snapshot;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+import static com.netease.arctic.flink.read.ArcticSourceTest.tableRecords;
+
+public class ArcticFileWriterITCase extends FlinkTestBase {
+
+  public static final Logger LOG = LoggerFactory.getLogger(ArcticFileWriterITCase.class);
+
+  private static final Map<String, CountDownLatch> LATCH_MAP = new ConcurrentHashMap<>();
+  public ArcticTableLoader tableLoader;
+  private String latchId;
+  private int NUM_SOURCES = 4;
+  private int NUM_RECORDS = 10000;
+
+  @Before
+  public void setup() {
+    this.latchId = UUID.randomUUID().toString();
+    // We wait for two successful checkpoints in sources before shutting down. This ensures that
+    // the sink can commit its data.
+    // We need to keep a "static" latch here because all sources need to be kept running
+    // while we're waiting for the required number of checkpoints. Otherwise, we would lock up
+    // because we can only do checkpoints while all operators are running.
+    LATCH_MAP.put(latchId, new CountDownLatch(NUM_SOURCES * 2));
+  }
+
+  protected static final double FAILOVER_RATIO = 0.4;
+
+  private static class StreamingExecutionTestSource extends RichParallelSourceFunction<RowData>
+      implements CheckpointListener, CheckpointedFunction {
+
+    private final String latchId;
+
+    private final int numberOfRecords;
+
+    /**
+     * Whether the test is executing in a scenario that induces a failover. This doesn't mean
+     * that this source induces the failover.
+     */
+    private final boolean isFailoverScenario;
+
+    private ListState<Integer> nextValueState;
+
+    private int nextValue;
+
+    private volatile boolean isCanceled;
+
+    private volatile boolean snapshottedAfterAllRecordsOutput;
+
+    private volatile boolean isWaitingCheckpointComplete;
+
+    private volatile boolean hasCompletedCheckpoint;
+
+    public StreamingExecutionTestSource(
+        String latchId, int numberOfRecords, boolean isFailoverScenario) {
+      this.latchId = latchId;
+      this.numberOfRecords = numberOfRecords;
+      this.isFailoverScenario = isFailoverScenario;
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+      nextValueState =
+          context.getOperatorStateStore()
+              .getListState(new ListStateDescriptor<>("nextValue", Integer.class));
+
+      if (nextValueState.get() != null && nextValueState.get().iterator().hasNext()) {
+        nextValue = nextValueState.get().iterator().next();
+      }
+    }
+
+    @Override
+    public void run(SourceContext<RowData> ctx) throws Exception {
+      if (isFailoverScenario && getRuntimeContext().getAttemptNumber() == 0) {
+        // In the first execution, we first send a part of record...
+        sendRecordsUntil((int) (numberOfRecords * FAILOVER_RATIO * 0.5), ctx);
+
+        // Wait till the first part of data is committed.
+        while (!hasCompletedCheckpoint) {
+          Thread.sleep(50);
+        }
+
+        // Then we write the second part of data...
+        sendRecordsUntil((int) (numberOfRecords * FAILOVER_RATIO), ctx);
+
+        // And then trigger the failover.
+        if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+          throw new RuntimeException("Designated Exception");
+        } else {
+          while (true) {
+            Thread.sleep(50);
+          }
+        }
+      } else {
+        // If we are not going to trigger failover or we have already triggered failover,
+        // run until finished.
+        sendRecordsUntil(numberOfRecords, ctx);
+
+        // Wait the last checkpoint to commit all the pending records.
+        isWaitingCheckpointComplete = true;
+        CountDownLatch latch = LATCH_MAP.get(latchId);
+        latch.await();
+      }
+    }
+
+    private void sendRecordsUntil(int targetNumber, SourceContext<RowData> ctx) {
+      while (!isCanceled && nextValue < targetNumber) {
+        synchronized (ctx.getCheckpointLock()) {
+          ctx.collect(GenericRowData.of(
+              nextValue++, StringData.fromString(""), TimestampData.fromLocalDateTime(LocalDateTime.now())));
+        }
+      }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+      nextValueState.update(Collections.singletonList(nextValue));
+
+      if (isWaitingCheckpointComplete) {
+        snapshottedAfterAllRecordsOutput = true;
+      }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+      if (isWaitingCheckpointComplete && snapshottedAfterAllRecordsOutput) {
+        CountDownLatch latch = LATCH_MAP.get(latchId);
+        latch.countDown();
+      }
+
+      hasCompletedCheckpoint = true;
+    }
+
+    @Override
+    public void cancel() {
+      isCanceled = true;
+    }
+  }
+
+  protected JobGraph createJobGraph(ArcticTableLoader tableLoader, TableSchema tableSchema, boolean triggerFailover) {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    Configuration config = new Configuration();
+    config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
+    env.configure(config, getClass().getClassLoader());
+
+    env.enableCheckpointing(10, CheckpointingMode.EXACTLY_ONCE);
+
+    if (triggerFailover) {
+      env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, Time.milliseconds(100)));
+    } else {
+      env.setRestartStrategy(RestartStrategies.noRestart());
+    }
+
+    DataStreamSource<RowData> source = env.addSource(
+            new StreamingExecutionTestSource(latchId, NUM_RECORDS, triggerFailover))
+        .setParallelism(4);
+    ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
+    FlinkSink
+        .forRowData(source)
+        .table(table)
+        .tableLoader(tableLoader)
+        .flinkSchema(tableSchema)
+        .build();
+
+    StreamGraph streamGraph = env.getStreamGraph();
+    return streamGraph.getJobGraph();
+  }
+
+  @Test
+  public void testWrite() throws Exception {
+    tableLoader = ArcticTableLoader.of(PK_TABLE_ID, catalogBuilder);
+
+    JobGraph jobGraph = createJobGraph(tableLoader, FLINK_SCHEMA, true);
+    final Configuration config = new Configuration();
+    config.setString(RestOptions.BIND_PORT, "18081-19000");
+    final MiniClusterConfiguration cfg =
+        new MiniClusterConfiguration.Builder()
+            .setNumTaskManagers(1)
+            .setNumSlotsPerTaskManager(NUM_SOURCES)
+            .setConfiguration(config)
+            .build();
+
+    try (MiniCluster miniCluster = new MiniCluster(cfg)) {
+      miniCluster.start();
+      miniCluster.executeJobBlocking(jobGraph);
+    }
+
+    KeyedTable keyedTable = tableLoader.loadArcticTable().asKeyedTable();
+    checkResult(keyedTable, NUM_RECORDS * NUM_SOURCES);
+  }
+
+  public static void checkResult(KeyedTable keyedTable, int exceptedSize) {
+    keyedTable.refresh();
+    Snapshot crt = keyedTable.changeTable().currentSnapshot();
+
+    Stack<Snapshot> snapshots = new Stack<>();
+    while (crt != null) {
+      snapshots.push(crt);
+      if (crt.parentId() == null) {
+        break;
+      }
+      crt = keyedTable.changeTable().snapshot(crt.parentId());
+    }
+
+    Set<String> paths = new HashSet<>();
+    int maxTxId = -1;
+    while (!snapshots.isEmpty()) {
+      Snapshot snapshot = snapshots.pop();
+      int minTxIdInSnapshot = Integer.MAX_VALUE;
+      int maxTxIdInSnapshot = -1;
+      for (DataFile addedFile : snapshot.addedFiles()) {
+        String path = addedFile.path().toString();
+        Assert.assertFalse(paths.contains(path));
+        paths.add(path);
+        LOG.info("add file: {}", addedFile.path());
+
+        int txId = AdaptHiveOutputFileFactory.parseTransactionId(path);
+        minTxIdInSnapshot = Math.min(minTxIdInSnapshot, txId);
+        maxTxIdInSnapshot = Math.max(maxTxIdInSnapshot, txId);
+      }
+      Assert.assertTrue(maxTxId <= minTxIdInSnapshot);
+
+      maxTxId = maxTxIdInSnapshot;
+    }
+
+    Assert.assertEquals(exceptedSize, tableRecords(keyedTable).size());
+  }
+
+}

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -26,9 +26,11 @@ import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -70,6 +72,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private transient int attemptId;
   private transient String jobId;
   private transient long checkpointId = 0;
+  private transient ListState<Long> checkpointState;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
    * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
@@ -112,12 +115,27 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     super.initializeState(context);
 
     this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
+    checkpointState =
+        context.getOperatorStateStore()
+            .getListState(
+                new ListStateDescriptor<>(
+                    subTaskId + "-task-file-writer-state",
+                    LongSerializer.INSTANCE));
 
     if (context.isRestored()) {
-      checkpointId = context.getRestoredCheckpointId().getAsLong();
+      // get last success ckp num from state when failover continuously
+      checkpointId = checkpointState.get().iterator().next();
       // prepare for the writer init in open(). It is used for next ckpId.
       checkpointId++;
     }
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+
+    checkpointState.clear();
+    checkpointState.add(context.getCheckpointId());
   }
 
   private void initTaskWriterFactory(Long mask) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -71,7 +71,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private transient int subTaskId;
   private transient int attemptId;
   private transient String jobId;
-  private transient long checkpointId = 0;
+  private transient long checkpointId = 1;
   private transient ListState<Long> checkpointState;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
@@ -185,7 +185,8 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-    this.checkpointId = checkpointId;
+    // get ckpId for next cp writer
+    this.checkpointId = checkpointId + 1;
 
     table.io().doAs(() -> {
       completeAndEmitFiles();

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterITCase.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterITCase.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Snapshot;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+import static com.netease.arctic.flink.read.ArcticSourceTest.tableRecords;
+
+public class ArcticFileWriterITCase extends FlinkTestBase {
+
+  public static final Logger LOG = LoggerFactory.getLogger(ArcticFileWriterITCase.class);
+
+  private static final Map<String, CountDownLatch> LATCH_MAP = new ConcurrentHashMap<>();
+  public ArcticTableLoader tableLoader;
+  private String latchId;
+  private int NUM_SOURCES = 4;
+  private int NUM_RECORDS = 10000;
+
+  @Before
+  public void setup() {
+    this.latchId = UUID.randomUUID().toString();
+    // We wait for two successful checkpoints in sources before shutting down. This ensures that
+    // the sink can commit its data.
+    // We need to keep a "static" latch here because all sources need to be kept running
+    // while we're waiting for the required number of checkpoints. Otherwise, we would lock up
+    // because we can only do checkpoints while all operators are running.
+    LATCH_MAP.put(latchId, new CountDownLatch(NUM_SOURCES * 2));
+  }
+
+  protected static final double FAILOVER_RATIO = 0.4;
+
+  private static class StreamingExecutionTestSource extends RichParallelSourceFunction<RowData>
+      implements CheckpointListener, CheckpointedFunction {
+
+    private final String latchId;
+
+    private final int numberOfRecords;
+
+    /**
+     * Whether the test is executing in a scenario that induces a failover. This doesn't mean
+     * that this source induces the failover.
+     */
+    private final boolean isFailoverScenario;
+
+    private ListState<Integer> nextValueState;
+
+    private int nextValue;
+
+    private volatile boolean isCanceled;
+
+    private volatile boolean snapshottedAfterAllRecordsOutput;
+
+    private volatile boolean isWaitingCheckpointComplete;
+
+    private volatile boolean hasCompletedCheckpoint;
+
+    public StreamingExecutionTestSource(
+        String latchId, int numberOfRecords, boolean isFailoverScenario) {
+      this.latchId = latchId;
+      this.numberOfRecords = numberOfRecords;
+      this.isFailoverScenario = isFailoverScenario;
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+      nextValueState =
+          context.getOperatorStateStore()
+              .getListState(new ListStateDescriptor<>("nextValue", Integer.class));
+
+      if (nextValueState.get() != null && nextValueState.get().iterator().hasNext()) {
+        nextValue = nextValueState.get().iterator().next();
+      }
+    }
+
+    @Override
+    public void run(SourceContext<RowData> ctx) throws Exception {
+      if (isFailoverScenario && getRuntimeContext().getAttemptNumber() == 0) {
+        // In the first execution, we first send a part of record...
+        sendRecordsUntil((int) (numberOfRecords * FAILOVER_RATIO * 0.5), ctx);
+
+        // Wait till the first part of data is committed.
+        while (!hasCompletedCheckpoint) {
+          Thread.sleep(50);
+        }
+
+        // Then we write the second part of data...
+        sendRecordsUntil((int) (numberOfRecords * FAILOVER_RATIO), ctx);
+
+        // And then trigger the failover.
+        if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+          throw new RuntimeException("Designated Exception");
+        } else {
+          while (true) {
+            Thread.sleep(50);
+          }
+        }
+      } else {
+        // If we are not going to trigger failover or we have already triggered failover,
+        // run until finished.
+        sendRecordsUntil(numberOfRecords, ctx);
+
+        // Wait the last checkpoint to commit all the pending records.
+        isWaitingCheckpointComplete = true;
+        CountDownLatch latch = LATCH_MAP.get(latchId);
+        latch.await();
+      }
+    }
+
+    private void sendRecordsUntil(int targetNumber, SourceContext<RowData> ctx) {
+      while (!isCanceled && nextValue < targetNumber) {
+        synchronized (ctx.getCheckpointLock()) {
+          ctx.collect(GenericRowData.of(
+              nextValue++, StringData.fromString(""), TimestampData.fromLocalDateTime(LocalDateTime.now())));
+        }
+      }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+      nextValueState.update(Collections.singletonList(nextValue));
+
+      if (isWaitingCheckpointComplete) {
+        snapshottedAfterAllRecordsOutput = true;
+      }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+      if (isWaitingCheckpointComplete && snapshottedAfterAllRecordsOutput) {
+        CountDownLatch latch = LATCH_MAP.get(latchId);
+        latch.countDown();
+      }
+
+      hasCompletedCheckpoint = true;
+    }
+
+    @Override
+    public void cancel() {
+      isCanceled = true;
+    }
+  }
+
+  protected JobGraph createJobGraph(ArcticTableLoader tableLoader, TableSchema tableSchema, boolean triggerFailover) {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    Configuration config = new Configuration();
+    config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
+    env.configure(config, getClass().getClassLoader());
+
+    env.enableCheckpointing(10, CheckpointingMode.EXACTLY_ONCE);
+
+    if (triggerFailover) {
+      env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, Time.milliseconds(100)));
+    } else {
+      env.setRestartStrategy(RestartStrategies.noRestart());
+    }
+
+    DataStreamSource<RowData> source = env.addSource(
+            new StreamingExecutionTestSource(latchId, NUM_RECORDS, triggerFailover))
+        .setParallelism(4);
+    ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
+    FlinkSink
+        .forRowData(source)
+        .table(table)
+        .tableLoader(tableLoader)
+        .flinkSchema(tableSchema)
+        .build();
+
+    StreamGraph streamGraph = env.getStreamGraph();
+    return streamGraph.getJobGraph();
+  }
+
+  @Test
+  public void testWrite() throws Exception {
+    tableLoader = ArcticTableLoader.of(PK_TABLE_ID, catalogBuilder);
+
+    JobGraph jobGraph = createJobGraph(tableLoader, FLINK_SCHEMA, true);
+    final Configuration config = new Configuration();
+    config.setString(RestOptions.BIND_PORT, "18081-19000");
+    final MiniClusterConfiguration cfg =
+        new MiniClusterConfiguration.Builder()
+            .setNumTaskManagers(1)
+            .setNumSlotsPerTaskManager(NUM_SOURCES)
+            .setConfiguration(config)
+            .build();
+
+    try (MiniCluster miniCluster = new MiniCluster(cfg)) {
+      miniCluster.start();
+      miniCluster.executeJobBlocking(jobGraph);
+    }
+
+    KeyedTable keyedTable = tableLoader.loadArcticTable().asKeyedTable();
+    checkResult(keyedTable, NUM_RECORDS * NUM_SOURCES);
+  }
+
+  public static void checkResult(KeyedTable keyedTable, int exceptedSize) {
+    keyedTable.refresh();
+    Snapshot crt = keyedTable.changeTable().currentSnapshot();
+
+    Stack<Snapshot> snapshots = new Stack<>();
+    while (crt != null) {
+      snapshots.push(crt);
+      if (crt.parentId() == null) {
+        break;
+      }
+      crt = keyedTable.changeTable().snapshot(crt.parentId());
+    }
+
+    Set<String> paths = new HashSet<>();
+    int maxTxId = -1;
+    while (!snapshots.isEmpty()) {
+      Snapshot snapshot = snapshots.pop();
+      int minTxIdInSnapshot = Integer.MAX_VALUE;
+      int maxTxIdInSnapshot = -1;
+      for (DataFile addedFile : snapshot.addedFiles()) {
+        String path = addedFile.path().toString();
+        Assert.assertFalse(paths.contains(path));
+        paths.add(path);
+        LOG.info("add file: {}", addedFile.path());
+
+        int txId = AdaptHiveOutputFileFactory.parseTransactionId(path);
+        minTxIdInSnapshot = Math.min(minTxIdInSnapshot, txId);
+        maxTxIdInSnapshot = Math.max(maxTxIdInSnapshot, txId);
+      }
+      Assert.assertTrue(maxTxId <= minTxIdInSnapshot);
+
+      maxTxId = maxTxIdInSnapshot;
+    }
+
+    Assert.assertEquals(exceptedSize, tableRecords(keyedTable).size());
+  }
+
+}

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -71,7 +71,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private transient int subTaskId;
   private transient int attemptId;
   private transient String jobId;
-  private transient long checkpointId = 0;
+  private transient long checkpointId = 1;
   private transient ListState<Long> checkpointState;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
@@ -184,7 +184,8 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-    this.checkpointId = checkpointId;
+    // get ckpId for next cp writer
+    this.checkpointId = checkpointId + 1;
 
     table.io().doAs(() -> {
       completeAndEmitFiles();

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -26,7 +26,11 @@ import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -68,6 +72,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private transient int attemptId;
   private transient String jobId;
   private transient long checkpointId = 0;
+  private transient ListState<Long> checkpointState;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
    * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
@@ -109,12 +114,27 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     super.initializeState(context);
 
     this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
+    checkpointState =
+        context.getOperatorStateStore()
+            .getListState(
+                new ListStateDescriptor<>(
+                    subTaskId + "-task-file-writer-state",
+                    LongSerializer.INSTANCE));
 
     if (context.isRestored()) {
-      checkpointId = context.getRestoredCheckpointId().getAsLong();
+      // get last success ckp num from state when failover continuously
+      checkpointId = checkpointState.get().iterator().next();
       // prepare for the writer init in open(). It is used for next ckpId.
       checkpointId++;
     }
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+
+    checkpointState.clear();
+    checkpointState.add(context.getCheckpointId());
   }
 
   private void initTaskWriterFactory(Long mask) {

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterITCase.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/ArcticFileWriterITCase.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.util.ArcticUtils;
+import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Snapshot;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Stack;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+import static com.netease.arctic.flink.read.ArcticSourceTest.tableRecords;
+
+public class ArcticFileWriterITCase extends FlinkTestBase {
+
+  public static final Logger LOG = LoggerFactory.getLogger(ArcticFileWriterITCase.class);
+
+  private static final Map<String, CountDownLatch> LATCH_MAP = new ConcurrentHashMap<>();
+  public ArcticTableLoader tableLoader;
+  private String latchId;
+  private int NUM_SOURCES = 4;
+  private int NUM_RECORDS = 10000;
+
+  @Before
+  public void setup() {
+    this.latchId = UUID.randomUUID().toString();
+    // We wait for two successful checkpoints in sources before shutting down. This ensures that
+    // the sink can commit its data.
+    // We need to keep a "static" latch here because all sources need to be kept running
+    // while we're waiting for the required number of checkpoints. Otherwise, we would lock up
+    // because we can only do checkpoints while all operators are running.
+    LATCH_MAP.put(latchId, new CountDownLatch(NUM_SOURCES * 2));
+  }
+
+  protected static final double FAILOVER_RATIO = 0.4;
+
+  private static class StreamingExecutionTestSource extends RichParallelSourceFunction<RowData>
+      implements CheckpointListener, CheckpointedFunction {
+
+    private final String latchId;
+
+    private final int numberOfRecords;
+
+    /**
+     * Whether the test is executing in a scenario that induces a failover. This doesn't mean
+     * that this source induces the failover.
+     */
+    private final boolean isFailoverScenario;
+
+    private ListState<Integer> nextValueState;
+
+    private int nextValue;
+
+    private volatile boolean isCanceled;
+
+    private volatile boolean snapshottedAfterAllRecordsOutput;
+
+    private volatile boolean isWaitingCheckpointComplete;
+
+    private volatile boolean hasCompletedCheckpoint;
+
+    public StreamingExecutionTestSource(
+        String latchId, int numberOfRecords, boolean isFailoverScenario) {
+      this.latchId = latchId;
+      this.numberOfRecords = numberOfRecords;
+      this.isFailoverScenario = isFailoverScenario;
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+      nextValueState =
+          context.getOperatorStateStore()
+              .getListState(new ListStateDescriptor<>("nextValue", Integer.class));
+
+      if (nextValueState.get() != null && nextValueState.get().iterator().hasNext()) {
+        nextValue = nextValueState.get().iterator().next();
+      }
+    }
+
+    @Override
+    public void run(SourceContext<RowData> ctx) throws Exception {
+      if (isFailoverScenario && getRuntimeContext().getAttemptNumber() == 0) {
+        // In the first execution, we first send a part of record...
+        sendRecordsUntil((int) (numberOfRecords * FAILOVER_RATIO * 0.5), ctx);
+
+        // Wait till the first part of data is committed.
+        while (!hasCompletedCheckpoint) {
+          Thread.sleep(50);
+        }
+
+        // Then we write the second part of data...
+        sendRecordsUntil((int) (numberOfRecords * FAILOVER_RATIO), ctx);
+
+        // And then trigger the failover.
+        if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+          throw new RuntimeException("Designated Exception");
+        } else {
+          while (true) {
+            Thread.sleep(50);
+          }
+        }
+      } else {
+        // If we are not going to trigger failover or we have already triggered failover,
+        // run until finished.
+        sendRecordsUntil(numberOfRecords, ctx);
+
+        // Wait the last checkpoint to commit all the pending records.
+        isWaitingCheckpointComplete = true;
+        CountDownLatch latch = LATCH_MAP.get(latchId);
+        latch.await();
+      }
+    }
+
+    private void sendRecordsUntil(int targetNumber, SourceContext<RowData> ctx) {
+      while (!isCanceled && nextValue < targetNumber) {
+        synchronized (ctx.getCheckpointLock()) {
+          ctx.collect(GenericRowData.of(
+              nextValue++, StringData.fromString(""), TimestampData.fromLocalDateTime(LocalDateTime.now())));
+        }
+      }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+      nextValueState.update(Collections.singletonList(nextValue));
+
+      if (isWaitingCheckpointComplete) {
+        snapshottedAfterAllRecordsOutput = true;
+      }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+      if (isWaitingCheckpointComplete && snapshottedAfterAllRecordsOutput) {
+        CountDownLatch latch = LATCH_MAP.get(latchId);
+        latch.countDown();
+      }
+
+      hasCompletedCheckpoint = true;
+    }
+
+    @Override
+    public void cancel() {
+      isCanceled = true;
+    }
+  }
+
+  protected JobGraph createJobGraph(ArcticTableLoader tableLoader, TableSchema tableSchema, boolean triggerFailover) {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    Configuration config = new Configuration();
+    config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
+    env.configure(config, getClass().getClassLoader());
+
+    env.enableCheckpointing(10, CheckpointingMode.EXACTLY_ONCE);
+
+    if (triggerFailover) {
+      env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, Time.milliseconds(100)));
+    } else {
+      env.setRestartStrategy(RestartStrategies.noRestart());
+    }
+
+    DataStreamSource<RowData> source = env.addSource(
+            new StreamingExecutionTestSource(latchId, NUM_RECORDS, triggerFailover))
+        .setParallelism(4);
+    ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
+    FlinkSink
+        .forRowData(source)
+        .context(Optional::of)
+        .table(table)
+        .tableLoader(tableLoader)
+        .flinkSchema(tableSchema)
+        .build();
+
+    StreamGraph streamGraph = env.getStreamGraph();
+    return streamGraph.getJobGraph();
+  }
+
+  @Test
+  public void testWrite() throws Exception {
+    tableLoader = ArcticTableLoader.of(PK_TABLE_ID, catalogBuilder);
+
+    JobGraph jobGraph = createJobGraph(tableLoader, FLINK_SCHEMA, true);
+    final Configuration config = new Configuration();
+    config.setString(RestOptions.BIND_PORT, "18081-19000");
+    final MiniClusterConfiguration cfg =
+        new MiniClusterConfiguration.Builder()
+            .setNumTaskManagers(1)
+            .setNumSlotsPerTaskManager(NUM_SOURCES)
+            .setConfiguration(config)
+            .build();
+
+    try (MiniCluster miniCluster = new MiniCluster(cfg)) {
+      miniCluster.start();
+      miniCluster.executeJobBlocking(jobGraph);
+    }
+
+    KeyedTable keyedTable = tableLoader.loadArcticTable().asKeyedTable();
+    checkResult(keyedTable, NUM_RECORDS * NUM_SOURCES);
+  }
+
+  public static void checkResult(KeyedTable keyedTable, int exceptedSize) {
+    keyedTable.refresh();
+    Snapshot crt = keyedTable.changeTable().currentSnapshot();
+
+    Stack<Snapshot> snapshots = new Stack<>();
+    while (crt != null) {
+      snapshots.push(crt);
+      if (crt.parentId() == null) {
+        break;
+      }
+      crt = keyedTable.changeTable().snapshot(crt.parentId());
+    }
+
+    Set<String> paths = new HashSet<>();
+    int maxTxId = -1;
+    while (!snapshots.isEmpty()) {
+      Snapshot snapshot = snapshots.pop();
+      int minTxIdInSnapshot = Integer.MAX_VALUE;
+      int maxTxIdInSnapshot = -1;
+      for (DataFile addedFile : snapshot.addedFiles()) {
+        String path = addedFile.path().toString();
+        Assert.assertFalse(paths.contains(path));
+        paths.add(path);
+        LOG.info("add file: {}", addedFile.path());
+
+        int txId = AdaptHiveOutputFileFactory.parseTransactionId(path);
+        minTxIdInSnapshot = Math.min(minTxIdInSnapshot, txId);
+        maxTxIdInSnapshot = Math.max(maxTxIdInSnapshot, txId);
+      }
+      Assert.assertTrue(maxTxId <= minTxIdInSnapshot);
+
+      maxTxId = maxTxIdInSnapshot;
+    }
+
+    Assert.assertEquals(exceptedSize, tableRecords(keyedTable).size());
+  }
+
+}

--- a/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveOutputFileFactory.java
+++ b/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveOutputFileFactory.java
@@ -32,25 +32,33 @@ import org.apache.iceberg.io.OutputFile;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.netease.arctic.utils.FileUtil.getFileName;
+
 /**
  * For adapt hive table with partitions the dir construct is :
- *    ${table_location}
- *            -| change
- *            -| base
- *            -| hive
- *                 -| ${partition_name1}
- *                 -| ${partition_name2}
- *                            -| ${timestamp}_{txid}
- *
+ * ${table_location}
+ * -| change
+ * -| base
+ * -| hive
+ * -| ${partition_name1}
+ * -| ${partition_name2}
+ * -| ${timestamp}_{txid}
+ * <p>
  * For adapt hive table without partitions the dir construct is :
- *    ${table_location}
- *            -| change
- *            -| base
- *            -| hive
- *                  -| ${timestamp}_{txid}
+ * ${table_location}
+ * -| change
+ * -| base
+ * -| hive
+ * -| ${timestamp}_{txid}
  * txId of unkeyed table is random long.
  */
 public class AdaptHiveOutputFileFactory implements OutputFileFactory {
+
+  public static final String SEPARATOR = "-";
+  /**
+   * start from 0
+   */
+  public static final int TRANSACTION_INDEX = 2;
 
   private final String baseLocation;
   private final String hiveSubDirectory;
@@ -117,4 +125,17 @@ public class AdaptHiveOutputFileFactory implements OutputFileFactory {
     OutputFile outputFile = io.newOutputFile(fileLocation);
     return encryptionManager.encrypt(outputFile);
   }
+
+  /**
+   * extract transactionId from data path name.
+   */
+  public static int parseTransactionId(CharSequence path) {
+    String fileName = getFileName(path.toString());
+    String[] values = fileName.split(SEPARATOR);
+    if (values.length <= TRANSACTION_INDEX) {
+      throw new IllegalArgumentException("path is invalid. " + path);
+    }
+    return Integer.parseInt(values[TRANSACTION_INDEX]);
+  }
+
 }

--- a/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveOutputFileFactory.java
+++ b/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveOutputFileFactory.java
@@ -36,20 +36,20 @@ import static com.netease.arctic.utils.FileUtil.getFileName;
 
 /**
  * For adapt hive table with partitions the dir construct is :
- * ${table_location}
- * -| change
- * -| base
- * -| hive
- * -| ${partition_name1}
- * -| ${partition_name2}
- * -| ${timestamp}_{txid}
- * <p>
+ *    ${table_location}
+ *            -| change
+ *            -| base
+ *            -| hive
+ *                 -| ${partition_name1}
+ *                 -| ${partition_name2}
+ *                            -| ${timestamp}_{txid}
+ *
  * For adapt hive table without partitions the dir construct is :
- * ${table_location}
- * -| change
- * -| base
- * -| hive
- * -| ${timestamp}_{txid}
+ *    ${table_location}
+ *            -| change
+ *            -| base
+ *            -| hive
+ *                  -| ${timestamp}_{txid}
  * txId of unkeyed table is random long.
  */
 public class AdaptHiveOutputFileFactory implements OutputFileFactory {


### PR DESCRIPTION
Fix #561 Fix #826 

## Why are the changes needed?
the fix #568 about Flink 1.14, 1.15 was wrong due to the op cannot fetch right restore ckpId after failover if op has no state.

And the ckpId assigned to writer is not one to one correspondence, which leads to the repeatable file name.

## Brief change log

  - *The flink 1.12, 1.14 and 1.15 versions are affected.*

## How was this patch tested?
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
