### PR TITLE
[ARCTIC-967] Fix change files exceeding TTL deleted by mistake

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/FileInfoCacheMapper.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/FileInfoCacheMapper.java
@@ -145,8 +145,8 @@ public interface FileInfoCacheMapper {
           @Param("tableIdentifier") TableIdentifier tableIdentifier, @Param("partition") String partition);
 
   @Select("select file_path, file_type, file_size, file_mask, file_index, record_count, spec_id, partition_name, " +
-      "commit_time from " + TABLE_NAME + " where table_identifier = #{tableIdentifier, typeHandler=com.netease.arctic" +
-      ".ams.server.mybatis.TableIdentifier2StringConverter} and " +
+      "commit_time, add_snapshot_sequence from " + TABLE_NAME + " where table_identifier = #{tableIdentifier, " +
+      "typeHandler=com.netease.arctic.ams.server.mybatis.TableIdentifier2StringConverter} and " +
       "commit_time <= #{ttl, typeHandler=com.netease.arctic.ams.server.mybatis.Long2TsConvertor} " +
       "and inner_table = #{innerTable} and " +
       "delete_snapshot_id is null  ")
@@ -160,7 +160,8 @@ public interface FileInfoCacheMapper {
       @Result(column = "spec_id", property = "specId"),
       @Result(column = "partition_name", property = "partition"),
       @Result(column = "commit_time", property = "commitTime",
-          typeHandler = Long2TsConvertor.class)
+          typeHandler = Long2TsConvertor.class),
+      @Result(column = "add_snapshot_sequence", property = "sequence")
   })
   List<DataFileInfo> getChangeTableTTLDataFiles(@Param("tableIdentifier") TableIdentifier tableIdentifier,
                                                 @Param("innerTable") String innerTable,

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/service/TestFileInfoCacheService.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/service/TestFileInfoCacheService.java
@@ -339,6 +339,77 @@ public class TestFileInfoCacheService extends TableTestBase {
         transactionsOfTables.get(2).getTransactionId()).get(1).getType(), "pos-deletes");
   }
 
+  @Test
+  public void testGetChangeTableTTLDataFiles() throws MetaException {
+    TableIdentifier tableIdentifier = new TableIdentifier(AMS_TEST_CATALOG_NAME, "test", "test1");
+    TableCommitMeta meta = new TableCommitMeta();
+    meta.setAction("append");
+    long commitTime = System.currentTimeMillis();
+    meta.setCommitTime(commitTime);
+    meta.setCommitMetaProducer(CommitMetaProducer.INGESTION);
+    meta.setTableIdentifier(tableIdentifier);
+    List<TableChange> changes = new ArrayList<>();
+    TableChange change = new TableChange();
+    change.setParentSnapshotId(-1);
+    change.setInnerTable("change");
+    List<DataFile> dataFiles = new ArrayList<>();
+    DataFile dataFile = genDatafile();
+    dataFiles.add(dataFile);
+    change.setAddFiles(dataFiles);
+    long snapshotId = 1L;
+    long snapshotSequence = 20L;
+    change.setSnapshotId(snapshotId);
+    change.setSnapshotSequence(snapshotSequence);
+    TableChange change1 = new TableChange();
+    change1.setParentSnapshotId(snapshotId);
+    change1.setInnerTable("change");
+    List<DataFile> dataFiles1 = new ArrayList<>();
+    DataFile dataFile1 = genDatafile();
+    dataFiles1.add(dataFile1);
+    change1.setAddFiles(dataFiles1);
+    long snapshotId1 = 2L;
+    long snapshotSequence1 = 30L;
+    change1.setSnapshotId(snapshotId1);
+    change1.setSnapshotSequence(snapshotSequence1);
+
+    changes.add(change);
+    changes.add(change1);
+    meta.setChanges(changes);
+    Map<String, String> properties = new HashMap<>();
+    properties.put(TableProperties.TABLE_EVENT_TIME_FIELD, "eventTime");
+    meta.setProperties(properties);
+    ServiceContainer.getFileInfoCacheService().commitCacheFileInfo(meta);
+
+    List<DataFileInfo> changeFiles =
+        ServiceContainer.getFileInfoCacheService().getOptimizeDatafiles(tableIdentifier, "change");
+
+    assertDataFile(dataFile, commitTime, snapshotSequence, changeFiles.get(0));
+    assertDataFile(dataFile1, commitTime, snapshotSequence1, changeFiles.get(1));
+
+    List<DataFileInfo> emptyDataFiles =
+        ServiceContainer.getFileInfoCacheService().getChangeTableTTLDataFiles(tableIdentifier, commitTime - 1);
+    Assert.assertEquals(0, emptyDataFiles.size());
+
+    List<DataFileInfo> ttlDataFiles =
+        ServiceContainer.getFileInfoCacheService().getChangeTableTTLDataFiles(tableIdentifier, commitTime);
+    Assert.assertEquals(2, ttlDataFiles.size());
+    assertDataFile(dataFile, commitTime, snapshotSequence, ttlDataFiles.get(0));
+    assertDataFile(dataFile1, commitTime, snapshotSequence1, ttlDataFiles.get(1));
+  }
+  
+  private void assertDataFile(DataFile file, long commitTime, long sequence, DataFileInfo dataFileInfo) {
+    Assert.assertEquals(file.getPath().toString(), dataFileInfo.getPath());
+    Assert.assertEquals("pt=2022-08-31", dataFileInfo.getPartition());
+    Assert.assertEquals(file.getIndex(), dataFileInfo.getIndex());
+    Assert.assertEquals(file.getMask(), dataFileInfo.getMask());
+    Assert.assertEquals(sequence, dataFileInfo.getSequence());
+    Assert.assertEquals(file.getFileSize(), dataFileInfo.getSize());
+    Assert.assertEquals(file.getRecordCount(), dataFileInfo.getRecordCount());
+    Assert.assertEquals(commitTime, dataFileInfo.getCommitTime());
+    Assert.assertEquals(file.getFileType(), dataFileInfo.getType());
+    Assert.assertEquals(file.getSpecId(), dataFileInfo.getSpecId());
+  }
+
   private DataFile genDatafile() {
     DataFile dataFile = new DataFile();
     dataFile.setFileSize(1);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix #967 

## Brief change log

  - Load sequence from `file_info_cache` when `getChangeTableTTLDataFiles` is invoked

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
