### PR TITLE
[ARCTIC-907][SPARK]Duplicate keys verification for the source table should add a property to control in Spark

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/local/LocalSessionFactory.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/local/LocalSessionFactory.java
@@ -62,6 +62,7 @@ public class LocalSessionFactory implements TerminalSessionFactory {
 
     Map<String, String> sparkConf = SparkContextUtil.getSparkConf(configuration);
     Map<String, String> finallyConf = Maps.newLinkedHashMap();
+    sparkConf.put(REFRESH_CATALOG_BEFORE_USAGE, "true");
     for (String key : sparkConf.keySet()) {
       if (STATIC_SPARK_CONF.contains(key)) {
         continue;
@@ -69,7 +70,6 @@ public class LocalSessionFactory implements TerminalSessionFactory {
       updateSessionConf(session, initializeLogs, key, sparkConf.get(key));
       finallyConf.put(key, sparkConf.get(key));
     }
-    finallyConf.put(REFRESH_CATALOG_BEFORE_USAGE, "true");
 
     return new LocalTerminalSession(catalogs, session, initializeLogs, finallyConf);
   }

--- a/site/docs/ch/spark/spark-conf.md
+++ b/site/docs/ch/spark/spark-conf.md
@@ -30,15 +30,15 @@ spark.sql.catalog.spark_catalog=com.netease.arctic.spark.ArcticSparkSessionCatal
 ```
 您可以把 Spark 内置的 Catalog：`spark_catalog`配置为您想要的 Catalog 类型来实现访问不同的表。  
 
-Arctic Spark 提供一个参数来控制 session catalog 的行为：`spark.arctic.sql.delegate.enabled`，该参数默认为 `true`。  
+Arctic Spark 提供一个参数来控制 session catalog 的行为：`spark.sql.arctic.delegate.enabled`，该参数默认为 `true`。  
 
-您可以在 Spark 的配置文件中修改该配置，也可以在启动 Spark 时通过命令行参数 `--conf spark.arctic.sql.delegate.enabled=${OPTION}` 来设置该参数。
+您可以在 Spark 的配置文件中修改该配置，也可以在启动 Spark 时通过命令行参数 `--conf spark.sql.arctic.delegate.enabled=${OPTION}` 来设置该参数。
 
 将该参数设置为 `true` 表示ArcticSessionCatalog 会代理 Hive 表为 Arctic 表。
 ```
-spark.arctic.sql.delegate.enabled=true
+spark.sql.arctic.delegate.enabled=true
 ```
 将该参数设置为 `false` 表示不进入代理模式，将使用 Spark 默认的 Catalog：
 ```
-spark.arctic.sql.delegate.enabled=false
+spark.sql.arctic.delegate.enabled=false
 ```

--- a/site/docs/ch/spark/spark-ddl.md
+++ b/site/docs/ch/spark/spark-ddl.md
@@ -71,6 +71,7 @@ USING arctic
 AS SELECT ...
 ```
 > CREATE TABLE ... AS SELECT 语法作用为创建表并将查询结果写入表中，主键、分区、以及 properties 不会从源表中继承，需单独配置。
+> 可以通过 SPARK SQL`set spark.sql.arctic.check-source-data-uniqueness.enabled = true` 开启对源表主键的唯一性校验，若存在相同主键，写入时会报错提示。
 
 创建带主键、分区、preoperties 的表，可以使用如下语法：
 

--- a/site/docs/ch/spark/spark-dml.md
+++ b/site/docs/ch/spark/spark-dml.md
@@ -31,7 +31,7 @@ SELECT * FROM arctic_catalog.db.sample.change
 
 ## Write
 
-### Insert overwrite 
+### INSERT OVERWRITE 
 
 `INSERT OVERWRITE`可以用查询的结果替换表中的数据
 
@@ -72,7 +72,7 @@ partition( dt = '2021-1-1')  values
 
 > 可以通过 SPARK SQL`set spark.sql.arctic.check-source-data-uniqueness.enabled = true` 开启对源表主键的唯一性校验，若存在相同主键，写入时会报错提示。
 
-### Insert into
+### INSERT INTO
 
 #### 无主键表
 要向无主键表添加新数据，请使用 `INSERT INTO`
@@ -108,7 +108,7 @@ INSERT INTO prod.db.keyedTable SELECT ...
 
 
 
-### Delete from
+### DELETE FROM
 
 Arctic Spark 支持 `DELETE FROM` 语法用于删除表中数据
 
@@ -124,7 +124,7 @@ WHERE EXISTS (SELECT oid FROM prod.db.returned_orders WHERE t1.oid = oid)
 ```
 
 
-### Update 
+### UPDATE 
 
 支持 `UPDATE` 语句对表进行更新
 

--- a/site/docs/ch/spark/spark-dml.md
+++ b/site/docs/ch/spark/spark-dml.md
@@ -70,6 +70,8 @@ partition( dt = '2021-1-1')  values
 
 > 在 Static 模式下，不支持在分区字段上定义 transform
 
+> 可以通过 SPARK SQL`set spark.sql.arctic.check-source-data-uniqueness.enabled = true` 开启对源表主键的唯一性校验，若存在相同主键，写入时会报错提示。
+
 ### Insert into
 
 #### 无主键表
@@ -102,7 +104,7 @@ INSERT INTO arctic_catalog.db.keyedTable VALUES (1, 'a'), (2, 'b')
 
 INSERT INTO prod.db.keyedTable SELECT ...
 ```
-> 目前写入时如果数据没有去重，会导致 primary key 唯一性被破坏
+> 可以通过 SPARK SQL`set spark.sql.arctic.check-source-data-uniqueness.enabled = true` 开启对源表主键的唯一性校验，若存在相同主键，写入时会报错提示。
 
 
 

--- a/spark/v2.3/spark/src/main/java/com/netease/arctic/spark/util/ArcticSparkUtil.java
+++ b/spark/v2.3/spark/src/main/java/com/netease/arctic/spark/util/ArcticSparkUtil.java
@@ -62,7 +62,7 @@ import static com.netease.arctic.table.TableProperties.WRITE_DISTRIBUTION_MODE_D
 public class ArcticSparkUtil {
   private static final Logger LOG = LoggerFactory.getLogger(ArcticSparkUtil.class);
   public static final String CATALOG_URL = "spark.sql.arctic.catalog.url";
-  public static final String SQL_DELEGATE_HIVE_TABLE = "spark.arctic.sql.delegate.enabled";
+  public static final String SQL_DELEGATE_HIVE_TABLE = "spark.sql.arctic.delegate.enabled";
 
   public static String catalogUrl(RuntimeConfig conf) {
     String catalogUrl = conf.get(CATALOG_URL, "");

--- a/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -129,7 +129,7 @@ public class SparkTestContext extends ExternalResource {
 
     configs.put("spark.sql.catalogImplementation", "hive");
     configs.put("hive.metastore.uris", "thrift://127.0.0.1:" + hms.getMetastorePort());
-    configs.put("spark.arctic.sql.delegate.enabled", "true");
+    configs.put("spark.sql.arctic.delegate.enabled", "true");
     //hive.metastore.client.capability.check
     configs.put("hive.metastore.client.capability.check", "false");
 

--- a/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestKeyedHiveTableInsertOverwriteDynamic.java
+++ b/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestKeyedHiveTableInsertOverwriteDynamic.java
@@ -76,11 +76,11 @@ public class TestKeyedHiveTableInsertOverwriteDynamic extends SparkTestBase {
     Assert.assertEquals(4, rows.size());
     assertContainIdSet(rows, 0, 4, 5, 6, 3);
     //read by hive
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select id, data, dt from {0}.{1} order by id", database, table);
     Assert.assertEquals(4, rows.size());
     assertContainIdSet(rows, 0, 4, 5, 6, 3);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
 
     List<Partition> partitions = hms.getClient().listPartitions(
         database,
@@ -100,11 +100,11 @@ public class TestKeyedHiveTableInsertOverwriteDynamic extends SparkTestBase {
     Assert.assertEquals(6, rows.size());
     assertContainIdSet(rows, 0, 1, 2, 3, 4, 5, 6);
     //read by hive
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select id, data, dt from {0}.{1} order by id", database, table);
     Assert.assertEquals(6, rows.size());
     assertContainIdSet(rows, 0, 1, 2, 3, 4, 5, 6);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
 
     List<Partition> partitions = hms.getClient().listPartitions(
         database,

--- a/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestKeyedHiveTableInsertOverwriteStatic.java
+++ b/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestKeyedHiveTableInsertOverwriteStatic.java
@@ -56,9 +56,9 @@ public class TestKeyedHiveTableInsertOverwriteStatic extends SparkTestBase {
         "(2, ''bbb'',  ''2021-1-2''), \n " +
         "(3, ''ccc'',  ''2021-1-3'') \n ", database, table);
 
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     sql("select * from {0}.{1} order by id", database, table);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
 
   }
 
@@ -77,7 +77,7 @@ public class TestKeyedHiveTableInsertOverwriteStatic extends SparkTestBase {
         "(5, ''bbb'',  ''2021-1-2''), \n " +
         "(6, ''ccc'',  ''2021-1-2'') \n ", database, table);
 
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select * from {0}.{1}", database, table);
     Assert.assertEquals(3, rows.size());
     assertContainIdSet(rows, 0, 4, 5, 6);
@@ -87,7 +87,7 @@ public class TestKeyedHiveTableInsertOverwriteStatic extends SparkTestBase {
         table,
         (short) -1);
     Assert.assertEquals(2, partitions.size());
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
 
   }
 
@@ -99,7 +99,7 @@ public class TestKeyedHiveTableInsertOverwriteStatic extends SparkTestBase {
         "(5, ''bbb''), \n " +
         "(6, ''ccc'') \n ", database, table);
 
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select * from {0}.{1} order by id", database, table);
     Assert.assertEquals(5, rows.size());
     assertContainIdSet(rows, 0, 4, 5, 6, 2, 3);
@@ -109,6 +109,6 @@ public class TestKeyedHiveTableInsertOverwriteStatic extends SparkTestBase {
         table,
         (short) -1);
     Assert.assertEquals(3, partitions.size());
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
   }
 }

--- a/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestKeyedHiveTableMergeOnRead.java
+++ b/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestKeyedHiveTableMergeOnRead.java
@@ -109,14 +109,14 @@ public class TestKeyedHiveTableMergeOnRead extends SparkTestBase {
         (short) -1);
     Assert.assertEquals(2, partitions.size());
     //disable arctic
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     sql("select * from {0}.{1} order by id", database, table);
     assertEquals("Should have rows matching the expected rows",
         files.subList(6, files.size()),
         rows);
     Assert.assertEquals(4, rows.size());
     assertContainIdSet(rows, 0, 7, 8, 9, 10);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
   }
 
 
@@ -156,14 +156,14 @@ public class TestKeyedHiveTableMergeOnRead extends SparkTestBase {
     Assert.assertEquals(9, rows.size());
     assertContainIdSet(rows, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     //disable arctic
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     sql("select * from {0}.{1} order by id", database, table);
     assertEquals("Should have rows matching the expected rows",
         files.subList(6, files.size()),
         rows);
     Assert.assertEquals(4, rows.size());
     assertContainIdSet(rows, 0, 7, 8, 9, 10);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
   }
 
 }

--- a/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestUnkeyedHiveTableInsertOverwriteDynamic.java
+++ b/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestUnkeyedHiveTableInsertOverwriteDynamic.java
@@ -51,9 +51,9 @@ public class TestUnkeyedHiveTableInsertOverwriteDynamic extends SparkTestBase {
         "(2, ''bbb'',  ''2021-1-2''), \n " +
         "(3, ''ccc'',  ''2021-1-3'') \n ", database, table);
 
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     sql("select * from {0}.{1} order by id", database, table);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
 
     System.out.println("spark.sql.sources.partitionOverwriteMode = " + contextOverwriteMode);
     sql("set spark.sql.sources.partitionOverwriteMode = {0}", "DYNAMIC");
@@ -76,11 +76,11 @@ public class TestUnkeyedHiveTableInsertOverwriteDynamic extends SparkTestBase {
     Assert.assertEquals(4, rows.size());
     assertContainIdSet(rows, 0, 4, 5, 6, 3);
     //read by hive
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select id, data, dt from {0}.{1} order by id", database, table);
     Assert.assertEquals(4, rows.size());
     assertContainIdSet(rows, 0, 4, 5, 6, 3);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
 
     List<Partition> partitions = hms.getClient().listPartitions(
         database,
@@ -101,11 +101,11 @@ public class TestUnkeyedHiveTableInsertOverwriteDynamic extends SparkTestBase {
     Assert.assertEquals(6, rows.size());
     assertContainIdSet(rows, 0, 1, 2, 3, 4, 5, 6);
     //read by hive
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select id, data, dt from {0}.{1} order by id", database, table);
     Assert.assertEquals(6, rows.size());
     assertContainIdSet(rows, 0, 1, 2, 3, 4, 5, 6);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
 
     List<Partition> partitions = hms.getClient().listPartitions(
         database,

--- a/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestUnkeyedHiveTableMergeOnRead.java
+++ b/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/TestUnkeyedHiveTableMergeOnRead.java
@@ -83,14 +83,14 @@ public class TestUnkeyedHiveTableMergeOnRead extends SparkTestBase {
         (short) -1);
     Assert.assertEquals(2, partitions.size());
     //disable arctic
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select * from {0}.{1} order by id", database, table);
     assertEquals("Should have rows matching the expected rows",
         files.subList(6, files.size()),
         rows);
     Assert.assertEquals(4, rows.size());
     assertContainIdSet(rows, 0, 7, 8, 9, 10);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
   }
 
   @Test
@@ -124,13 +124,13 @@ public class TestUnkeyedHiveTableMergeOnRead extends SparkTestBase {
     Assert.assertEquals(10, rows.size());
     assertContainIdSet(rows, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     //disable arctic
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select * from {0}.{1} order by id", database, table);
     assertEquals("Should have rows matching the expected rows",
         files.subList(6, files.size()),
         rows);
     Assert.assertEquals(4, rows.size());
     assertContainIdSet(rows, 0, 7, 8, 9, 10);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
   }
 }

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
@@ -31,4 +31,8 @@ public class SparkSQLProperties {
   public static final String REFRESH_CATALOG_BEFORE_USAGE = "spark.sql.arctic.refresh-catalog-before-usage";
 
   public static final String REFRESH_CATALOG_BEFORE_USAGE_DEFAULT = "false";
+
+  public static final String CHECK_DATA_DUPLICATES_ENABLE = "spark.sql.check-data-duplicates.enabled";
+
+  public static final String CHECK_DATA_DUPLICATES_ENABLE_DEFAULT = "true";
 }

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
@@ -20,7 +20,7 @@ package com.netease.arctic.spark;
 
 public class SparkSQLProperties {
 
-  public static final String DELEGATE_DEFAULT_CATALOG_TABLE = "spark.arctic.sql.delegate.enabled";
+  public static final String DELEGATE_DEFAULT_CATALOG_TABLE = "spark.sql.arctic.delegate.enabled";
 
   public static final String USE_TIMESTAMP_WITHOUT_TIME_ZONE_IN_NEW_TABLES =
           "spark.sql.arctic.use-timestamp-without-timezone-in-new-tables";
@@ -32,7 +32,7 @@ public class SparkSQLProperties {
 
   public static final String REFRESH_CATALOG_BEFORE_USAGE_DEFAULT = "false";
 
-  public static final String CHECK_DATA_DUPLICATES_ENABLE = "spark.sql.check-data-duplicates.enabled";
+  public static final String CHECK_DATA_DUPLICATES_ENABLE = "spark.sql.arctic.check-source-data-uniqueness.enabled";
 
   public static final String CHECK_DATA_DUPLICATES_ENABLE_DEFAULT = "true";
 }

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
@@ -34,5 +34,5 @@ public class SparkSQLProperties {
 
   public static final String CHECK_DATA_DUPLICATES_ENABLE = "spark.sql.arctic.check-source-data-uniqueness.enabled";
 
-  public static final String CHECK_DATA_DUPLICATES_ENABLE_DEFAULT = "true";
+  public static final String CHECK_DATA_DUPLICATES_ENABLE_DEFAULT = "false";
 }

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -194,6 +194,7 @@ public class SparkTestContext extends ExternalResource {
     sparkConfigs.put("spark.sql.extensions", ArcticSparkExtensions.class.getName());
     sparkConfigs.put("spark.testing.memory", "471859200");
     sparkConfigs.put("spark.sql.arctic.use-timestamp-without-timezone-in-new-tables", "false");
+    sparkConfigs.put("spark.sql.arctic.check-source-data-uniqueness.enabled", "true");
 
     sparkConfigs.putAll(configs);
     sparkConfigs.forEach(((k, v) -> System.out.println("--" + k + "=" + v)));

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
@@ -61,7 +61,7 @@ public class TestArcticSessionCatalog extends SparkTestContext {
 
     configs.put("spark.sql.catalog.spark_catalog", ArcticSparkSessionCatalog.class.getName());
     configs.put("spark.sql.catalog.spark_catalog.url", amsUrl + "/" + catalogNameHive);
-    configs.put("spark.arctic.sql.delegate.enabled", "true");
+    configs.put("spark.sql.arctic.delegate.enabled", "true");
 
     setUpSparkSession(configs);
   }
@@ -99,7 +99,7 @@ public class TestArcticSessionCatalog extends SparkTestContext {
   @Ignore
   @Test
   public void testHiveDelegate() throws TException {
-    System.out.println("spark.arctic.sql.delegate.enabled = " + spark.conf().get("spark.arctic.sql.delegate.enabled"));
+    System.out.println("spark.sql.arctic.delegate.enabled = " + spark.conf().get("spark.sql.arctic.delegate.enabled"));
     sql("use spark_catalog");
     sql("create table {0}.{1} ( id int, data string) using arctic", database, table_D);
     sql("create table {0}.{1} ( id int, data string) STORED AS parquet", database, table_D2);
@@ -126,9 +126,9 @@ public class TestArcticSessionCatalog extends SparkTestContext {
   @Ignore
   @Test
   public void testCatalogEnable() throws TException {
-    sql("set spark.arctic.sql.delegate.enabled=false");
+    sql("set spark.sql.arctic.delegate.enabled=false");
     sql("use spark_catalog");
-    System.out.println("spark.arctic.sql.delegate.enabled = " + spark.conf().get("spark.arctic.sql.delegate.enabled"));
+    System.out.println("spark.sql.arctic.delegate.enabled = " + spark.conf().get("spark.sql.arctic.delegate.enabled"));
     sql("create table {0}.{1} ( id int, data string) STORED AS parquet", database, table2);
     sql("insert overwrite {0}.{1} values \n" +
         "(1, ''aaa''), \n " +
@@ -153,7 +153,7 @@ public class TestArcticSessionCatalog extends SparkTestContext {
 
   @Test
   public void testCreateTableLikeUsingSparkCatalog() {
-    sql("set spark.arctic.sql.delegate.enabled=true");
+    sql("set spark.sql.arctic.delegate.enabled=true");
     sql("use spark_catalog");
     sql("create table {0}.{1} ( \n" +
         " id int , \n" +
@@ -181,7 +181,7 @@ public class TestArcticSessionCatalog extends SparkTestContext {
 
   @Test
   public void testCreateTableAsSelect() {
-    sql("set spark.arctic.sql.delegate.enabled=true");
+    sql("set spark.sql.arctic.delegate.enabled=true");
     String table = "test_create_table_as_select";
     List<Row> tempRows = com.google.common.collect.Lists.newArrayList(
         RowFactory.create(1L, "a", "2020-01-01"),

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestMultiDelegateSessionCatalog.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestMultiDelegateSessionCatalog.java
@@ -177,10 +177,10 @@ public class TestMultiDelegateSessionCatalog extends SparkTestContext {
     assertContainIdSet(rows,0, 1L, 2L, 3L);
 
 
-    sql("set spark.arctic.sql.delegate.enabled = false");
+    sql("set spark.sql.arctic.delegate.enabled = false");
     rows = sql("select id, name, pt from {0}.{1}", database, arcticTable);
     assertContainIdSet(rows,0, 1L, 2L, 3L);
-    sql("set spark.arctic.sql.delegate.enabled = true");
+    sql("set spark.sql.arctic.delegate.enabled = true");
   }
 
 

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedHiveInsertOverwriteDynamic.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedHiveInsertOverwriteDynamic.java
@@ -99,7 +99,6 @@ public class TestKeyedHiveInsertOverwriteDynamic extends SparkTestBase {
 
   @Test
   public void testInsertOverwriteDuplicateData() {
-    sql("set `spark.sql.check-data-duplicates.enabled` = `false`");
     sql("create table {0}.{1}( \n" +
             " id int, \n" +
             " name string, \n" +

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedHiveInsertOverwriteDynamic.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedHiveInsertOverwriteDynamic.java
@@ -99,6 +99,7 @@ public class TestKeyedHiveInsertOverwriteDynamic extends SparkTestBase {
 
   @Test
   public void testInsertOverwriteDuplicateData() {
+    sql("set `spark.sql.check-data-duplicates.enabled` = `false`");
     sql("create table {0}.{1}( \n" +
             " id int, \n" +
             " name string, \n" +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
resolve #907 

## Brief change log

Add a spark property: spark.sql.check-data-duplicates.enabled, the default value is true 

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
