### PR TITLE
[ARCTIC-910]Ignore committing error to HMS when committing Hive format table

### DIFF
--- a/hive/src/main/java/com/netease/arctic/hive/op/UpdateHiveFiles.java
+++ b/hive/src/main/java/com/netease/arctic/hive/op/UpdateHiveFiles.java
@@ -113,10 +113,14 @@ public abstract class UpdateHiveFiles<T extends SnapshotUpdate<T>> implements Sn
       return;
     }
 
-    if (table.spec().isUnpartitioned()) {
-      commitNonPartitionedTable();
-    } else {
-      commitPartitionedTable();
+    try {
+      if (table.spec().isUnpartitioned()) {
+        commitNonPartitionedTable();
+      } else {
+        commitPartitionedTable();
+      }
+    } catch (Exception e) {
+      LOG.warn("Commit operation to HMS failed.", e);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

*Fix #910.*

## Brief change log

  - *Ignore committing error to HMS when committing Hive format table*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
