### PR TITLE
[ARCTIC-635]Skip cleaning maniftes files when commiting failed for hadoop table

### DIFF
--- a/core/src/main/java/com/netease/arctic/op/ArcticHadoopTableOperations.java
+++ b/core/src/main/java/com/netease/arctic/op/ArcticHadoopTableOperations.java
@@ -59,8 +59,6 @@ public class ArcticHadoopTableOperations extends HadoopTableOperations {
           // Do to wrap the direct CommitFailedException, we should retry committing.
           throw e;
         }
-      } catch (RuntimeException e) {
-        throw new CommitStateUnknownException(e);
       }
       return null;
     });

--- a/core/src/main/java/com/netease/arctic/op/ArcticHadoopTableOperations.java
+++ b/core/src/main/java/com/netease/arctic/op/ArcticHadoopTableOperations.java
@@ -22,6 +22,7 @@ import com.netease.arctic.io.ArcticFileIO;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.hadoop.HadoopTableOperations;
 import org.apache.iceberg.util.LockManagers;
@@ -45,12 +46,20 @@ public class ArcticHadoopTableOperations extends HadoopTableOperations {
     arcticFileIO.doAs(() -> {
       try {
         super.commit(base, metadata);
-      } catch (RuntimeException e) {
+
         // HadoopTableOperations#commit will throw CommitFailedException even though rename metadata file successfully
         // in hdfs, it may be not safe. So transform all RuntimeException to CommitStateUnknownException to avoid
         // delete the committed metadata and manifest files.
         //
-        // But this change may invalid the retry action for all commit operation.
+        // But this change may invalid the retry action for some commit operation.
+      } catch (CommitFailedException e) {
+        if (e.getCause() != null) {
+          throw new CommitStateUnknownException(e);
+        } else {
+          // Do to wrap the direct CommitFailedException, we should retry committing.
+          throw e;
+        }
+      } catch (RuntimeException e) {
         throw new CommitStateUnknownException(e);
       }
       return null;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

*Fix #635*

## Brief change log

  - *Throw CommitStateUnknownException when Hadoop table commit failed*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no)**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
