### PR TITLE
[ARCTIC-966][Core]Check the written row number before closing the file writer

### DIFF
--- a/core/src/main/java/com/netease/arctic/io/writer/BaseTaskWriter.java
+++ b/core/src/main/java/com/netease/arctic/io/writer/BaseTaskWriter.java
@@ -84,7 +84,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     } else {
       writer = dataWriterMap.get(writerKey);
     }
-    writer.write(row);
+    write(writer, row);
 
     if (shouldRollToNewFile(writer)) {
       writer.close();

--- a/core/src/main/java/com/netease/arctic/io/writer/BaseTaskWriter.java
+++ b/core/src/main/java/com/netease/arctic/io/writer/BaseTaskWriter.java
@@ -92,6 +92,10 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     }
   }
 
+  protected void write(TaskDataWriter writer, T row) throws IOException {
+    writer.write(row);
+  }
+
   protected TaskWriterKey buildWriterKey(T row) {
     StructLike structLike = asStructLike(row);
     partitionKey.partition(structLike);

--- a/core/src/main/java/com/netease/arctic/io/writer/BaseTaskWriter.java
+++ b/core/src/main/java/com/netease/arctic/io/writer/BaseTaskWriter.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Tasks;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 
@@ -56,7 +57,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   private final PartitionKey partitionKey;
   private final PrimaryKeyData primaryKey;
 
-  private final Map<TaskWriterKey, DataWriter<T>> dataWriterMap = Maps.newHashMap();
+  private final Map<TaskWriterKey, TaskDataWriter> dataWriterMap = Maps.newHashMap();
   private final List<DataFile> completedFiles = Lists.newArrayList();
 
   protected BaseTaskWriter(FileFormat format, FileAppenderFactory<T> appenderFactory,
@@ -75,26 +76,20 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   @Override
   public void write(T row) throws IOException {
     TaskWriterKey writerKey = buildWriterKey(row);
-    DataWriter<T> writer;
+    TaskDataWriter writer;
     if (!dataWriterMap.containsKey(writerKey)) {
       TaskWriterKey key = new TaskWriterKey(partitionKey.copy(), writerKey.getTreeNode(), writerKey.getFileType());
-      writer = io.doAs(() -> appenderFactory.newDataWriter(
-          outputFileFactory.newOutputFile(writerKey), format, key.getPartitionKey()));
+      writer = new TaskDataWriter(key);
       dataWriterMap.put(key, writer);
     } else {
       writer = dataWriterMap.get(writerKey);
     }
-    write(writer, row);
+    writer.write(row);
 
     if (shouldRollToNewFile(writer)) {
-      closeWriter(writer);
-      completedFiles.add(writer.toDataFile());
+      writer.close();
       dataWriterMap.remove(writerKey);
     }
-  }
-
-  protected void write(DataWriter<T> writer, T row) throws IOException {
-    writer.add(row);
   }
 
   protected TaskWriterKey buildWriterKey(T row) {
@@ -110,7 +105,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     return new TaskWriterKey(partitionKey, node, DataFileType.BASE_FILE);
   }
 
-  private boolean shouldRollToNewFile(DataWriter<T> dataWriter) {
+  private boolean shouldRollToNewFile(TaskDataWriter dataWriter) {
     // TODO: ORC file now not support target file size before closed
     return !format.equals(FileFormat.ORC) && dataWriter.length() >= targetFileSize;
   }
@@ -136,9 +131,8 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
 
   @Override
   public void close() throws IOException {
-    for (DataWriter<T> dataWriter : dataWriterMap.values()) {
-      closeWriter(dataWriter);
-      completedFiles.add(dataWriter.toDataFile());
+    for (TaskDataWriter dataWriter : dataWriterMap.values()) {
+      dataWriter.close();
     }
     dataWriterMap.clear();
   }
@@ -148,10 +142,38 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
    */
   protected abstract StructLike asStructLike(T data);
 
-  private void closeWriter(DataWriter<T> dataWriter) {
-    io.doAs(() -> {
-      dataWriter.close();
-      return null;
-    });
+  protected class TaskDataWriter {
+    private final DataWriter<T> dataWriter;
+    private long currentRows = 0;
+
+    protected TaskDataWriter(TaskWriterKey writerKey) {
+      this.dataWriter = io.doAs(() -> appenderFactory.newDataWriter(
+          outputFileFactory.newOutputFile(writerKey), format, writerKey.getPartitionKey()));
+    }
+
+    protected void write(T record) {
+      dataWriter.write(record);
+      currentRows++;
+    }
+
+    protected void close() {
+      io.doAs(() -> {
+        dataWriter.close();
+        return null;
+      });
+      if (currentRows > 0) {
+        completedFiles.add(dataWriter.toDataFile());
+      } else {
+        try {
+          io.deleteFile(dataWriter.toDataFile().path().toString());
+        } catch (UncheckedIOException e) {
+          // the file may not have been created, and it isn't worth failing the job to clean up, skip deleting
+        }
+      }
+    }
+
+    protected long length() {
+      return dataWriter.length();
+    }
   }
 }

--- a/core/src/main/java/com/netease/arctic/io/writer/ChangeTaskWriter.java
+++ b/core/src/main/java/com/netease/arctic/io/writer/ChangeTaskWriter.java
@@ -25,7 +25,6 @@ import com.netease.arctic.table.PrimaryKeySpec;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.FileAppenderFactory;
 
 import java.io.IOException;
@@ -61,7 +60,7 @@ public abstract class ChangeTaskWriter<T> extends BaseTaskWriter<T> {
   }
 
   @Override
-  protected void write(DataWriter<T> writer, T row) throws IOException {
+  protected void write(TaskDataWriter writer, T row) throws IOException {
     super.write(writer, appendFileOffset(row));
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To fix #966, check the written row number before closing the file writer.

## Brief change log

  - *Calculate the written row number in task writer*
  - *Complete only if written row number > 0*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
