### PR TITLE
[ARCTIC-955] Improve performance of Table entries scan

### DIFF
--- a/core/src/main/java/com/netease/arctic/op/ArcticTableOperations.java
+++ b/core/src/main/java/com/netease/arctic/op/ArcticTableOperations.java
@@ -39,7 +39,7 @@ public class ArcticTableOperations implements TableOperations {
 
   @Override
   public TableMetadata current() {
-    return arcticFileIO.doAs(() -> ops.current());
+    return ops.current();
   }
 
   @Override

--- a/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
+++ b/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.Metrics;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;

--- a/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
+++ b/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
@@ -180,10 +180,10 @@ public class TableEntriesScan {
           if (shouldKeep(status, fileContent)) {
             ContentFile<?> contentFile = buildContentFile(fileContent, fileRecord);
             if (metricsEvaluator().eval(contentFile)) {
-              ContentFile<?> copyFile = includeColumnStats ?
-                  (ContentFile<?>) contentFile.copy() :
-                  (ContentFile<?>) contentFile.copyWithoutStats();
-              return new IcebergFileEntry(snapshotId, sequence, copyFile);
+              if (needMetrics() && !includeColumnStats) {
+                contentFile = (ContentFile<?>) contentFile.copyWithoutStats();
+              }
+              return new IcebergFileEntry(snapshotId, sequence, contentFile);
             }
           }
           return null;

--- a/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
+++ b/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
@@ -89,6 +89,7 @@ public class TableEntriesScan {
 
     /**
      * Set the filter
+     *
      * @param dataFilter default is always true
      * @return this for chain
      */
@@ -99,6 +100,7 @@ public class TableEntriesScan {
 
     /**
      * If only return the Existing, Add entries
+     *
      * @param aliveEntry true for only Existing, Add
      * @return this for chain
      */
@@ -109,6 +111,7 @@ public class TableEntriesScan {
 
     /**
      * Set the fileContent
+     *
      * @param fileContent default is nothing
      * @return this for chain
      */
@@ -119,6 +122,7 @@ public class TableEntriesScan {
 
     /**
      * Set the snapshotId
+     *
      * @param snapshotId snapshotId
      * @return this for chain
      */
@@ -130,6 +134,7 @@ public class TableEntriesScan {
     /**
      * Set if loads the column stats with each file.
      * <p>Column stats include: value count, null value count, lower bounds, and upper bounds.
+     *
      * @return this for chain
      */
     public Builder includeColumnStats() {
@@ -205,7 +210,7 @@ public class TableEntriesScan {
     }
     throw new IllegalArgumentException("not support content id " + contentId);
   }
-  
+
   private boolean needMetrics() {
     return dataFilter != null || includeColumnStats;
   }
@@ -236,7 +241,7 @@ public class TableEntriesScan {
     }
     return file;
   }
-  
+
   private PartitionSpec spec() {
     if (spec == null) {
       spec = table.spec();
@@ -254,7 +259,7 @@ public class TableEntriesScan {
         .withFileSizeInBytes(fileSize)
         .withRecordCount(recordCount);
     if (needMetrics()) {
-        builder.withMetrics(buildMetrics(fileRecord));
+      builder.withMetrics(buildMetrics(fileRecord));
     }
     if (spec().isPartitioned()) {
       StructLike partition = fileRecord.get(dataFileFieldIndex(DataFile.PARTITION_NAME), StructLike.class);
@@ -272,7 +277,7 @@ public class TableEntriesScan {
         .withFileSizeInBytes(fileSize)
         .withRecordCount(recordCount);
     if (needMetrics()) {
-        builder.withMetrics(buildMetrics(fileRecord));
+      builder.withMetrics(buildMetrics(fileRecord));
     }
     if (spec().isPartitioned()) {
       StructLike partition = fileRecord.get(dataFileFieldIndex(DataFile.PARTITION_NAME), StructLike.class);
@@ -333,7 +338,7 @@ public class TableEntriesScan {
     }
     return lazyMetricsEvaluator;
   }
-  
+
   private static class AlwaysTrueEvaluator extends InclusiveMetricsEvaluator {
     public AlwaysTrueEvaluator(Schema schema) {
       super(schema, Expressions.alwaysTrue());


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As described in the #955, when process table entries scan for getting file sequence, we call `table.spec()` many times which invokes `ugi.doAs()` each time.

And also, there is no need to load column metrics if not necessary.

## Brief change log

- cache table spec for table entries scan
- only include colum stats when necessary

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
