### PR TITLE
[ARCTIC-890][AMS] Fix the data loss when the minor optimize in progress and restart the ams at the same time

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
@@ -317,6 +317,7 @@ public class TableOptimizeItem extends IJDBCService {
         // if minor optimize, insert files as base new files
         if (optimizeTaskItem.getOptimizeTask().getTaskId().getType() == OptimizeType.Minor &&
             !com.netease.arctic.utils.TableTypeUtil.isIcebergTableFormat(getArcticTable())) {
+          optimizeTaskItem.setFiles();
           targetFiles.addAll(optimizeTaskItem.getOptimizeTask().getInsertFiles());
           targetFileSize = targetFileSize + optimizeTaskItem.getOptimizeTask().getInsertFileSize();
         }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
@@ -317,7 +317,10 @@ public class TableOptimizeItem extends IJDBCService {
         // if minor optimize, insert files as base new files
         if (optimizeTaskItem.getOptimizeTask().getTaskId().getType() == OptimizeType.Minor &&
             !com.netease.arctic.utils.TableTypeUtil.isIcebergTableFormat(getArcticTable())) {
-          optimizeTaskItem.setFiles();
+          if (optimizeTaskItem.getOptimizeTask().getInsertFileCnt() !=
+              optimizeTaskItem.getOptimizeTask().getInsertFiles().size()) {
+            optimizeTaskItem.setFiles();
+          }
           targetFiles.addAll(optimizeTaskItem.getOptimizeTask().getInsertFiles());
           targetFileSize = targetFileSize + optimizeTaskItem.getOptimizeTask().getInsertFileSize();
         }


### PR DESCRIPTION
## Why are the changes needed?
fix #890 

## Brief change log

  - *Load the insert files cache in optimize task when adding the insert files into the target files*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
