### PR TITLE
[ARCTIC-996][Hive]Fix data inaccuracy when query data using where statement contain without time zone column

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveParquetConversions.java
+++ b/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveParquetConversions.java
@@ -31,6 +31,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -94,8 +96,9 @@ class AdaptHiveParquetConversions {
 
         if (!((Types.TimestampType) icebergType).shouldAdjustToUTC()) {
           //iceberg org.apache.iceberg.expressions.Literals resolve timestamp without tz use UTC, but in fact it is
-          // local time zone, so the Literals time will plus 8 hours
-          instant = instant.plus(8, ChronoUnit.HOURS);
+          // local time zone
+          instant = instant.atZone(ZoneId.systemDefault()).toLocalDateTime().toInstant(
+              ZoneOffset.UTC);
         }
         return ChronoUnit.MICROS.between(EPOCH, instant);
       };

--- a/hive/src/test/java/com/netease/arctic/hive/ArcticHiveTestMain.java
+++ b/hive/src/test/java/com/netease/arctic/hive/ArcticHiveTestMain.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.hive;
 
 import com.netease.arctic.hive.catalog.TestArcticHiveCatalog;
+import com.netease.arctic.hive.io.TestAdaptHiveReader;
 import com.netease.arctic.hive.io.TestAdaptHiveWriter;
 import com.netease.arctic.hive.op.AutoSyncHiveTest;
 import com.netease.arctic.hive.op.TestHiveSchemaUpdate;
@@ -40,7 +41,8 @@ import org.junit.runners.Suite;
     TestHiveSchemaUpdate.class,
     HiveMetaSynchronizerTest.class,
     TestAdaptHiveWriter.class,
-    AutoSyncHiveTest.class
+    AutoSyncHiveTest.class,
+    TestAdaptHiveReader.class
 })
 public class ArcticHiveTestMain {
 


### PR DESCRIPTION

## Why are the changes needed?
fix: #996

## Brief change log
Resolve time zone in org.apache.iceberg.parquet.AdaptHiveParquetConversions

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
