### PR TITLE
[Docker] Limit JVM memory for AMS in docker

### DIFF
--- a/dist/src/main/arctic-bin/bin/ams.sh
+++ b/dist/src/main/arctic-bin/bin/ams.sh
@@ -39,7 +39,8 @@ XMX=$XMX_CONFIG
 XMS=$XMS_CONFIG
 MAX_PERM=$MAX_PERM_CONFIG
 
-JAVA_OPTS="-server -Xloggc:$ARCTIC_HOME/logs/gc.log -Xms${XMS}m -Xmx${XMX}m -XX:MaxPermSize=${MAX_PERM}m \
+JAVA_OPTS="-server -Xloggc:$ARCTIC_HOME/logs/gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M \
+-Xms${XMS}m -Xmx${XMX}m -XX:MaxPermSize=${MAX_PERM}m \
 -verbose:gc -XX:+PrintGCDetails \
 -Dcom.sun.management.jmxremote \
 -Dcom.sun.management.jmxremote.ssl=false \

--- a/dist/src/main/arctic-bin/bin/ams.sh
+++ b/dist/src/main/arctic-bin/bin/ams.sh
@@ -39,7 +39,7 @@ XMX=$XMX_CONFIG
 XMS=$XMS_CONFIG
 MAX_PERM=$MAX_PERM_CONFIG
 
-JAVA_OPTS="-server -Xms${XMS}m -Xmx${XMX}m -XX:MaxPermSize=${MAX_PERM}m \
+JAVA_OPTS="-server -Xloggc:$ARCTIC_HOME/logs/gc.log -Xms${XMS}m -Xmx${XMX}m -XX:MaxPermSize=${MAX_PERM}m \
 -verbose:gc -XX:+PrintGCDetails \
 -Dcom.sun.management.jmxremote \
 -Dcom.sun.management.jmxremote.ssl=false \

--- a/docker/ams/config.sh
+++ b/docker/ams/config.sh
@@ -20,11 +20,11 @@
 
 
 if [ -z "$XMX_CONFIG" ]; then
-    XMX_CONFIG="8196"
+    XMX_CONFIG="2048"
 fi
 
 if [ -z "$XMS_CONFIG" ]; then
-    XMS_CONFIG="1024"
+    XMS_CONFIG="2048"
 fi
 
 if [ -z "$MAX_PERM_CONFIG" ]; then


### PR DESCRIPTION
## Why are the changes needed?
Limit JVM memory for AMS in docker.
Print Gc log details.

## Brief change log

  - *Change XMX XMS parameter in docker.*
  - *Add JVM GC parameter to print GC logs and rotation it.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (docs)
