### PR TITLE
[ARCTIC-849] Filestore reader emits keyed table data without shuffle and keeps data ordering

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -226,10 +226,12 @@ public class TableProperties {
   /**
    * table read related properties
    */
+  @Deprecated
   public static final String READ_DISTRIBUTION_MODE = "read.distribution-mode";
   public static final String READ_DISTRIBUTION_MODE_NONE = "none";
   public static final String READ_DISTRIBUTION_MODE_HASH = "hash";
   public static final String READ_DISTRIBUTION_MODE_DEFAULT = READ_DISTRIBUTION_MODE_NONE;
+  @Deprecated
   public static final String READ_DISTRIBUTION_HASH_MODE = "read.distribution.hash-mode";
   public static final String READ_DISTRIBUTION_HASH_PARTITION = "partition-key";
   public static final String READ_DISTRIBUTION_HASH_PRIMARY = "primary-key";

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -225,12 +225,18 @@ public class TableProperties {
 
   /**
    * table read related properties
+   * TODO
+   * This Configuration will be removed in the v0.5.0 version.
    */
   @Deprecated
   public static final String READ_DISTRIBUTION_MODE = "read.distribution-mode";
   public static final String READ_DISTRIBUTION_MODE_NONE = "none";
   public static final String READ_DISTRIBUTION_MODE_HASH = "hash";
   public static final String READ_DISTRIBUTION_MODE_DEFAULT = READ_DISTRIBUTION_MODE_NONE;
+  /**
+   * TODO
+   * This Configuration will be removed in the v0.5.0 version.
+   */
   @Deprecated
   public static final String READ_DISTRIBUTION_HASH_MODE = "read.distribution.hash-mode";
   public static final String READ_DISTRIBUTION_HASH_PARTITION = "partition-key";

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -71,10 +71,10 @@ public class TableProperties {
    */
   public static final String ENABLE_SELF_OPTIMIZING = "self-optimizing.enabled";
   public static final boolean ENABLE_SELF_OPTIMIZING_DEFAULT = true;
-  
+
   public static final String SELF_OPTIMIZING_GROUP = "self-optimizing.group";
   public static final String SELF_OPTIMIZING_GROUP_DEFAULT = "default";
-  
+
   public static final String SELF_OPTIMIZING_QUOTA = "self-optimizing.quota";
   public static final double SELF_OPTIMIZING_QUOTA_DEFAULT = 0.1;
 
@@ -108,11 +108,11 @@ public class TableProperties {
 
   public static final String SELF_OPTIMIZING_MAJOR_TRIGGER_INTERVAL = "self-optimizing.major.trigger.interval";
   public static final long SELF_OPTIMIZING_MAJOR_TRIGGER_INTERVAL_DEFAULT = 86400000; // 1 day
-  
+
   public static final String SELF_OPTIMIZING_FULL_TRIGGER_INTERVAL = "self-optimizing.full.trigger.interval";
   public static final long SELF_OPTIMIZING_FULL_TRIGGER_INTERVAL_DEFAULT = -1; // not trigger
-  
-  
+
+
   /**
    * deprecated table optimize related properties
    */
@@ -229,7 +229,7 @@ public class TableProperties {
   public static final String READ_DISTRIBUTION_MODE = "read.distribution-mode";
   public static final String READ_DISTRIBUTION_MODE_NONE = "none";
   public static final String READ_DISTRIBUTION_MODE_HASH = "hash";
-  public static final String READ_DISTRIBUTION_MODE_DEFAULT = READ_DISTRIBUTION_MODE_HASH;
+  public static final String READ_DISTRIBUTION_MODE_DEFAULT = READ_DISTRIBUTION_MODE_NONE;
   public static final String READ_DISTRIBUTION_HASH_MODE = "read.distribution.hash-mode";
   public static final String READ_DISTRIBUTION_HASH_PARTITION = "partition-key";
   public static final String READ_DISTRIBUTION_HASH_PRIMARY = "primary-key";

--- a/core/src/main/java/com/netease/arctic/utils/SchemaUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/SchemaUtil.java
@@ -20,7 +20,12 @@ package com.netease.arctic.utils;
 
 import com.netease.arctic.table.MetadataColumns;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+import java.util.Set;
 
 public class SchemaUtil {
 
@@ -29,5 +34,31 @@ public class SchemaUtil {
         MetadataColumns.FILE_OFFSET_FILED
     );
     return TypeUtil.join(changeTableSchema, changeWriteMetaColumnsSchema);
+  }
+
+  /**
+   * Convert an Iceberg Schema {@link Schema} to a {@link Schema} based on the given schema.
+   * <p>
+   * This fill-up does not assign new ids; it uses ids from the base schema.
+   * <p>
+   * If the toSchema does contain the identifierFields of the based schema, it will fill-up the identifierFields to
+   * a new schema.
+   *
+   * @param baseSchema a Schema on which loading is based
+   * @param fromSchema   a Schema on which compared to
+   * @return a new Schema on which contain the identifier fields of the base Schema and column fields of the fromSchema
+   */
+  public static Schema fillUpIdentifierFields(Schema baseSchema, Schema fromSchema) {
+    int schemaId = fromSchema.schemaId();
+    Types.StructType struct = fromSchema.asStruct();
+    List<Types.NestedField> fields = Lists.newArrayList(struct.fields());
+    Set<Integer> identifierFields = baseSchema.identifierFieldIds();
+    identifierFields.forEach(fieldId -> {
+      if (struct.field(fieldId) == null) {
+        fields.add(baseSchema.findField(fieldId));
+      }
+    });
+
+    return new Schema(schemaId, fields, identifierFields);
   }
 }

--- a/core/src/main/java/com/netease/arctic/utils/SchemaUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/SchemaUtil.java
@@ -41,11 +41,11 @@ public class SchemaUtil {
    * <p>
    * This fill-up does not assign new ids; it uses ids from the base schema.
    * <p>
-   * If the toSchema does contain the identifierFields of the based schema, it will fill-up the identifierFields to
+   * If the fromSchema does contain the identifierFields of the based schema, it will fill-up the identifierFields to
    * a new schema.
    *
    * @param baseSchema a Schema on which loading is based
-   * @param fromSchema   a Schema on which compared to
+   * @param fromSchema a Schema on which compared to
    * @return a new Schema on which contain the identifier fields of the base Schema and column fields of the fromSchema
    */
   public static Schema fillUpIdentifierFields(Schema baseSchema, Schema fromSchema) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
@@ -141,6 +141,7 @@ public class FlinkSchemaUtil {
    * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
    * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
+  @Deprecated
   public static List<Types.NestedField> addPrimaryKey(
       List<Types.NestedField> projectedColumns, ArcticTable table) {
     List<String> primaryKeys = table.isUnkeyedTable() ? Collections.EMPTY_LIST
@@ -166,6 +167,7 @@ public class FlinkSchemaUtil {
    * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
    * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
+  @Deprecated
   public static void addPrimaryKey(
       TableSchema.Builder builder, ArcticTable table, TableSchema tableSchema, String[] projectedColumns) {
     Set<String> projectedNames = Arrays.stream(projectedColumns).collect(Collectors.toSet());

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/PartitionAndNodeGroup.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/PartitionAndNodeGroup.java
@@ -75,7 +75,7 @@ public class PartitionAndNodeGroup {
    *
    * @param insert if plan insert files or not
    * @param nodes  the key of nodes is partition info which the file located, the value of nodes is hashmap of
-   *               transactionId and {@link Node}
+   *               arctic tree node id and {@link Node}
    */
   private void plan(boolean insert, Map<String, Map<Long, Node>> nodes) {
     Collection<ArcticFileScanTask> tasks = insert ? insertTasks : deleteTasks;
@@ -85,15 +85,15 @@ public class PartitionAndNodeGroup {
 
     tasks.forEach(task -> {
       String partitionKey = task.file().partition().toString();
-      Long index = task.file().node().index();
+      Long nodeId = task.file().node().getId();
       Map<Long, Node> indexNodes = nodes.getOrDefault(partitionKey, new HashMap<>());
-      Node node = indexNodes.getOrDefault(index, new Node());
+      Node node = indexNodes.getOrDefault(nodeId, new Node());
       if (insert) {
         node.addInsert(task);
       } else {
         node.addDelete(task);
       }
-      indexNodes.put(index, node);
+      indexNodes.put(nodeId, node);
       nodes.put(partitionKey, indexNodes);
     });
   }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -196,6 +196,22 @@ public class ShuffleSplitAssigner implements SplitAssigner {
     }
   }
 
+  /**
+   * <p>
+   * |mask=0          o
+   * |             /     \
+   * |mask=1     o        o
+   * |         /   \    /   \
+   * |mask=3  o     o  o     o
+   * <p>
+   * Different data files may locate in different layers when multi snapshots are committed, so arctic source reading
+   * should consider emitting the records and keeping ordering. According to the dataTreeNode of the arctic split and
+   * the currentMaskOfTreeNode, return the exact tree node list which may move up or go down layers in the arctic tree.
+   * </p>
+   *
+   * @param arcticSplit arctic split.
+   * @return the exact tree node list.
+   */
   public List<DataTreeNode> getExactlyTreeNodes(ArcticSplit arcticSplit) {
     DataTreeNode dataTreeNode = arcticSplit.dataTreeNode();
     long mask = dataTreeNode.mask();

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -23,7 +23,6 @@ import com.netease.arctic.data.PrimaryKeyedFile;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplitState;
 import com.netease.arctic.scan.ArcticFileScanTask;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.slf4j.Logger;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -124,7 +124,6 @@ public class ShuffleSplitAssigner implements SplitAssigner {
   @Override
   public void onDiscoveredSplits(Collection<ArcticSplit> splits) {
     splits.forEach(this::putArcticIntoQueue);
-    totalSplitNum += splits.size();
   }
 
   @Override
@@ -132,23 +131,26 @@ public class ShuffleSplitAssigner implements SplitAssigner {
     onDiscoveredSplits(splits);
   }
 
-  void putArcticIntoQueue(ArcticSplit split) {
-    int subtaskId = getSubtaskIdByArcticSplit(split);
-    PriorityBlockingQueue<ArcticSplit> queue = subtaskSplitMap.getOrDefault(subtaskId, new PriorityBlockingQueue<>());
-    LOG.info("put split into queue: {}", split);
-    queue.add(split);
-    subtaskSplitMap.put(subtaskId, queue);
-  }
+  void putArcticIntoQueue(final ArcticSplit split) {
+    List<DataTreeNode> exactlyTreeNodes = getExactlyTreeNodes(split);
 
-  private int getSubtaskIdByArcticSplit(ArcticSplit arcticSplit) {
-    PrimaryKeyedFile file = findAnyFileInArcticSplit(arcticSplit);
-    long partitionIndexKey = partitionAndIndexHashCode(
-        file.partition().toString(), arcticSplit);
+    PrimaryKeyedFile file = findAnyFileInArcticSplit(split);
 
-    int subtaskId = partitionIndexSubtaskMap.computeIfAbsent(
-        partitionIndexKey, key -> (partitionIndexSubtaskMap.size() + 1) % totalParallelism);
-    LOG.info("partition = {}, index = {}, subtaskId = {}", file.partition().toString(), file.node().index(), subtaskId);
-    return subtaskId;
+    for (DataTreeNode node : exactlyTreeNodes) {
+      long partitionIndexKey = Math.abs(file.partition().toString().hashCode() + node.index());
+      int subtaskId = partitionIndexSubtaskMap.computeIfAbsent(
+          partitionIndexKey, key -> (partitionIndexSubtaskMap.size() + 1) % totalParallelism);
+      LOG.info("partition = {}, (mask, index) = ({}, {}), subtaskId = {}",
+          file.partition().toString(), node.mask(), node.index(), subtaskId);
+
+      PriorityBlockingQueue<ArcticSplit> queue = subtaskSplitMap.getOrDefault(subtaskId, new PriorityBlockingQueue<>());
+      ArcticSplit copiedSplit = split.copy();
+      copiedSplit.modifyTreeNode(node);
+      LOG.info("put split into queue: {}", copiedSplit);
+      queue.add(copiedSplit);
+      totalSplitNum = totalSplitNum + 1;
+      subtaskSplitMap.put(subtaskId, queue);
+    }
   }
 
   @Override
@@ -195,14 +197,8 @@ public class ShuffleSplitAssigner implements SplitAssigner {
     }
   }
 
-  private long partitionAndIndexHashCode(String partition, ArcticSplit arcticSplit) {
-    return Math.abs(partition.hashCode() + getExactlyIndexOfTreeNode(arcticSplit));
-  }
-
-  @VisibleForTesting
-  public long getExactlyIndexOfTreeNode(ArcticSplit arcticSplit) {
+  public List<DataTreeNode> getExactlyTreeNodes(ArcticSplit arcticSplit) {
     DataTreeNode dataTreeNode = arcticSplit.dataTreeNode();
-    long index = dataTreeNode.index();
     long mask = dataTreeNode.mask();
 
     synchronized (lock) {
@@ -211,27 +207,23 @@ public class ShuffleSplitAssigner implements SplitAssigner {
       }
     }
 
-    boolean modifyDataTreeNode = mask != currentMaskOfTreeNode;
-    boolean greaterThanCurrent = mask > currentMaskOfTreeNode;
-    ++mask;
-    while (mask != currentMaskOfTreeNode + 1) {
-      if (greaterThanCurrent) {
-        mask = mask >> 1;
-        index = index >> 1;
-      } else {
-        mask = mask << 1;
-        index = index << 1;
-      }
-    }
+    return scanTreeNode(dataTreeNode);
+  }
 
-    // Have to modify the dataTreeNode of the arcticSplit due to the mask of this split is diff from the current
-    // mask assigned to source readers.
-    if (modifyDataTreeNode) {
-      DataTreeNode expectedNode = DataTreeNode.of(currentMaskOfTreeNode, index);
-      LOG.info("original dataTreeNode is {}, new dataTreeNode is {}.", dataTreeNode, expectedNode);
-      arcticSplit.modifyTreeNode(expectedNode);
+  private List<DataTreeNode> scanTreeNode(DataTreeNode dataTreeNode) {
+    long mask = dataTreeNode.mask();
+    if (mask == currentMaskOfTreeNode) {
+      return Collections.singletonList(dataTreeNode);
+    } else if (mask > currentMaskOfTreeNode) {
+      // move up one layer
+      return scanTreeNode(dataTreeNode.parent());
+    } else {
+      // go down one layer
+      List<DataTreeNode> allNodes = new ArrayList<>();
+      allNodes.addAll(scanTreeNode(dataTreeNode.left()));
+      allNodes.addAll(scanTreeNode(dataTreeNode.right()));
+      return allNodes;
     }
-    return index;
   }
 
   /**

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunction.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunction.java
@@ -26,6 +26,7 @@ import com.netease.arctic.flink.read.source.FlinkArcticDataReader;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.io.ArcticFileIO;
 import com.netease.arctic.table.PrimaryKeySpec;
+import com.netease.arctic.utils.NodeFilter;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.Schema;
@@ -37,6 +38,7 @@ import java.util.Collections;
 
 import static com.netease.arctic.flink.shuffle.RowKindUtil.convertToFlinkRowKind;
 import static com.netease.arctic.utils.SchemaUtil.changeWriteSchema;
+import static com.netease.arctic.utils.SchemaUtil.fillUpIdentifierFields;
 
 /**
  * This Function accept a {@link ArcticSplit} and produces an {@link DataIterator} of {@link RowData}.
@@ -49,7 +51,15 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
   private final boolean caseSensitive;
   private final ArcticFileIO io;
   private final PrimaryKeySpec primaryKeySpec;
+  /**
+   * The accurate selected columns size if the arctic source projected
+   */
   private final int columnSize;
+  /**
+   * The index of the arctic file offset field in the read schema
+   * Refer to {@link this#wrapArcticFileOffsetColumnMeta}
+   */
+  private final int arcticFileOffsetIndex;
 
   public RowDataReaderFunction(
       ReadableConfig config, Schema tableSchema, Schema projectedSchema, PrimaryKeySpec primaryKeySpec,
@@ -57,13 +67,14 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
     super(new ArrayPoolDataIteratorBatcher<>(config, new RowDataRecordFactory(
         FlinkSchemaUtil.convert(readSchema(tableSchema, projectedSchema)))));
     this.tableSchema = tableSchema;
-    this.readSchema = readSchema(tableSchema, projectedSchema);
+    this.readSchema = fillUpReadSchema(tableSchema, projectedSchema);
     this.primaryKeySpec = primaryKeySpec;
     this.nameMapping = nameMapping;
     this.caseSensitive = caseSensitive;
     this.io = io;
-    // Add file offset column after readSchema. Refer to this#wrapArcticFileOffsetColumnMeta
-    this.columnSize = readSchema.columns().size();
+    // Add file offset column after readSchema.
+    this.arcticFileOffsetIndex = readSchema.columns().size();
+    this.columnSize = projectedSchema == null ? readSchema.columns().size() : projectedSchema.columns().size();
   }
 
   @Override
@@ -77,7 +88,8 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
       return new DataIterator<>(
           rowDataReader,
           split.asSnapshotSplit().insertTasks(),
-          rowData -> Long.MIN_VALUE);
+          rowData -> Long.MIN_VALUE,
+          this::removeArcticMetaColumn);
     } else if (split.isChangelogSplit()) {
       FileScanTaskReader<RowData> rowDataReader =
           new FlinkArcticDataReader(
@@ -102,7 +114,7 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
   }
 
   long arcticFileOffset(RowData rowData) {
-    return rowData.getLong(columnSize);
+    return rowData.getLong(arcticFileOffsetIndex);
   }
 
   /**
@@ -116,6 +128,23 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
     RowData rowData = trans.row();
     rowData.setRowKind(convertToFlinkRowKind(trans.changeAction()));
     return rowData;
+  }
+
+  /**
+   * If the projected schema is not null, this method will check and fill up the identifierFields of the tableSchema and
+   * the projected schema.
+   * <p>
+   * projectedSchema may not include the primary keys, but the {@link NodeFilter} must filter the record with
+   * the value of the primary keys. So the Arctic reader function schema must include the primary keys.
+   * </p>
+   *
+   * @param tableSchema     table schema
+   * @param projectedSchema projected schema
+   * @return a new Schema on which include the identifier fields.
+   */
+  private static Schema fillUpReadSchema(Schema tableSchema, Schema projectedSchema) {
+    Preconditions.checkNotNull(tableSchema, "Table schema can't be null");
+    return projectedSchema == null ? tableSchema : fillUpIdentifierFields(tableSchema, projectedSchema);
   }
 
   private static Schema readSchema(Schema tableSchema, Schema projectedSchema) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ArcticSplit.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ArcticSplit.java
@@ -102,4 +102,6 @@ public abstract class ArcticSplit implements SourceSplit, Serializable, Comparab
                 .add("transactionId", primaryKeyedFile.transactionId())
                 .toString()).collect(Collectors.toList()));
   }
+
+  public abstract ArcticSplit copy();
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ChangelogSplit.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ChangelogSplit.java
@@ -80,6 +80,11 @@ public class ChangelogSplit extends ArcticSplit {
   }
 
   @Override
+  public ArcticSplit copy() {
+    return new ChangelogSplit(insertScanTasks, deleteScanTasks, taskIndex);
+  }
+
+  @Override
   public String splitId() {
     return MoreObjects.toStringHelper(this)
         .add("insertTasks", toString(insertScanTasks))

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/SnapshotSplit.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/SnapshotSplit.java
@@ -81,6 +81,11 @@ public class SnapshotSplit extends ArcticSplit {
     insertRecordOffset = (long) offsets[1];
   }
 
+  @Override
+  public ArcticSplit copy() {
+    return new SnapshotSplit(insertScanTasks, taskIndex);
+  }
+
   public int insertFileOffset() {
     return insertFileOffset;
   }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/ChangeLogDataIterator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/ChangeLogDataIterator.java
@@ -51,10 +51,12 @@ public class ChangeLogDataIterator<T> extends DataIterator<T> {
       Function<T, Long> arcticFileOffsetGetter,
       Function<T, T> arcticMetaColumnRemover,
       Function<ChangeActionTrans<T>, T> changeActionTransformer) {
-    super(fileScanTaskReader, Collections.emptyList(), arcticFileOffsetGetter);
-    this.insertDataIterator = initDataIterator(fileScanTaskReader, arcticFileOffsetGetter, insertTasks);
+    super(fileScanTaskReader, Collections.emptyList(), arcticFileOffsetGetter, arcticMetaColumnRemover);
+    this.insertDataIterator =
+        new DataIterator<>(fileScanTaskReader, insertTasks, arcticFileOffsetGetter, arcticMetaColumnRemover);
     if (deleteTasks != null && !deleteTasks.isEmpty()) {
-      this.deleteDataIterator = initDataIterator(fileScanTaskReader, arcticFileOffsetGetter, deleteTasks);
+      this.deleteDataIterator =
+          new DataIterator<>(fileScanTaskReader, deleteTasks, arcticFileOffsetGetter, arcticMetaColumnRemover);
     }
     this.arcticMetaColumnRemover = arcticMetaColumnRemover;
     this.changeActionTransformer = changeActionTransformer;
@@ -149,16 +151,6 @@ public class ChangeLogDataIterator<T> extends DataIterator<T> {
 
   public long deleteRecordOffset() {
     return deleteDataIterator.recordOffset();
-  }
-
-  private DataIterator<T> initDataIterator(
-      FileScanTaskReader<T> fileScanTaskReader,
-      Function<T, Long> arcticFileOffsetGetter,
-      Collection<ArcticFileScanTask> tasks) {
-    return new DataIterator<>(
-        fileScanTaskReader,
-        tasks,
-        arcticFileOffsetGetter);
   }
 
   private static class QueueHolder<T> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -51,7 +51,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -61,7 +60,7 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
     SupportsProjectionPushDown, SupportsLimitPushDown, SupportsWatermarkPushDown {
 
   private static final Logger LOG = LoggerFactory.getLogger(ArcticFileSource.class);
-  
+
   private int[] projectedFields;
   private long limit;
   private List<Expression> filters;
@@ -139,7 +138,6 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
           projectedColumns,
           Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
 
-      addPrimaryKey(builder, table, tableSchema, projectedColumns);
       TableSchema ts = builder.build();
       LOG.info("TableSchema builder after addPrimaryKey, schema:{}", ts);
       return ts;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -154,8 +154,8 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         arcticDynamicSource = createLogSource(arcticTable, context, confWithAll);
     }
 
-    return new ArcticDynamicSource(identifier.getObjectName(), arcticDynamicSource, arcticTable, tableSchema,
-        arcticTable.properties());
+    return new ArcticDynamicSource(
+        identifier.getObjectName(), arcticDynamicSource, arcticTable, arcticTable.properties());
   }
 
   @Override

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -140,10 +140,21 @@ public class FlinkSource {
         return buildUnkeyedTableSource();
       }
 
+      boolean dimTable = CompatibleFlinkPropertyUtil.propertyAsBoolean(properties, DIM_TABLE_ENABLE.key(),
+          DIM_TABLE_ENABLE.defaultValue());
+      RowType rowType;
+
       if (projectedSchema == null) {
         contextBuilder.project(arcticTable.schema());
+        rowType = FlinkSchemaUtil.convert(arcticTable.schema());
       } else {
         contextBuilder.project(FlinkSchemaUtil.convert(arcticTable.schema(), filterWatermark(projectedSchema)));
+        // If dim table is enabled, we reserve a RowTime field in Emitter.
+        if (dimTable) {
+          rowType = toRowType(projectedSchema);
+        } else {
+          rowType = toRowType(filterWatermark(projectedSchema));
+        }
       }
       contextBuilder.fromProperties(properties);
       ArcticScanContext scanContext = contextBuilder.build();
@@ -157,20 +168,6 @@ public class FlinkSource {
           scanContext.caseSensitive(),
           arcticTable.io()
       );
-
-      boolean dimTable = CompatibleFlinkPropertyUtil.propertyAsBoolean(properties, DIM_TABLE_ENABLE.key(),
-          DIM_TABLE_ENABLE.defaultValue());
-      RowType rowType;
-      if (projectedSchema != null) {
-        // If dim table is enabled, we reserve a RowTime field in Emitter.
-        if (dimTable) {
-          rowType = toRowType(projectedSchema);
-        } else {
-          rowType = toRowType(filterWatermark(projectedSchema));
-        }
-      } else {
-        rowType = FlinkSchemaUtil.convert(scanContext.project());
-      }
 
       return env.fromSource(
           new ArcticSource<>(tableLoader, scanContext, rowDataReaderFunction,

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
@@ -88,7 +88,7 @@ public class FlinkTestBase extends TableTestBase {
   @ClassRule
   public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
       MiniClusterResource.createWithClassloaderCheckDisabled();
-  
+
   public static boolean IS_LOCAL = true;
   public static String METASTORE_URL = "thrift://127.0.0.1:" + AMS.port();
 
@@ -314,10 +314,15 @@ public class FlinkTestBase extends TableTestBase {
 
   protected static TaskWriter<RowData> createKeyedTaskWriter(KeyedTable keyedTable, RowType rowType, long transactionId,
                                                              boolean base) {
+    return createKeyedTaskWriter(keyedTable, rowType, transactionId, base, 3);
+  }
+
+  protected static TaskWriter<RowData> createKeyedTaskWriter(KeyedTable keyedTable, RowType rowType, long transactionId,
+                                                             boolean base, long mask) {
     ArcticRowDataTaskWriterFactory taskWriterFactory =
         new ArcticRowDataTaskWriterFactory(keyedTable, rowType, base);
     taskWriterFactory.setTransactionId(transactionId);
-    taskWriterFactory.setMask(3);
+    taskWriterFactory.setMask(mask);
     taskWriterFactory.initialize(0, 0);
     return taskWriterFactory.create();
   }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssignerTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssignerTest.java
@@ -20,25 +20,32 @@ package com.netease.arctic.flink.read.hybrid.assigner;
 
 import com.netease.arctic.data.DataTreeNode;
 import com.netease.arctic.flink.read.FlinkSplitPlanner;
+import com.netease.arctic.flink.read.hybrid.reader.RowDataReaderFunction;
 import com.netease.arctic.flink.read.hybrid.reader.RowDataReaderFunctionTest;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
+import com.netease.arctic.flink.read.source.DataIterator;
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.table.data.RowData;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 public class ShuffleSplitAssignerTest extends RowDataReaderFunctionTest {
   private static final Logger LOG = LoggerFactory.getLogger(ShuffleSplitAssignerTest.class);
@@ -90,7 +97,10 @@ public class ShuffleSplitAssignerTest extends RowDataReaderFunctionTest {
     ShuffleSplitAssigner shuffleSplitAssigner = instanceSplitAssigner(3);
     long[][] treeNodes = new long[][]{{3, 0}, {3, 1}, {3, 2}, {3, 3}, {7, 0}, {7, 1}, {7, 2}, {7, 3}, {7, 4},
         {1, 0}, {1, 1}, {0, 0}, {7, 7}, {15, 15}};
-    List<Long> actual = new ArrayList<>();
+    long[][] expectNodes = new long[][]{{3, 0}, {3, 1}, {3, 2}, {3, 3}, {3, 0}, {3, 1}, {3, 2}, {3, 3}, {3, 0},
+        {3, 0}, {3, 2}, {3, 1}, {3, 3}, {3, 0}, {3, 2}, {3, 1}, {3, 3}, {3, 3}, {3, 3}};
+
+    List<DataTreeNode> actualNodes = new ArrayList<>();
 
     for (long[] node : treeNodes) {
       ArcticSplit arcticSplit = new ArcticSplit() {
@@ -103,6 +113,11 @@ public class ShuffleSplitAssignerTest extends RowDataReaderFunctionTest {
 
         @Override
         public void updateOffset(Object[] recordOffsets) {
+        }
+
+        @Override
+        public ArcticSplit copy() {
+          return null;
         }
 
         @Override
@@ -125,15 +140,56 @@ public class ShuffleSplitAssignerTest extends RowDataReaderFunctionTest {
           return dataTreeNode.toString();
         }
       };
-      LOG.info("before split {}.", arcticSplit);
-      long index = shuffleSplitAssigner.getExactlyIndexOfTreeNode(arcticSplit);
-      LOG.info("after split {}.", arcticSplit);
-      actual.add(index);
+      List<DataTreeNode> exactTreeNodes = shuffleSplitAssigner.getExactlyTreeNodes(arcticSplit);
+      actualNodes.addAll(exactTreeNodes);
     }
-    long[] result = actual.stream().mapToLong(l -> l).toArray();
-    long[] expect = new long[]{0, 1, 2, 3, 0, 0, 1, 1, 2, 0, 2, 0, 3, 3};
+    long[][] result = actualNodes.stream().map(treeNode -> new long[]{treeNode.mask(), treeNode.index()}).toArray(value -> new long[actualNodes.size()][]);
 
-    Assert.assertArrayEquals(expect, result);
+    Assert.assertArrayEquals(expectNodes, result);
+  }
+
+  @Test
+  public void testNodeUpMoved() throws IOException {
+    writeUpdateWithSpecifiedMaskOne();
+    List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(testKeyedTable, new AtomicInteger(0));
+    int totalParallelism = 3;
+    ShuffleSplitAssigner assigner = instanceSplitAssigner(totalParallelism);
+    assigner.onDiscoveredSplits(arcticSplits);
+    RowDataReaderFunction rowDataReaderFunction = new RowDataReaderFunction(
+        new Configuration(),
+        testKeyedTable.schema(),
+        testKeyedTable.schema(),
+        testKeyedTable.primaryKeySpec(),
+        null,
+        true,
+        testKeyedTable.io()
+    );
+    int subtaskId = 0;
+    Optional<ArcticSplit> split;
+    List<RowData> actual = new ArrayList<>();
+    LOG.info("subtaskId={}...", subtaskId);
+    do {
+      split = assigner.getNext(subtaskId);
+      if (split.isPresent()) {
+        DataIterator<RowData> dataIterator = rowDataReaderFunction.createDataIterator(split.get());
+        while (dataIterator.hasNext()) {
+          RowData rowData = dataIterator.next();
+          LOG.info("{}", rowData);
+          actual.add(rowData);
+        }
+      } else {
+        subtaskId = subtaskId + 1;
+        LOG.info("subtaskId={}...", subtaskId);
+      }
+    } while (subtaskId < totalParallelism);
+
+
+    List<RowData> excepts = exceptsCollection();
+    excepts.addAll(generateRecords());
+    RowData[] array = excepts.stream().sorted(Comparator.comparing(RowData::toString))
+        .collect(Collectors.toList())
+        .toArray(new RowData[excepts.size()]);
+    assertArrayEquals(array, actual);
   }
 
   protected ShuffleSplitAssigner instanceSplitAssigner(int parallelism) {

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/TemporalJoinSplitsThreadSafeTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/TemporalJoinSplitsThreadSafeTest.java
@@ -95,6 +95,11 @@ public class TemporalJoinSplitsThreadSafeTest {
     }
 
     @Override
+    public ArcticSplit copy() {
+      return new TestArcticSplit(this.splitId);
+    }
+
+    @Override
     public String splitId() {
       return splitId;
     }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/reader/RowDataReaderFunctionTest.java
@@ -86,6 +86,7 @@ public class RowDataReaderFunctionTest extends ContinuousSplitPlannerImplTest {
 
     long snapshotId = testKeyedTable.changeTable().currentSnapshot().snapshotId();
     writeUpdate();
+
     testKeyedTable.changeTable().refresh();
     long nowSnapshotId = testKeyedTable.changeTable().currentSnapshot().snapshotId();
 
@@ -119,6 +120,41 @@ public class RowDataReaderFunctionTest extends ContinuousSplitPlannerImplTest {
       actual.add(rowData);
     }
     assertArrayEquals(excepts2(), actual);
+
+  }
+
+  @Test
+  public void testReadNodesUpMoved() throws IOException {
+    writeUpdateWithSpecifiedMaskOne();
+    List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(testKeyedTable, new AtomicInteger(0));
+
+    RowDataReaderFunction rowDataReaderFunction = new RowDataReaderFunction(
+        new Configuration(),
+        testKeyedTable.schema(),
+        testKeyedTable.schema(),
+        testKeyedTable.primaryKeySpec(),
+        null,
+        true,
+        testKeyedTable.io()
+    );
+
+    List<RowData> actual = new ArrayList<>();
+    arcticSplits.forEach(split -> {
+      LOG.info("ArcticSplit {}.", split);
+      DataIterator<RowData> dataIterator = rowDataReaderFunction.createDataIterator(split);
+      while (dataIterator.hasNext()) {
+        RowData rowData = dataIterator.next();
+        LOG.info("{}", rowData);
+        actual.add(rowData);
+      }
+    });
+
+    List<RowData> excepts = exceptsCollection();
+    excepts.addAll(generateRecords());
+    RowData[] array = excepts.stream().sorted(Comparator.comparing(RowData::toString))
+        .collect(Collectors.toList())
+        .toArray(new RowData[excepts.size()]);
+    assertArrayEquals(array, actual);
   }
 
   protected void assertArrayEquals(RowData[] excepts, List<RowData> actual) {
@@ -143,6 +179,22 @@ public class RowDataReaderFunctionTest extends ContinuousSplitPlannerImplTest {
     writeUpdate(input, testKeyedTable);
   }
 
+  protected void writeUpdateWithSpecifiedMaskOne() throws IOException {
+    List<RowData> excepts = generateRecords();
+
+    writeUpdateWithSpecifiedMask(excepts, testKeyedTable, 1);
+  }
+
+  protected void writeUpdateWithSpecifiedMask(List<RowData> input, KeyedTable table, long mask) throws IOException {
+    // write change update
+    TaskWriter<RowData> taskWriter = createKeyedTaskWriter(table, ROW_TYPE, TRANSACTION_ID.getAndIncrement(), false, mask);
+
+    for (RowData record : input) {
+      taskWriter.write(record);
+    }
+    commit(table, taskWriter.complete(), false);
+  }
+
   protected void writeUpdate(List<RowData> input, KeyedTable table) throws IOException {
     //write change update
     TaskWriter<RowData> taskWriter = createKeyedTaskWriter(table, ROW_TYPE, TRANSACTION_ID.getAndIncrement(), false);
@@ -151,6 +203,16 @@ public class RowDataReaderFunctionTest extends ContinuousSplitPlannerImplTest {
       taskWriter.write(record);
     }
     commit(table, taskWriter.complete(), false);
+  }
+
+  protected List<RowData> generateRecords() {
+    List<RowData> excepts = new ArrayList<>();
+    excepts.add(GenericRowData.ofKind(RowKind.INSERT, 7, StringData.fromString("syan"), TimestampData.fromLocalDateTime(ldt)));
+    excepts.add(GenericRowData.ofKind(RowKind.UPDATE_BEFORE, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+    excepts.add(GenericRowData.ofKind(RowKind.UPDATE_AFTER, 2, StringData.fromString("daniel"), TimestampData.fromLocalDateTime(ldt)));
+    excepts.add(GenericRowData.ofKind(RowKind.UPDATE_BEFORE, 7, StringData.fromString("syan"), TimestampData.fromLocalDateTime(ldt)));
+    excepts.add(GenericRowData.ofKind(RowKind.UPDATE_AFTER, 7, StringData.fromString("syan2"), TimestampData.fromLocalDateTime(ldt)));
+    return excepts;
   }
 
   protected List<RowData> updateRecords() {

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -67,7 +67,7 @@ import static com.netease.arctic.ams.api.MockArcticMetastoreServer.TEST_CATALOG_
 import static com.netease.arctic.table.TableProperties.LOCATION;
 
 public class TestWatermark extends FlinkTestBase {
-  public static final Logger LOG = LoggerFactory.getLogger(TestJoin.class);
+  public static final Logger LOG = LoggerFactory.getLogger(TestWatermark.class);
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
@@ -141,6 +141,7 @@ public class FlinkSchemaUtil {
    * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
    * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
+  @Deprecated
   public static List<Types.NestedField> addPrimaryKey(
       List<Types.NestedField> projectedColumns, ArcticTable table) {
     List<String> primaryKeys = table.isUnkeyedTable() ? Collections.EMPTY_LIST
@@ -166,6 +167,7 @@ public class FlinkSchemaUtil {
    * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
    * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
+  @Deprecated
   public static void addPrimaryKey(
       TableSchema.Builder builder, ArcticTable table, TableSchema tableSchema, String[] projectedColumns) {
     Set<String> projectedNames = Arrays.stream(projectedColumns).collect(Collectors.toSet());
@@ -183,5 +185,5 @@ public class FlinkSchemaUtil {
           .orElseThrow(() -> new ValidationException("Arctic primary key should be declared in table")));
     });
   }
-  
+
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -294,7 +294,7 @@ public class ArcticCatalog extends AbstractCatalog {
     validateFlinkTable(table);
 
     TableSchema tableSchema = table.getSchema();
-    TableSchema.Builder b = TableSchema.builder();
+    TableSchema.Builder flinkSchemaBuilder = TableSchema.builder();
 
     tableSchema.getTableColumns().forEach(c -> {
       List<WatermarkSpec> ws = tableSchema.getWatermarkSpecs();
@@ -303,9 +303,12 @@ public class ArcticCatalog extends AbstractCatalog {
           return;
         }
       }
-      b.field(c.getName(), c.getType());
+      flinkSchemaBuilder.field(c.getName(), c.getType());
     });
-    TableSchema tableSchemaWithoutWatermark = b.build();
+    if (tableSchema.getPrimaryKey().isPresent()) {
+      flinkSchemaBuilder.primaryKey(tableSchema.getPrimaryKey().get().getColumns().toArray(new String[0]));
+    }
+    TableSchema tableSchemaWithoutWatermark = flinkSchemaBuilder.build();
 
     Schema icebergSchema = FlinkSchemaUtil.convert(tableSchemaWithoutWatermark);
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/PartitionAndNodeGroup.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/PartitionAndNodeGroup.java
@@ -75,7 +75,7 @@ public class PartitionAndNodeGroup {
    *
    * @param insert if plan insert files or not
    * @param nodes  the key of nodes is partition info which the file located, the value of nodes is hashmap of
-   *               transactionId and {@link Node}
+   *               arctic tree node id and {@link Node}
    */
   private void plan(boolean insert, Map<String, Map<Long, Node>> nodes) {
     Collection<ArcticFileScanTask> tasks = insert ? insertTasks : deleteTasks;
@@ -85,15 +85,15 @@ public class PartitionAndNodeGroup {
 
     tasks.forEach(task -> {
       String partitionKey = task.file().partition().toString();
-      Long index = task.file().node().index();
+      Long nodeId = task.file().node().getId();
       Map<Long, Node> indexNodes = nodes.getOrDefault(partitionKey, new HashMap<>());
-      Node node = indexNodes.getOrDefault(index, new Node());
+      Node node = indexNodes.getOrDefault(nodeId, new Node());
       if (insert) {
         node.addInsert(task);
       } else {
         node.addDelete(task);
       }
-      indexNodes.put(index, node);
+      indexNodes.put(nodeId, node);
       nodes.put(partitionKey, indexNodes);
     });
   }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -196,6 +196,22 @@ public class ShuffleSplitAssigner implements SplitAssigner {
     }
   }
 
+  /**
+   * <p>
+   * |mask=0          o
+   * |             /     \
+   * |mask=1     o        o
+   * |         /   \    /   \
+   * |mask=3  o     o  o     o
+   * <p>
+   * Different data files may locate in different layers when multi snapshots are committed, so arctic source reading
+   * should consider emitting the records and keeping ordering. According to the dataTreeNode of the arctic split and
+   * the currentMaskOfTreeNode, return the exact tree node list which may move up or go down layers in the arctic tree.
+   * </p>
+   *
+   * @param arcticSplit arctic split.
+   * @return the exact tree node list.
+   */
   public List<DataTreeNode> getExactlyTreeNodes(ArcticSplit arcticSplit) {
     DataTreeNode dataTreeNode = arcticSplit.dataTreeNode();
     long mask = dataTreeNode.mask();

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -23,7 +23,6 @@ import com.netease.arctic.data.PrimaryKeyedFile;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplitState;
 import com.netease.arctic.scan.ArcticFileScanTask;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.slf4j.Logger;
@@ -124,7 +123,6 @@ public class ShuffleSplitAssigner implements SplitAssigner {
   @Override
   public void onDiscoveredSplits(Collection<ArcticSplit> splits) {
     splits.forEach(this::putArcticIntoQueue);
-    totalSplitNum += splits.size();
   }
 
   @Override
@@ -132,23 +130,26 @@ public class ShuffleSplitAssigner implements SplitAssigner {
     onDiscoveredSplits(splits);
   }
 
-  void putArcticIntoQueue(ArcticSplit split) {
-    int subtaskId = getSubtaskIdByArcticSplit(split);
-    PriorityBlockingQueue<ArcticSplit> queue = subtaskSplitMap.getOrDefault(subtaskId, new PriorityBlockingQueue<>());
-    LOG.info("put split into queue: {}", split);
-    queue.add(split);
-    subtaskSplitMap.put(subtaskId, queue);
-  }
+  void putArcticIntoQueue(final ArcticSplit split) {
+    List<DataTreeNode> exactlyTreeNodes = getExactlyTreeNodes(split);
 
-  private int getSubtaskIdByArcticSplit(ArcticSplit arcticSplit) {
-    PrimaryKeyedFile file = findAnyFileInArcticSplit(arcticSplit);
-    long partitionIndexKey = partitionAndIndexHashCode(
-        file.partition().toString(), arcticSplit);
+    PrimaryKeyedFile file = findAnyFileInArcticSplit(split);
 
-    int subtaskId = partitionIndexSubtaskMap.computeIfAbsent(
-        partitionIndexKey, key -> (partitionIndexSubtaskMap.size() + 1) % totalParallelism);
-    LOG.info("partition = {}, index = {}, subtaskId = {}", file.partition().toString(), file.node().index(), subtaskId);
-    return subtaskId;
+    for (DataTreeNode node : exactlyTreeNodes) {
+      long partitionIndexKey = Math.abs(file.partition().toString().hashCode() + node.index());
+      int subtaskId = partitionIndexSubtaskMap.computeIfAbsent(
+          partitionIndexKey, key -> (partitionIndexSubtaskMap.size() + 1) % totalParallelism);
+      LOG.info("partition = {}, (mask, index) = ({}, {}), subtaskId = {}",
+          file.partition().toString(), node.mask(), node.index(), subtaskId);
+
+      PriorityBlockingQueue<ArcticSplit> queue = subtaskSplitMap.getOrDefault(subtaskId, new PriorityBlockingQueue<>());
+      ArcticSplit copiedSplit = split.copy();
+      copiedSplit.modifyTreeNode(node);
+      LOG.info("put split into queue: {}", copiedSplit);
+      queue.add(copiedSplit);
+      totalSplitNum = totalSplitNum + 1;
+      subtaskSplitMap.put(subtaskId, queue);
+    }
   }
 
   @Override
@@ -195,14 +196,8 @@ public class ShuffleSplitAssigner implements SplitAssigner {
     }
   }
 
-  private long partitionAndIndexHashCode(String partition, ArcticSplit arcticSplit) {
-    return Math.abs(partition.hashCode() + getExactlyIndexOfTreeNode(arcticSplit));
-  }
-
-  @VisibleForTesting
-  public long getExactlyIndexOfTreeNode(ArcticSplit arcticSplit) {
+  public List<DataTreeNode> getExactlyTreeNodes(ArcticSplit arcticSplit) {
     DataTreeNode dataTreeNode = arcticSplit.dataTreeNode();
-    long index = dataTreeNode.index();
     long mask = dataTreeNode.mask();
 
     synchronized (lock) {
@@ -211,27 +206,23 @@ public class ShuffleSplitAssigner implements SplitAssigner {
       }
     }
 
-    boolean modifyDataTreeNode = mask != currentMaskOfTreeNode;
-    boolean greaterThanCurrent = mask > currentMaskOfTreeNode;
-    ++mask;
-    while (mask != currentMaskOfTreeNode + 1) {
-      if (greaterThanCurrent) {
-        mask = mask >> 1;
-        index = index >> 1;
-      } else {
-        mask = mask << 1;
-        index = index << 1;
-      }
-    }
+    return scanTreeNode(dataTreeNode);
+  }
 
-    // Have to modify the dataTreeNode of the arcticSplit due to the mask of this split is diff from the current
-    // mask assigned to source readers.
-    if (modifyDataTreeNode) {
-      DataTreeNode expectedNode = DataTreeNode.of(currentMaskOfTreeNode, index);
-      LOG.info("original dataTreeNode is {}, new dataTreeNode is {}.", dataTreeNode, expectedNode);
-      arcticSplit.modifyTreeNode(expectedNode);
+  private List<DataTreeNode> scanTreeNode(DataTreeNode dataTreeNode) {
+    long mask = dataTreeNode.mask();
+    if (mask == currentMaskOfTreeNode) {
+      return Collections.singletonList(dataTreeNode);
+    } else if (mask > currentMaskOfTreeNode) {
+      // move up one layer
+      return scanTreeNode(dataTreeNode.parent());
+    } else {
+      // go down one layer
+      List<DataTreeNode> allNodes = new ArrayList<>();
+      allNodes.addAll(scanTreeNode(dataTreeNode.left()));
+      allNodes.addAll(scanTreeNode(dataTreeNode.right()));
+      return allNodes;
     }
-    return index;
   }
 
   /**

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -103,6 +103,7 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
       this.temporalJoinSplits = enumState.temporalJoinSplits();
     }
     this.dimTable = dimTable;
+    LOG.info("dimTable: {}", dimTable);
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ArcticSplit.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ArcticSplit.java
@@ -102,4 +102,6 @@ public abstract class ArcticSplit implements SourceSplit, Serializable, Comparab
                 .add("transactionId", primaryKeyedFile.transactionId())
                 .toString()).collect(Collectors.toList()));
   }
+
+  public abstract ArcticSplit copy();
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ChangelogSplit.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ChangelogSplit.java
@@ -80,6 +80,11 @@ public class ChangelogSplit extends ArcticSplit {
   }
 
   @Override
+  public ArcticSplit copy() {
+    return new ChangelogSplit(insertScanTasks, deleteScanTasks, taskIndex);
+  }
+
+  @Override
   public String splitId() {
     return MoreObjects.toStringHelper(this)
         .add("insertTasks", toString(insertScanTasks))

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/SnapshotSplit.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/SnapshotSplit.java
@@ -81,6 +81,11 @@ public class SnapshotSplit extends ArcticSplit {
     insertRecordOffset = (long) offsets[1];
   }
 
+  @Override
+  public ArcticSplit copy() {
+    return new SnapshotSplit(insertScanTasks, taskIndex);
+  }
+
   public int insertFileOffset() {
     return insertFileOffset;
   }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/ChangeLogDataIterator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/ChangeLogDataIterator.java
@@ -51,10 +51,12 @@ public class ChangeLogDataIterator<T> extends DataIterator<T> {
       Function<T, Long> arcticFileOffsetGetter,
       Function<T, T> arcticMetaColumnRemover,
       Function<ChangeActionTrans<T>, T> changeActionTransformer) {
-    super(fileScanTaskReader, Collections.emptyList(), arcticFileOffsetGetter);
-    this.insertDataIterator = initDataIterator(fileScanTaskReader, arcticFileOffsetGetter, insertTasks);
+    super(fileScanTaskReader, Collections.emptyList(), arcticFileOffsetGetter, arcticMetaColumnRemover);
+    this.insertDataIterator =
+        new DataIterator<>(fileScanTaskReader, insertTasks, arcticFileOffsetGetter, arcticMetaColumnRemover);
     if (deleteTasks != null && !deleteTasks.isEmpty()) {
-      this.deleteDataIterator = initDataIterator(fileScanTaskReader, arcticFileOffsetGetter, deleteTasks);
+      this.deleteDataIterator =
+          new DataIterator<>(fileScanTaskReader, deleteTasks, arcticFileOffsetGetter, arcticMetaColumnRemover);
     }
     this.arcticMetaColumnRemover = arcticMetaColumnRemover;
     this.changeActionTransformer = changeActionTransformer;
@@ -149,16 +151,6 @@ public class ChangeLogDataIterator<T> extends DataIterator<T> {
 
   public long deleteRecordOffset() {
     return deleteDataIterator.recordOffset();
-  }
-
-  private DataIterator<T> initDataIterator(
-      FileScanTaskReader<T> fileScanTaskReader,
-      Function<T, Long> arcticFileOffsetGetter,
-      Collection<ArcticFileScanTask> tasks) {
-    return new DataIterator<>(
-        fileScanTaskReader,
-        tasks,
-        arcticFileOffsetGetter);
   }
 
   private static class QueueHolder<T> {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/DataIterator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/DataIterator.java
@@ -49,15 +49,18 @@ public class DataIterator<T> implements CloseableIterator<T> {
   private long recordOffset;
   private long currentArcticFileOffset;
   private final Function<T, Long> arcticFileOffsetGetter;
+  private final Function<T, T> arcticMetaColumnRemover;
 
   public DataIterator(
       FileScanTaskReader<T> fileScanTaskReader,
       Collection<ArcticFileScanTask> tasks,
-      Function<T, Long> arcticFileOffsetGetter) {
+      Function<T, Long> arcticFileOffsetGetter,
+      Function<T, T> arcticMetaColumnRemover) {
     this.fileScanTaskReader = fileScanTaskReader;
     this.tasks = tasks.iterator();
     this.taskSize = tasks.size();
     this.arcticFileOffsetGetter = arcticFileOffsetGetter;
+    this.arcticMetaColumnRemover = arcticMetaColumnRemover;
 
     this.currentIterator = CloseableIterator.empty();
 
@@ -119,7 +122,7 @@ public class DataIterator<T> implements CloseableIterator<T> {
     recordOffset += 1;
     T row = currentIterator.next();
     currentArcticFileOffset = arcticFileOffsetGetter.apply(row);
-    return row;
+    return arcticMetaColumnRemover.apply(row);
   }
 
   public boolean currentFileHasNext() {
@@ -173,7 +176,7 @@ public class DataIterator<T> implements CloseableIterator<T> {
   private static class EmptyIterator<T> extends DataIterator<T> {
 
     public EmptyIterator() {
-      super(null, Collections.emptyList(), t -> Long.MIN_VALUE);
+      super(null, Collections.emptyList(), t -> Long.MIN_VALUE, t -> t);
     }
 
     @Override

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -18,13 +18,8 @@
 
 package com.netease.arctic.flink.table;
 
-import com.netease.arctic.flink.shuffle.ReadShuffleRulePolicy;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.table.ArcticTable;
-import com.netease.arctic.table.DistributionHashMode;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
@@ -37,14 +32,11 @@ import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDo
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,10 +49,6 @@ import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
-import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
-import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
-import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_MODE;
-import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_MODE_DEFAULT;
 
 /**
  * Flink table api that generates source operators.
@@ -133,79 +121,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
     Preconditions.checkArgument(origin instanceof DataStreamScanProvider,
         "file or log ScanRuntimeProvider should be DataStreamScanProvider, but provided is " +
             origin.getClass());
-    DataStreamScanProvider dataStreamScanProvider = (DataStreamScanProvider) origin;
-
-    DistributionHashMode distributionHashMode = getDistributionHashMode();
-    return new DataStreamScanProvider() {
-      @Override
-      public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
-        DataStream<RowData> ds = distribute(dataStreamScanProvider.produceDataStream(execEnv), distributionHashMode);
-        UserGroupInformation.reset();
-        LOG.info("ugi reset");
-        return ds;
-      }
-
-      @Override
-      public boolean isBounded() {
-        return false;
-      }
-    };
-  }
-
-  private DistributionHashMode getDistributionHashMode() {
-    String modeName = PropertyUtil.propertyAsString(properties,
-        READ_DISTRIBUTION_MODE,
-        READ_DISTRIBUTION_MODE_DEFAULT);
-
-    DistributionMode mode = DistributionMode.fromName(modeName);
-    switch (mode) {
-      case NONE:
-        return DistributionHashMode.NONE;
-      case HASH:
-        String hashMode = PropertyUtil.propertyAsString(properties, READ_DISTRIBUTION_HASH_MODE, null);
-        if (hashMode == null) {
-          // default none shuffle for unkeyed table
-          if (arcticTable.isUnkeyedTable()) {
-            return DistributionHashMode.NONE;
-          }
-          hashMode = READ_DISTRIBUTION_HASH_MODE_DEFAULT;
-        }
-        return DistributionHashMode.valueOfDesc(hashMode);
-      default:
-        return DistributionHashMode.AUTO;
-    }
-  }
-
-  private DataStream<RowData> distribute(DataStream<RowData> source, DistributionHashMode mode) {
-    ShuffleHelper helper = ShuffleHelper.build(arcticTable, readSchema, flinkSchemaRowType);
-    if (mode == DistributionHashMode.AUTO) {
-      mode = DistributionHashMode.autoSelect(arcticTable.isKeyedTable(), helper.isPartitionKeyExist());
-    }
-    LOG.info("source distribute mode in effect. {}", mode);
-    switch (mode) {
-      case NONE:
-        return source;
-      case PRIMARY_KEY:
-        Preconditions.checkArgument(arcticTable.isKeyedTable(),
-            "illegal shuffle policy " + mode.getDesc() + " for table without primary key");
-        return hash(source, helper, DistributionHashMode.PRIMARY_KEY);
-      case PARTITION_KEY:
-        Preconditions.checkArgument(!arcticTable.spec().isUnpartitioned(),
-            "illegal shuffle policy " + mode.getDesc() + " for table without partition key");
-        return hash(source, helper, DistributionHashMode.PARTITION_KEY);
-      case PRIMARY_PARTITION_KEY:
-        Preconditions.checkArgument(arcticTable.isKeyedTable() && !arcticTable.spec().isUnpartitioned(),
-            "illegal shuffle policy " + mode.getDesc() +
-                " for table without primary key or partition key");
-        return hash(source, helper, DistributionHashMode.PRIMARY_PARTITION_KEY);
-      default:
-        throw new RuntimeException("Unrecognized " + READ_DISTRIBUTION_HASH_MODE + ": " + mode);
-    }
-  }
-
-  public DataStream<RowData> hash(DataStream<RowData> source, ShuffleHelper helper, DistributionHashMode hashMode) {
-    ReadShuffleRulePolicy shuffleRulePolicy = new ReadShuffleRulePolicy(helper, hashMode);
-    return source.partitionCustom(shuffleRulePolicy.generatePartitioner(), shuffleRulePolicy.generateKeySelector());
+    return origin;
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -20,7 +20,6 @@ package com.netease.arctic.flink.table;
 
 import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -31,24 +30,14 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
-import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 
 /**
  * Flink table api that generates source operators.
@@ -63,51 +52,24 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
   private final ScanTableSource arcticDynamicSource;
   private final ArcticTable arcticTable;
   private final Map<String, String> properties;
-  private RowType flinkSchemaRowType;
-  private Schema readSchema;
 
   @Nullable
   protected WatermarkStrategy<RowData> watermarkStrategy;
-
-  public ArcticDynamicSource(String tableName,
-                             ScanTableSource arcticDynamicSource,
-                             ArcticTable arcticTable,
-                             Schema readSchema,
-                             RowType flinkSchemaRowType,
-                             Map<String, String> properties) {
-    this.tableName = tableName;
-    this.arcticDynamicSource = arcticDynamicSource;
-    this.arcticTable = arcticTable;
-    this.properties = properties;
-    this.readSchema = readSchema;
-    this.flinkSchemaRowType = flinkSchemaRowType;
-  }
 
   /**
    * @param tableName           tableName
    * @param arcticDynamicSource underlying source
    * @param arcticTable         arcticTable
-   * @param projectedSchema     read schema
    * @param properties          With all ArcticTable properties and sql options
    */
   public ArcticDynamicSource(String tableName,
                              ScanTableSource arcticDynamicSource,
                              ArcticTable arcticTable,
-                             TableSchema projectedSchema,
                              Map<String, String> properties) {
     this.tableName = tableName;
     this.arcticDynamicSource = arcticDynamicSource;
     this.arcticTable = arcticTable;
     this.properties = properties;
-
-    if (projectedSchema == null) {
-      readSchema = arcticTable.schema();
-      flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
-    } else {
-      readSchema = TypeUtil.reassignIds(
-          FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema());
-      flinkSchemaRowType = (RowType) projectedSchema.toRowDataType().getLogicalType();
-    }
   }
 
   @Override
@@ -126,8 +88,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
 
   @Override
   public DynamicTableSource copy() {
-    return new ArcticDynamicSource(tableName, arcticDynamicSource, arcticTable, readSchema, flinkSchemaRowType,
-        properties);
+    return new ArcticDynamicSource(tableName, arcticDynamicSource, arcticTable, properties);
   }
 
   @Override
@@ -155,20 +116,12 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
 
   @Override
   public void applyProjection(int[][] projectedFields) {
-    int[] projectionFields = new int[projectedFields.length];
     for (int i = 0; i < projectedFields.length; i++) {
       org.apache.flink.util.Preconditions.checkArgument(
           projectedFields[i].length == 1,
           "Don't support nested projection now.");
-      projectionFields[i] = projectedFields[i][0];
     }
-    final List<Types.NestedField> columns = readSchema.columns();
-    List<Types.NestedField> projectedColumns = Arrays.stream(projectionFields)
-        .mapToObj(columns::get)
-        .collect(Collectors.toList());
 
-    readSchema = new Schema(addPrimaryKey(projectedColumns, arcticTable));
-    flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);
     }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -51,7 +51,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -139,7 +138,6 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
           projectedColumns,
           Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
 
-      addPrimaryKey(builder, table, tableSchema, projectedColumns);
       TableSchema ts = builder.build();
       LOG.info("TableSchema builder after addPrimaryKey, schema:{}", ts);
       return ts;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -154,8 +154,8 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         arcticDynamicSource = createLogSource(arcticTable, context, confWithAll);
     }
 
-    return new ArcticDynamicSource(identifier.getObjectName(), arcticDynamicSource, arcticTable, tableSchema,
-        arcticTable.properties());
+    return new ArcticDynamicSource(
+        identifier.getObjectName(), arcticDynamicSource, arcticTable, arcticTable.properties());
   }
 
   @Override
@@ -245,10 +245,10 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     String startupMode = tableOptions.get(ArcticValidator.SCAN_STARTUP_MODE);
     long startupTimestampMillis = 0L;
     if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
-      startupTimestampMillis = Preconditions.checkNotNull(
-          tableOptions.get(ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS),
-          String.format("'%s' should be set in '%s' mode",
-              ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP));
+      startupTimestampMillis =
+          Preconditions.checkNotNull(tableOptions.get(ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS),
+              String.format("'%s' should be set in '%s' mode",
+                  ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP));
     }
 
     LOG.info("build log source");

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -141,10 +141,21 @@ public class FlinkSource {
         return buildUnkeyedTableSource();
       }
 
+      boolean dimTable = CompatibleFlinkPropertyUtil.propertyAsBoolean(properties, DIM_TABLE_ENABLE.key(),
+          DIM_TABLE_ENABLE.defaultValue());
+      RowType rowType;
+
       if (projectedSchema == null) {
         contextBuilder.project(arcticTable.schema());
+        rowType = FlinkSchemaUtil.convert(arcticTable.schema());
       } else {
         contextBuilder.project(FlinkSchemaUtil.convert(arcticTable.schema(), filterWatermark(projectedSchema)));
+        // If dim table is enabled, we reserve a RowTime field in Emitter.
+        if (dimTable) {
+          rowType = toRowType(projectedSchema);
+        } else {
+          rowType = toRowType(filterWatermark(projectedSchema));
+        }
       }
       contextBuilder.fromProperties(properties);
       ArcticScanContext scanContext = contextBuilder.build();
@@ -158,20 +169,6 @@ public class FlinkSource {
           scanContext.caseSensitive(),
           arcticTable.io()
       );
-
-      boolean dimTable = CompatibleFlinkPropertyUtil.propertyAsBoolean(properties, DIM_TABLE_ENABLE.key(),
-          DIM_TABLE_ENABLE.defaultValue());
-      RowType rowType;
-      if (projectedSchema != null) {
-        // If dim table is enabled, we reserve a RowTime field in Emitter.
-        if (dimTable) {
-          rowType = toRowType(projectedSchema);
-        } else {
-          rowType = toRowType(filterWatermark(projectedSchema));
-        }
-      } else {
-        rowType = FlinkSchemaUtil.convert(scanContext.project());
-      }
 
       return env.fromSource(
           new ArcticSource<>(tableLoader, scanContext, rowDataReaderFunction,

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
@@ -89,7 +89,7 @@ public class FlinkTestBase extends TableTestBase {
   @ClassRule
   public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
       MiniClusterResource.createWithClassloaderCheckDisabled();
-  
+
   public static boolean IS_LOCAL = true;
   public static String METASTORE_URL = "thrift://127.0.0.1:" + AMS.port();
 
@@ -315,10 +315,15 @@ public class FlinkTestBase extends TableTestBase {
 
   protected static TaskWriter<RowData> createKeyedTaskWriter(KeyedTable keyedTable, RowType rowType, long transactionId,
                                                              boolean base) {
+    return createKeyedTaskWriter(keyedTable, rowType, transactionId, base, 3);
+  }
+
+  protected static TaskWriter<RowData> createKeyedTaskWriter(KeyedTable keyedTable, RowType rowType, long transactionId,
+                                                             boolean base, long mask) {
     ArcticRowDataTaskWriterFactory taskWriterFactory =
         new ArcticRowDataTaskWriterFactory(keyedTable, rowType, base);
     taskWriterFactory.setTransactionId(transactionId);
-    taskWriterFactory.setMask(3);
+    taskWriterFactory.setMask(mask);
     taskWriterFactory.initialize(0, 0);
     return taskWriterFactory.create();
   }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/TemporalJoinSplitsThreadSafeTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/TemporalJoinSplitsThreadSafeTest.java
@@ -95,6 +95,11 @@ public class TemporalJoinSplitsThreadSafeTest {
     }
 
     @Override
+    public ArcticSplit copy() {
+      return new TestArcticSplit(splitId);
+    }
+
+    @Override
     public String splitId() {
       return splitId;
     }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -67,7 +67,7 @@ import static com.netease.arctic.ams.api.MockArcticMetastoreServer.TEST_CATALOG_
 import static com.netease.arctic.table.TableProperties.LOCATION;
 
 public class TestWatermark extends FlinkTestBase {
-  public static final Logger LOG = LoggerFactory.getLogger(TestJoin.class);
+  public static final Logger LOG = LoggerFactory.getLogger(TestWatermark.class);
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -86,21 +86,7 @@ public class TestWatermark extends FlinkTestBase {
   }
 
   @Test(timeout = 30000)
-  public void testWatermarkWithoutPKs() throws Exception {
-    testWatermark(0);
-  }
-
-  @Test(timeout = 30000)
-  public void testWatermarkWithPartialPKs() throws Exception {
-    testWatermark(1);
-  }
-
-  @Test(timeout = 30000)
-  public void testWatermarkWithFullPKs() throws Exception {
-    testWatermark(2);
-  }
-
-  public void testWatermark(int selectType) throws Exception {
+  public void testWatermark() throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
@@ -135,16 +121,7 @@ public class TestWatermark extends FlinkTestBase {
 
     sql("create table d (tt as cast(op_time as timestamp(3)), watermark for tt as tt) like %s", table);
 
-    Table source;
-    if (selectType == 0) {
-      source = getTableEnv().sqlQuery("select is_true from d");
-    } else if (selectType == 1) {
-      source = getTableEnv().sqlQuery("select id, is_true from d");
-    } else if (selectType == 2) {
-      source = getTableEnv().sqlQuery("select id, is_true, user_id from d");
-    } else {
-      throw new IllegalArgumentException("Unsupported select type " + selectType);
-    }
+    Table source = getTableEnv().sqlQuery("select is_true from d");
 
     WatermarkTestOperator op = new WatermarkTestOperator();
     getTableEnv().toRetractStream(source, RowData.class)

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/FlinkSchemaUtil.java
@@ -141,6 +141,7 @@ public class FlinkSchemaUtil {
    * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
    * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
+  @Deprecated
   public static List<Types.NestedField> addPrimaryKey(
       List<Types.NestedField> projectedColumns, ArcticTable table) {
     List<String> primaryKeys = table.isUnkeyedTable() ? Collections.EMPTY_LIST
@@ -166,6 +167,7 @@ public class FlinkSchemaUtil {
    * Primary keys are the required fields to guarantee that readers can read keyed table in right order, due to the
    * automatic scaling in/out of nodes. The required fields should be added even though projection push down
    */
+  @Deprecated
   public static void addPrimaryKey(
       TableSchema.Builder builder, ArcticTable table, TableSchema tableSchema, String[] projectedColumns) {
     Set<String> projectedNames = Arrays.stream(projectedColumns).collect(Collectors.toSet());
@@ -183,5 +185,5 @@ public class FlinkSchemaUtil {
           .orElseThrow(() -> new ValidationException("Arctic primary key should be declared in table")));
     });
   }
-  
+
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -294,7 +294,7 @@ public class ArcticCatalog extends AbstractCatalog {
     validateFlinkTable(table);
 
     TableSchema tableSchema = table.getSchema();
-    TableSchema.Builder b = TableSchema.builder();
+    TableSchema.Builder flinkSchemaBuilder = TableSchema.builder();
 
     tableSchema.getTableColumns().forEach(c -> {
       List<WatermarkSpec> ws = tableSchema.getWatermarkSpecs();
@@ -303,9 +303,12 @@ public class ArcticCatalog extends AbstractCatalog {
           return;
         }
       }
-      b.field(c.getName(), c.getType());
+      flinkSchemaBuilder.field(c.getName(), c.getType());
     });
-    TableSchema tableSchemaWithoutWatermark = b.build();
+    if (tableSchema.getPrimaryKey().isPresent()) {
+      flinkSchemaBuilder.primaryKey(tableSchema.getPrimaryKey().get().getColumns().toArray(new String[0]));
+    }
+    TableSchema tableSchemaWithoutWatermark = flinkSchemaBuilder.build();
 
     Schema icebergSchema = FlinkSchemaUtil.convert(tableSchemaWithoutWatermark);
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/PartitionAndNodeGroup.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/PartitionAndNodeGroup.java
@@ -75,7 +75,7 @@ public class PartitionAndNodeGroup {
    *
    * @param insert if plan insert files or not
    * @param nodes  the key of nodes is partition info which the file located, the value of nodes is hashmap of
-   *               transactionId and {@link Node}
+   *               arctic tree node id and {@link Node}
    */
   private void plan(boolean insert, Map<String, Map<Long, Node>> nodes) {
     Collection<ArcticFileScanTask> tasks = insert ? insertTasks : deleteTasks;
@@ -85,15 +85,15 @@ public class PartitionAndNodeGroup {
 
     tasks.forEach(task -> {
       String partitionKey = task.file().partition().toString();
-      Long index = task.file().node().index();
+      Long nodeId = task.file().node().getId();
       Map<Long, Node> indexNodes = nodes.getOrDefault(partitionKey, new HashMap<>());
-      Node node = indexNodes.getOrDefault(index, new Node());
+      Node node = indexNodes.getOrDefault(nodeId, new Node());
       if (insert) {
         node.addInsert(task);
       } else {
         node.addDelete(task);
       }
-      indexNodes.put(index, node);
+      indexNodes.put(nodeId, node);
       nodes.put(partitionKey, indexNodes);
     });
   }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -196,6 +196,22 @@ public class ShuffleSplitAssigner implements SplitAssigner {
     }
   }
 
+  /**
+   * <p>
+   * |mask=0          o
+   * |             /     \
+   * |mask=1     o        o
+   * |         /   \    /   \
+   * |mask=3  o     o  o     o
+   * <p>
+   * Different data files may locate in different layers when multi snapshots are committed, so arctic source reading
+   * should consider emitting the records and keeping ordering. According to the dataTreeNode of the arctic split and
+   * the currentMaskOfTreeNode, return the exact tree node list which may move up or go down layers in the arctic tree.
+   * </p>
+   *
+   * @param arcticSplit arctic split.
+   * @return the exact tree node list.
+   */
   public List<DataTreeNode> getExactlyTreeNodes(ArcticSplit arcticSplit) {
     DataTreeNode dataTreeNode = arcticSplit.dataTreeNode();
     long mask = dataTreeNode.mask();

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/assigner/ShuffleSplitAssigner.java
@@ -23,7 +23,6 @@ import com.netease.arctic.data.PrimaryKeyedFile;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
 import com.netease.arctic.flink.read.hybrid.split.ArcticSplitState;
 import com.netease.arctic.scan.ArcticFileScanTask;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.slf4j.Logger;
@@ -124,7 +123,6 @@ public class ShuffleSplitAssigner implements SplitAssigner {
   @Override
   public void onDiscoveredSplits(Collection<ArcticSplit> splits) {
     splits.forEach(this::putArcticIntoQueue);
-    totalSplitNum += splits.size();
   }
 
   @Override
@@ -133,22 +131,25 @@ public class ShuffleSplitAssigner implements SplitAssigner {
   }
 
   void putArcticIntoQueue(ArcticSplit split) {
-    int subtaskId = getSubtaskIdByArcticSplit(split);
-    PriorityBlockingQueue<ArcticSplit> queue = subtaskSplitMap.getOrDefault(subtaskId, new PriorityBlockingQueue<>());
-    LOG.info("put split into queue: {}", split);
-    queue.add(split);
-    subtaskSplitMap.put(subtaskId, queue);
-  }
+    List<DataTreeNode> exactlyTreeNodes = getExactlyTreeNodes(split);
 
-  private int getSubtaskIdByArcticSplit(ArcticSplit arcticSplit) {
-    PrimaryKeyedFile file = findAnyFileInArcticSplit(arcticSplit);
-    long partitionIndexKey = partitionAndIndexHashCode(
-        file.partition().toString(), arcticSplit);
+    PrimaryKeyedFile file = findAnyFileInArcticSplit(split);
 
-    int subtaskId = partitionIndexSubtaskMap.computeIfAbsent(
-        partitionIndexKey, key -> (partitionIndexSubtaskMap.size() + 1) % totalParallelism);
-    LOG.info("partition = {}, index = {}, subtaskId = {}", file.partition().toString(), file.node().index(), subtaskId);
-    return subtaskId;
+    for (DataTreeNode node : exactlyTreeNodes) {
+      long partitionIndexKey = Math.abs(file.partition().toString().hashCode() + node.index());
+      int subtaskId = partitionIndexSubtaskMap.computeIfAbsent(
+          partitionIndexKey, key -> (partitionIndexSubtaskMap.size() + 1) % totalParallelism);
+      LOG.info("partition = {}, (mask, index) = ({}, {}), subtaskId = {}",
+          file.partition().toString(), node.mask(), node.index(), subtaskId);
+
+      PriorityBlockingQueue<ArcticSplit> queue = subtaskSplitMap.getOrDefault(subtaskId, new PriorityBlockingQueue<>());
+      ArcticSplit copiedSplit = split.copy();
+      copiedSplit.modifyTreeNode(node);
+      LOG.info("put split into queue: {}", copiedSplit);
+      queue.add(copiedSplit);
+      totalSplitNum = totalSplitNum + 1;
+      subtaskSplitMap.put(subtaskId, queue);
+    }
   }
 
   @Override
@@ -195,14 +196,8 @@ public class ShuffleSplitAssigner implements SplitAssigner {
     }
   }
 
-  private long partitionAndIndexHashCode(String partition, ArcticSplit arcticSplit) {
-    return Math.abs(partition.hashCode() + getExactlyIndexOfTreeNode(arcticSplit));
-  }
-
-  @VisibleForTesting
-  public long getExactlyIndexOfTreeNode(ArcticSplit arcticSplit) {
+  public List<DataTreeNode> getExactlyTreeNodes(ArcticSplit arcticSplit) {
     DataTreeNode dataTreeNode = arcticSplit.dataTreeNode();
-    long index = dataTreeNode.index();
     long mask = dataTreeNode.mask();
 
     synchronized (lock) {
@@ -211,27 +206,23 @@ public class ShuffleSplitAssigner implements SplitAssigner {
       }
     }
 
-    boolean modifyDataTreeNode = mask != currentMaskOfTreeNode;
-    boolean greaterThanCurrent = mask > currentMaskOfTreeNode;
-    ++mask;
-    while (mask != currentMaskOfTreeNode + 1) {
-      if (greaterThanCurrent) {
-        mask = mask >> 1;
-        index = index >> 1;
-      } else {
-        mask = mask << 1;
-        index = index << 1;
-      }
-    }
+    return scanTreeNode(dataTreeNode);
+  }
 
-    // Have to modify the dataTreeNode of the arcticSplit due to the mask of this split is diff from the current
-    // mask assigned to source readers.
-    if (modifyDataTreeNode) {
-      DataTreeNode expectedNode = DataTreeNode.of(currentMaskOfTreeNode, index);
-      LOG.info("original dataTreeNode is {}, new dataTreeNode is {}.", dataTreeNode, expectedNode);
-      arcticSplit.modifyTreeNode(expectedNode);
+  private List<DataTreeNode> scanTreeNode(DataTreeNode dataTreeNode) {
+    long mask = dataTreeNode.mask();
+    if (mask == currentMaskOfTreeNode) {
+      return Collections.singletonList(dataTreeNode);
+    } else if (mask > currentMaskOfTreeNode) {
+      // move up one layer
+      return scanTreeNode(dataTreeNode.parent());
+    } else {
+      // go down one layer
+      List<DataTreeNode> allNodes = new ArrayList<>();
+      allNodes.addAll(scanTreeNode(dataTreeNode.left()));
+      allNodes.addAll(scanTreeNode(dataTreeNode.right()));
+      return allNodes;
     }
-    return index;
   }
 
   /**

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ArcticSplit.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ArcticSplit.java
@@ -102,4 +102,6 @@ public abstract class ArcticSplit implements SourceSplit, Serializable, Comparab
                 .add("transactionId", primaryKeyedFile.transactionId())
                 .toString()).collect(Collectors.toList()));
   }
+
+  public abstract ArcticSplit copy();
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ChangelogSplit.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/ChangelogSplit.java
@@ -80,6 +80,11 @@ public class ChangelogSplit extends ArcticSplit {
   }
 
   @Override
+  public ArcticSplit copy() {
+    return new ChangelogSplit(insertScanTasks, deleteScanTasks, taskIndex);
+  }
+
+  @Override
   public String splitId() {
     return MoreObjects.toStringHelper(this)
         .add("insertTasks", toString(insertScanTasks))

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/SnapshotSplit.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/split/SnapshotSplit.java
@@ -81,6 +81,11 @@ public class SnapshotSplit extends ArcticSplit {
     insertRecordOffset = (long) offsets[1];
   }
 
+  @Override
+  public ArcticSplit copy() {
+    return new SnapshotSplit(insertScanTasks, taskIndex);
+  }
+
   public int insertFileOffset() {
     return insertFileOffset;
   }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/ChangeLogDataIterator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/ChangeLogDataIterator.java
@@ -51,10 +51,12 @@ public class ChangeLogDataIterator<T> extends DataIterator<T> {
       Function<T, Long> arcticFileOffsetGetter,
       Function<T, T> arcticMetaColumnRemover,
       Function<ChangeActionTrans<T>, T> changeActionTransformer) {
-    super(fileScanTaskReader, Collections.emptyList(), arcticFileOffsetGetter);
-    this.insertDataIterator = initDataIterator(fileScanTaskReader, arcticFileOffsetGetter, insertTasks);
+    super(fileScanTaskReader, Collections.emptyList(), arcticFileOffsetGetter, arcticMetaColumnRemover);
+    this.insertDataIterator =
+        new DataIterator<>(fileScanTaskReader, insertTasks, arcticFileOffsetGetter, arcticMetaColumnRemover);
     if (deleteTasks != null && !deleteTasks.isEmpty()) {
-      this.deleteDataIterator = initDataIterator(fileScanTaskReader, arcticFileOffsetGetter, deleteTasks);
+      this.deleteDataIterator =
+          new DataIterator<>(fileScanTaskReader, deleteTasks, arcticFileOffsetGetter, arcticMetaColumnRemover);
     }
     this.arcticMetaColumnRemover = arcticMetaColumnRemover;
     this.changeActionTransformer = changeActionTransformer;
@@ -149,16 +151,6 @@ public class ChangeLogDataIterator<T> extends DataIterator<T> {
 
   public long deleteRecordOffset() {
     return deleteDataIterator.recordOffset();
-  }
-
-  private DataIterator<T> initDataIterator(
-      FileScanTaskReader<T> fileScanTaskReader,
-      Function<T, Long> arcticFileOffsetGetter,
-      Collection<ArcticFileScanTask> tasks) {
-    return new DataIterator<>(
-        fileScanTaskReader,
-        tasks,
-        arcticFileOffsetGetter);
   }
 
   private static class QueueHolder<T> {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/DataIterator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/DataIterator.java
@@ -49,15 +49,18 @@ public class DataIterator<T> implements CloseableIterator<T> {
   private long recordOffset;
   private long currentArcticFileOffset;
   private final Function<T, Long> arcticFileOffsetGetter;
+  private final Function<T, T> arcticMetaColumnRemover;
 
   public DataIterator(
       FileScanTaskReader<T> fileScanTaskReader,
       Collection<ArcticFileScanTask> tasks,
-      Function<T, Long> arcticFileOffsetGetter) {
+      Function<T, Long> arcticFileOffsetGetter,
+      Function<T, T> arcticMetaColumnRemover) {
     this.fileScanTaskReader = fileScanTaskReader;
     this.tasks = tasks.iterator();
     this.taskSize = tasks.size();
     this.arcticFileOffsetGetter = arcticFileOffsetGetter;
+    this.arcticMetaColumnRemover = arcticMetaColumnRemover;
 
     this.currentIterator = CloseableIterator.empty();
 
@@ -119,7 +122,7 @@ public class DataIterator<T> implements CloseableIterator<T> {
     recordOffset += 1;
     T row = currentIterator.next();
     currentArcticFileOffset = arcticFileOffsetGetter.apply(row);
-    return row;
+    return arcticMetaColumnRemover.apply(row);
   }
 
   public boolean currentFileHasNext() {
@@ -173,7 +176,7 @@ public class DataIterator<T> implements CloseableIterator<T> {
   private static class EmptyIterator<T> extends DataIterator<T> {
 
     public EmptyIterator() {
-      super(null, Collections.emptyList(), t -> Long.MIN_VALUE);
+      super(null, Collections.emptyList(), t -> Long.MIN_VALUE, t -> t);
     }
 
     @Override

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -20,7 +20,6 @@ package com.netease.arctic.flink.table;
 
 import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -31,24 +30,14 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
-import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
 
 /**
  * Flink table api that generates source operators.
@@ -63,51 +52,24 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
   private final ScanTableSource arcticDynamicSource;
   private final ArcticTable arcticTable;
   private final Map<String, String> properties;
-  private RowType flinkSchemaRowType;
-  private Schema readSchema;
 
   @Nullable
   protected WatermarkStrategy<RowData> watermarkStrategy;
-
-  public ArcticDynamicSource(String tableName,
-                             ScanTableSource arcticDynamicSource,
-                             ArcticTable arcticTable,
-                             Schema readSchema,
-                             RowType flinkSchemaRowType,
-                             Map<String, String> properties) {
-    this.tableName = tableName;
-    this.arcticDynamicSource = arcticDynamicSource;
-    this.arcticTable = arcticTable;
-    this.properties = properties;
-    this.readSchema = readSchema;
-    this.flinkSchemaRowType = flinkSchemaRowType;
-  }
 
   /**
    * @param tableName           tableName
    * @param arcticDynamicSource underlying source
    * @param arcticTable         arcticTable
-   * @param projectedSchema     read schema
    * @param properties          With all ArcticTable properties and sql options
    */
   public ArcticDynamicSource(String tableName,
                              ScanTableSource arcticDynamicSource,
                              ArcticTable arcticTable,
-                             TableSchema projectedSchema,
                              Map<String, String> properties) {
     this.tableName = tableName;
     this.arcticDynamicSource = arcticDynamicSource;
     this.arcticTable = arcticTable;
     this.properties = properties;
-
-    if (projectedSchema == null) {
-      readSchema = arcticTable.schema();
-      flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
-    } else {
-      readSchema = TypeUtil.reassignIds(
-          FlinkSchemaUtil.convert(filterWatermark(projectedSchema)), arcticTable.schema());
-      flinkSchemaRowType = (RowType) projectedSchema.toRowDataType().getLogicalType();
-    }
   }
 
   @Override
@@ -126,8 +88,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
 
   @Override
   public DynamicTableSource copy() {
-    return new ArcticDynamicSource(tableName, arcticDynamicSource, arcticTable, readSchema, flinkSchemaRowType,
-        properties);
+    return new ArcticDynamicSource(tableName, arcticDynamicSource, arcticTable, properties);
   }
 
   @Override
@@ -155,20 +116,12 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
 
   @Override
   public void applyProjection(int[][] projectedFields) {
-    int[] projectionFields = new int[projectedFields.length];
     for (int i = 0; i < projectedFields.length; i++) {
       org.apache.flink.util.Preconditions.checkArgument(
           projectedFields[i].length == 1,
           "Don't support nested projection now.");
-      projectionFields[i] = projectedFields[i][0];
     }
-    final List<Types.NestedField> columns = readSchema.columns();
-    List<Types.NestedField> projectedColumns = Arrays.stream(projectionFields)
-        .mapToObj(columns::get)
-        .collect(Collectors.toList());
 
-    readSchema = new Schema(addPrimaryKey(projectedColumns, arcticTable));
-    flinkSchemaRowType = FlinkSchemaUtil.convert(readSchema);
     if (arcticDynamicSource instanceof SupportsProjectionPushDown) {
       ((SupportsProjectionPushDown) arcticDynamicSource).applyProjection(projectedFields);
     }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -18,16 +18,10 @@
 
 package com.netease.arctic.flink.table;
 
-import com.netease.arctic.flink.shuffle.ReadShuffleRulePolicy;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.table.ArcticTable;
-import com.netease.arctic.table.DistributionHashMode;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
@@ -38,14 +32,11 @@ import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDo
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,10 +49,6 @@ import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.FlinkSchemaUtil.filterWatermark;
-import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE;
-import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_HASH_MODE_DEFAULT;
-import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_MODE;
-import static com.netease.arctic.table.TableProperties.READ_DISTRIBUTION_MODE_DEFAULT;
 
 /**
  * Flink table api that generates source operators.
@@ -134,82 +121,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
     Preconditions.checkArgument(origin instanceof DataStreamScanProvider,
         "file or log ScanRuntimeProvider should be DataStreamScanProvider, but provided is " +
             origin.getClass());
-    DataStreamScanProvider dataStreamScanProvider = (DataStreamScanProvider) origin;
-
-    DistributionHashMode distributionHashMode = getDistributionHashMode();
-    return new DataStreamScanProvider() {
-      @Override
-      public DataStream<RowData> produceDataStream(
-          ProviderContext providerContext,
-          StreamExecutionEnvironment execEnv) {
-        DataStream<RowData> ds =
-            distribute(dataStreamScanProvider.produceDataStream(providerContext, execEnv), distributionHashMode);
-        UserGroupInformation.reset();
-        LOG.info("ugi reset");
-        return ds;
-      }
-
-      @Override
-      public boolean isBounded() {
-        return false;
-      }
-    };
-  }
-
-  private DistributionHashMode getDistributionHashMode() {
-    String modeName = PropertyUtil.propertyAsString(properties,
-        READ_DISTRIBUTION_MODE,
-        READ_DISTRIBUTION_MODE_DEFAULT);
-
-    DistributionMode mode = DistributionMode.fromName(modeName);
-    switch (mode) {
-      case NONE:
-        return DistributionHashMode.NONE;
-      case HASH:
-        String hashMode = PropertyUtil.propertyAsString(properties, READ_DISTRIBUTION_HASH_MODE, null);
-        if (hashMode == null) {
-          // default none shuffle for unkeyed table
-          if (arcticTable.isUnkeyedTable()) {
-            return DistributionHashMode.NONE;
-          }
-          hashMode = READ_DISTRIBUTION_HASH_MODE_DEFAULT;
-        }
-        return DistributionHashMode.valueOfDesc(hashMode);
-      default:
-        return DistributionHashMode.AUTO;
-    }
-  }
-
-  private DataStream<RowData> distribute(DataStream<RowData> source, DistributionHashMode mode) {
-    ShuffleHelper helper = ShuffleHelper.build(arcticTable, readSchema, flinkSchemaRowType);
-    if (mode == DistributionHashMode.AUTO) {
-      mode = DistributionHashMode.autoSelect(arcticTable.isKeyedTable(), helper.isPartitionKeyExist());
-    }
-    LOG.info("source distribute mode in effect. {}", mode);
-    switch (mode) {
-      case NONE:
-        return source;
-      case PRIMARY_KEY:
-        Preconditions.checkArgument(arcticTable.isKeyedTable(),
-            "illegal shuffle policy " + mode.getDesc() + " for table without primary key");
-        return hash(source, helper, DistributionHashMode.PRIMARY_KEY);
-      case PARTITION_KEY:
-        Preconditions.checkArgument(!arcticTable.spec().isUnpartitioned(),
-            "illegal shuffle policy " + mode.getDesc() + " for table without partition key");
-        return hash(source, helper, DistributionHashMode.PARTITION_KEY);
-      case PRIMARY_PARTITION_KEY:
-        Preconditions.checkArgument(arcticTable.isKeyedTable() && !arcticTable.spec().isUnpartitioned(),
-            "illegal shuffle policy " + mode.getDesc() +
-                " for table without primary key or partition key");
-        return hash(source, helper, DistributionHashMode.PRIMARY_PARTITION_KEY);
-      default:
-        throw new RuntimeException("Unrecognized " + READ_DISTRIBUTION_HASH_MODE + ": " + mode);
-    }
-  }
-
-  public DataStream<RowData> hash(DataStream<RowData> source, ShuffleHelper helper, DistributionHashMode hashMode) {
-    ReadShuffleRulePolicy shuffleRulePolicy = new ReadShuffleRulePolicy(helper, hashMode);
-    return source.partitionCustom(shuffleRulePolicy.generatePartitioner(), shuffleRulePolicy.generateKeySelector());
+    return origin;
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticFileSource.java
@@ -52,7 +52,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.netease.arctic.flink.FlinkSchemaUtil.addPrimaryKey;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.DIM_TABLE_ENABLE;
 
 /**
@@ -141,7 +140,6 @@ public class ArcticFileSource implements ScanTableSource, SupportsFilterPushDown
           projectedColumns,
           Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new));
 
-      addPrimaryKey(builder, table, tableSchema, projectedColumns);
       TableSchema ts = builder.build();
       LOG.info("TableSchema builder after addPrimaryKey, schema:{}", ts);
       return ts;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -154,8 +154,8 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         arcticDynamicSource = createLogSource(arcticTable, context, confWithAll);
     }
 
-    return new ArcticDynamicSource(identifier.getObjectName(), arcticDynamicSource, arcticTable, tableSchema,
-        arcticTable.properties());
+    return new ArcticDynamicSource(
+        identifier.getObjectName(), arcticDynamicSource, arcticTable, arcticTable.properties());
   }
 
   @Override
@@ -245,10 +245,10 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     String startupMode = tableOptions.get(ArcticValidator.SCAN_STARTUP_MODE);
     long startupTimestampMillis = 0L;
     if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
-      startupTimestampMillis = Preconditions.checkNotNull(
-          tableOptions.get(ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS),
-          String.format("'%s' should be set in '%s' mode",
-              ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP));
+      startupTimestampMillis =
+          Preconditions.checkNotNull(tableOptions.get(ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS),
+              String.format("'%s' should be set in '%s' mode",
+                  ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP));
     }
 
     LOG.info("build log source");

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
@@ -314,10 +314,15 @@ public class FlinkTestBase extends TableTestBase {
 
   protected static TaskWriter<RowData> createKeyedTaskWriter(KeyedTable keyedTable, RowType rowType, long transactionId,
                                                              boolean base) {
+    return createKeyedTaskWriter(keyedTable, rowType, transactionId, base, 3);
+  }
+
+  protected static TaskWriter<RowData> createKeyedTaskWriter(KeyedTable keyedTable, RowType rowType, long transactionId,
+                                                             boolean base, long mask) {
     ArcticRowDataTaskWriterFactory taskWriterFactory =
         new ArcticRowDataTaskWriterFactory(keyedTable, rowType, base);
     taskWriterFactory.setTransactionId(transactionId);
-    taskWriterFactory.setMask(3);
+    taskWriterFactory.setMask(mask);
     taskWriterFactory.initialize(0, 0);
     return taskWriterFactory.create();
   }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/TemporalJoinSplitsThreadSafeTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/TemporalJoinSplitsThreadSafeTest.java
@@ -95,6 +95,11 @@ public class TemporalJoinSplitsThreadSafeTest {
     }
 
     @Override
+    public ArcticSplit copy() {
+      return new TestArcticSplit(splitId);
+    }
+
+    @Override
     public String splitId() {
       return splitId;
     }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestWatermark.java
@@ -86,7 +86,21 @@ public class TestWatermark extends FlinkTestBase {
   }
 
   @Test(timeout = 30000)
-  public void testWatermark() throws Exception {
+  public void testWatermarkWithoutPKs() throws Exception {
+    testWatermark(0);
+  }
+
+  @Test(timeout = 30000)
+  public void testWatermarkWithPartialPKs() throws Exception {
+    testWatermark(1);
+  }
+
+  @Test(timeout = 30000)
+  public void testWatermarkWithFullPKs() throws Exception {
+    testWatermark(2);
+  }
+
+  public void testWatermark(int selectType) throws Exception {
     sql(String.format("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props)));
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
@@ -121,8 +135,17 @@ public class TestWatermark extends FlinkTestBase {
 
     sql("create table d (tt as cast(op_time as timestamp(3)), watermark for tt as tt) like %s", table);
 
-    Table source = getTableEnv().sqlQuery("select is_true from d");
-
+    Table source;
+    if (selectType == 0) {
+      source = getTableEnv().sqlQuery("select is_true from d");
+    } else if (selectType == 1) {
+      source = getTableEnv().sqlQuery("select id, is_true from d");
+    } else if (selectType == 2) {
+      source = getTableEnv().sqlQuery("select id, is_true, user_id from d");
+    } else {
+      throw new IllegalArgumentException("Unsupported select type " + selectType);
+    }
+    
     WatermarkTestOperator op = new WatermarkTestOperator();
     getTableEnv().toRetractStream(source, RowData.class)
         .transform("test watermark", TypeInformation.of(RowData.class), op);


### PR DESCRIPTION
fix #849 

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Keep data ordering when the ArcticSource assigns the multi-splits with different layers in the arctic tree node.
1. Arctic source read `mask=3` layer nodes.
2. Arctic enumerator finds `mask=1` layer data files are committed in the next snapshot, these files should split into the `mask=3` layer and put into the  `ShuffleSplitAssigner`.

## Brief change log


  - *Support data files move up layers or go down layers in the arctic tree nodes.*
  - *Add more UTs*
  - *Affect the Flink 1.12\1.14\1.15 versions*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not documented
