### PR TITLE
[ARCTIC-928] Trino support hadoop proxy user 

### DIFF
--- a/site/docs/ch/mpp/trino.md
+++ b/site/docs/ch/mpp/trino.md
@@ -73,3 +73,17 @@ SELECT * FROM "{TABLE_NAME}#CHANGE"
 | `LIST(e)`      | `ARRAY(e)`                    |
 | `MAP(k,v)`     | `MAP(k,v)`                    |
 
+### Trino 使用代理用户访问 Hadoop 集群
+默认情况下，Trino 查询 Arctic 时，使用 [创建catalog](../guides/managing-catalogs.md#catalog) 中配置的 Hadoop 用户去访问 Hadoop 集群。
+若想使用 Trino 查询中的用户去访问 Hadoop 集群，可开启 Hadoop 代理功能， 在 {trino_home}/etc/catalog 目录下 Arctic 的 Catalog 配置文件中增加 `arctic.hdfs.impersonation.enabled=true` 参数，如下
+
+```tex
+connector.name=arctic
+arctic.url=thrift://{ip}:{port}/{catalogName}
+arctic.hdfs.impersonation.enabled=true
+```
+`arctic.hdfs.impersonation.enabled` 默认为 false
+
+???+ 注意
+
+    使用 Hadoop 代理功能，需提前在 Hadoop 集群对 [创建catalog](../guides/managing-catalogs.md#catalog) 中配置的 Hadoop 用户开启 proxy 功能，并保证能够代理该 Trino 查询用户，参考 [Hadoop Proxy User](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/Superusers.html#Configurations)

--- a/trino/src/main/java/com/netease/arctic/trino/ArcticConfig.java
+++ b/trino/src/main/java/com/netease/arctic/trino/ArcticConfig.java
@@ -20,20 +20,29 @@
 package com.netease.arctic.trino;
 
 import io.airlift.configuration.Config;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Arctic config
  */
 public class ArcticConfig {
   private String catalogUrl;
+  private boolean hdfsImpersonationEnabled;
 
   public String getCatalogUrl() {
     return catalogUrl;
   }
 
+  public boolean getHdfsImpersonationEnabled() {
+    return hdfsImpersonationEnabled;
+  }
+
   @Config("arctic.url")
   public void setCatalogUrl(String catalogUrl) {
     this.catalogUrl = catalogUrl;
+  }
+
+  @Config("arctic.hdfs.impersonation.enabled")
+  public void setHdfsImpersonationEnabled(boolean enabled) {
+    this.hdfsImpersonationEnabled = enabled;
   }
 }


### PR DESCRIPTION
Signed-off-by: Yi Xie <xieyi01@rd.netease.com>

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
fix: https://github.com/NetEase/arctic/issues/928

## Brief change log
It only can config one kerberos user in trino cluster, but trino have many users in one cluster.
We need proxy trino user to connector hadoop


## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
 **yes**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  **docs, in site/docs/ch/mpp/trino.md**
