### PR TITLE
[ARCTIC-860] Improve  memory usage when plan table

### DIFF
--- a/core/src/main/java/com/netease/arctic/data/DefaultKeyedFile.java
+++ b/core/src/main/java/com/netease/arctic/data/DefaultKeyedFile.java
@@ -41,8 +41,6 @@ public class DefaultKeyedFile implements PrimaryKeyedFile, Serializable {
   private final DataFile internalFile;
 
   private transient FileMeta meta;
-  private transient ChangedLsn minLsn;
-  private transient ChangedLsn maxLsn;
 
   public DefaultKeyedFile(DataFile internalFile) {
     this.internalFile = internalFile;
@@ -50,22 +48,6 @@ public class DefaultKeyedFile implements PrimaryKeyedFile, Serializable {
 
   private void parse() {
     this.meta = FileUtil.parseFileMetaFromFileName(FileUtil.getFileName(internalFile.path().toString()));
-    if (internalFile.lowerBounds() != null) {
-      ByteBuffer minOffsetBuffer = internalFile.lowerBounds().get(MetadataColumns.FILE_OFFSET_FILED_ID);
-      if (minOffsetBuffer != null) {
-        minLsn = ChangedLsn.of(meta.transactionId(), Conversions.fromByteBuffer(Types.LongType.get(), minOffsetBuffer));
-      } else {
-        minLsn = ChangedLsn.of(meta.transactionId(), Long.MAX_VALUE);
-      }
-    }
-    if (internalFile.upperBounds() != null) {
-      ByteBuffer maxOffsetBuffer = internalFile.upperBounds().get(MetadataColumns.FILE_OFFSET_FILED_ID);
-      if (maxOffsetBuffer != null) {
-        maxLsn = ChangedLsn.of(meta.transactionId(), Conversions.fromByteBuffer(Types.LongType.get(), maxOffsetBuffer));
-      } else {
-        maxLsn = ChangedLsn.of(meta.transactionId(), Long.MAX_VALUE);
-      }
-    }
   }
 
   @Override
@@ -74,16 +56,6 @@ public class DefaultKeyedFile implements PrimaryKeyedFile, Serializable {
       parse();
     }
     return meta.transactionId();
-  }
-
-  @Override
-  public ChangedLsn minLsn() {
-    throw new UnsupportedOperationException("Unsupported method minLsn");
-  }
-
-  @Override
-  public ChangedLsn maxLsn() {
-    throw new UnsupportedOperationException("Unsupported method maxLsn");
   }
 
   @Override

--- a/core/src/main/java/com/netease/arctic/data/DefaultKeyedFile.java
+++ b/core/src/main/java/com/netease/arctic/data/DefaultKeyedFile.java
@@ -78,18 +78,12 @@ public class DefaultKeyedFile implements PrimaryKeyedFile, Serializable {
 
   @Override
   public ChangedLsn minLsn() {
-    if (minLsn == null) {
-      parse();
-    }
-    return minLsn;
+    throw new UnsupportedOperationException("Unsupported method minLsn");
   }
 
   @Override
   public ChangedLsn maxLsn() {
-    if (maxLsn == null) {
-      parse();
-    }
-    return maxLsn;
+    throw new UnsupportedOperationException("Unsupported method maxLsn");
   }
 
   @Override

--- a/core/src/main/java/com/netease/arctic/data/PrimaryKeyedFile.java
+++ b/core/src/main/java/com/netease/arctic/data/PrimaryKeyedFile.java
@@ -41,16 +41,6 @@ public interface PrimaryKeyedFile extends DataFile {
   Long transactionId();
 
   /**
-   * Returns the minimum {@link ChangedLsn} within file
-   */
-  ChangedLsn minLsn();
-
-  /**
-   * Return the maximum {@link ChangedLsn} within file
-   */
-  ChangedLsn maxLsn();
-
-  /**
    * File information summary for logging
    */
   default String fileInfo() {

--- a/core/src/main/java/com/netease/arctic/table/BaseUnkeyedTable.java
+++ b/core/src/main/java/com/netease/arctic/table/BaseUnkeyedTable.java
@@ -101,7 +101,7 @@ public class BaseUnkeyedTable implements UnkeyedTable, HasTableOperations {
 
   @Override
   public TableScan newScan() {
-    return icebergTable.newScan().includeColumnStats();
+    return icebergTable.newScan();
   }
 
   @Override

--- a/core/src/test/java/com/netease/arctic/data/KeyedDataFileTest.java
+++ b/core/src/test/java/com/netease/arctic/data/KeyedDataFileTest.java
@@ -43,8 +43,6 @@ public class KeyedDataFileTest extends TableTestBase {
     Long txId = AMS.handler().getTableCurrentTxId(PK_TABLE_ID.buildTableIdentifier());
     Assert.assertEquals(0, defaultKeyedFile.node().index());
     Assert.assertEquals(txId, defaultKeyedFile.transactionId());
-    Assert.assertEquals(ChangedLsn.of(txId, 1), defaultKeyedFile.minLsn());
-    Assert.assertEquals(ChangedLsn.of(txId,2), defaultKeyedFile.maxLsn());
 
   }
 


### PR DESCRIPTION
## Why are the changes needed?
fix: #860 

## Brief change log
BaseUnkeyedTable get TableScan without includeColumnStats

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
