### PR TITLE
[ARCTIC-979][Core]Use alter to modify partition location rather than delete and add the partitions in UpdateHiveFiles commit

### DIFF
--- a/hive/src/main/java/com/netease/arctic/hive/op/UpdateHiveFiles.java
+++ b/hive/src/main/java/com/netease/arctic/hive/op/UpdateHiveFiles.java
@@ -321,7 +321,9 @@ public abstract class UpdateHiveFiles<T extends SnapshotUpdate<T>> implements Sn
               "partition will be " +
               "delete and re-create with same location");
         } else {
-          partitions.put(entry.getKey(), entry.getValue());
+          // this partition is need to alter, rather than delete
+          partitionToAlter.put(entry.getKey(), entry.getValue());
+          partitionToDelete.remove(entry.getKey());
           continue;
         }
       }


### PR DESCRIPTION

## Why are the changes needed?
improve #979 

## Brief change log

  - *use alter to modify partition location rather than delete and add the partitions in UpdateHiveFiles commit*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
