### PR TITLE
[ARCTIC-1023][Flink] Move kafka class to a new package

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaPartitionSplitReader.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaPartitionSplitReader.java
@@ -18,7 +18,6 @@
 
 package com.netease.arctic.flink.read.internals;
 
-import com.netease.arctic.flink.read.source.log.LogRecordWithRetractInfo;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
@@ -26,8 +25,6 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.util.Collector;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/LogSourceHelper.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/LogSourceHelper.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.read.source.log;
 
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitReader.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitReader.java
@@ -16,17 +16,16 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaPartitionSplitReader;
+import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonDeserialization;
-import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
-import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.Schema;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitState.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitState.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
@@ -91,8 +91,7 @@ public class LogKafkaPartitionSplitState extends KafkaPartitionSplitState {
     } else {
       setCurrentOffset(record.offset() + 1);
     }
-    initEpicStartOffsetIfEmpty(record.getLogData().getUpstreamId(), record.getLogData().getEpicNo(),
-        record.offset());
+    initEpicStartOffsetIfEmpty(record.getLogData().getUpstreamId(), record.getLogData().getEpicNo(), record.offset());
     
     // todo: clear useless epic start offset in state
     retracting = record.isRetracting();

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaRecordEmitter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaRecordEmitter.java
@@ -16,29 +16,25 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.api.connector.source.SourceOutput;
-import org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter;
-import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
 import org.apache.flink.table.data.RowData;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-public class LogKafkaRecordEmitter extends KafkaRecordEmitter<RowData> {
-
-  public LogKafkaRecordEmitter(KafkaRecordDeserializationSchema<RowData> deserializationSchema) {
-    super(deserializationSchema);
-  }
+public class LogKafkaRecordEmitter
+    implements RecordEmitter<ConsumerRecord<byte[], byte[]>, RowData, KafkaPartitionSplitState> {
 
   @Override
   public void emitRecord(
-      ConsumerRecord<byte[], byte[]> consumerRecord,
+      ConsumerRecord<byte[], byte[]> element,
       SourceOutput<RowData> output,
       KafkaPartitionSplitState splitState)
       throws Exception {
-    LogRecordWithRetractInfo<RowData> element = (LogRecordWithRetractInfo) consumerRecord;
-    output.collect(element.getActualValue(), element.timestamp());
-    ((LogKafkaPartitionSplitState) splitState).updateState(element);
+    LogRecordWithRetractInfo<RowData> record = ((LogRecordWithRetractInfo<RowData>) element);
+    output.collect(record.getActualValue(), record.timestamp());
+    ((LogKafkaPartitionSplitState) splitState).updateState(record);
   }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.kafka.source.KafkaSource;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
@@ -16,19 +16,18 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaSourceFetcherManager;
 import com.netease.arctic.flink.read.internals.KafkaSourceReader;
+import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
-import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
-import org.apache.flink.table.data.RowData;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogRecordWithRetractInfo.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogRecordWithRetractInfo.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.log.LogData;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -18,8 +18,8 @@
 
 package com.netease.arctic.flink.table;
 
-import com.netease.arctic.flink.read.source.log.LogKafkaSource;
-import com.netease.arctic.flink.read.source.log.LogKafkaSourceBuilder;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceBuilder;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.table.ArcticTable;

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/LogKafkaPartitionSplitReaderTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/LogKafkaPartitionSplitReaderTest.java
@@ -20,11 +20,10 @@ package com.netease.arctic.flink.read.hidden.kafka;
 
 import com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate;
 import com.netease.arctic.flink.kafka.testutils.KafkaContainerTest;
-import com.netease.arctic.flink.read.source.log.LogKafkaPartitionSplitReader;
-import com.netease.arctic.flink.read.source.log.LogRecordWithRetractInfo;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplitReader;
+import com.netease.arctic.flink.read.source.log.kafka.LogRecordWithRetractInfo;
 import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.log.FormatVersion;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonDeserialization;
@@ -34,7 +33,6 @@ import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
-import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.table.data.RowData;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -45,7 +43,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +55,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.UUID;
 
 import static com.netease.arctic.flink.kafka.testutils.KafkaContainerTest.KAFKA_CONTAINER;
 import static com.netease.arctic.flink.kafka.testutils.KafkaContainerTest.readRecordsBytes;

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden.kafka;
 
-import com.netease.arctic.flink.read.source.log.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/LogSourceHelper.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/LogSourceHelper.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.read.source.log;
 
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitReader.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitReader.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaPartitionSplitReader;
+import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.log.LogData;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitState.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitState.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaRecordEmitter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaRecordEmitter.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaSource;
+import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
@@ -30,7 +31,9 @@ import org.apache.flink.connector.base.source.reader.synchronization.FutureCompl
 import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
-import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
+import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -75,7 +78,7 @@ public class LogKafkaSource extends KafkaSource<RowData> {
       OffsetsInitializer startingOffsetsInitializer,
       @Nullable OffsetsInitializer stoppingOffsetsInitializer,
       Boundedness boundedness,
-      KafkaRecordDeserializer<RowData> deserializationSchema,
+      KafkaRecordDeserializationSchema<RowData> deserializationSchema,
       Properties props,
       Schema schema,
       Map<String, String> tableProperties) {
@@ -103,19 +106,21 @@ public class LogKafkaSource extends KafkaSource<RowData> {
         new FutureCompletingBlockingQueue<>();
     LogSourceHelper logReadHelper = logRetractionEnable ? new LogSourceHelper() : null;
 
+    final KafkaSourceReaderMetrics kafkaSourceReaderMetrics = new KafkaSourceReaderMetrics(readerContext.metricGroup());
     Supplier<LogKafkaPartitionSplitReader> splitReaderSupplier =
         () ->
             new LogKafkaPartitionSplitReader(
-                props, deserializationSchema, readerContext.getIndexOfSubtask(), schema, logRetractionEnable,
+                props, readerContext, kafkaSourceReaderMetrics, schema, logRetractionEnable,
                 logReadHelper, logConsumerChangelogMode);
-    LogKafkaRecordEmitter recordEmitter = new LogKafkaRecordEmitter();
+    LogKafkaRecordEmitter recordEmitter = new LogKafkaRecordEmitter(null);
 
     return new LogKafkaSourceReader<>(
         elementsQueue,
-        splitReaderSupplier,
+        new KafkaSourceFetcherManager(elementsQueue, splitReaderSupplier::get, (ignore) -> {}),
         recordEmitter,
         toConfiguration(props),
         readerContext,
+        kafkaSourceReaderMetrics,
         logReadHelper);
   }
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.kafka.source.KafkaSource;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaSourceReader;
+import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogRecordWithRetractInfo.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogRecordWithRetractInfo.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.log.LogData;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -18,8 +18,8 @@
 
 package com.netease.arctic.flink.table;
 
-import com.netease.arctic.flink.read.source.log.LogKafkaSource;
-import com.netease.arctic.flink.read.source.log.LogKafkaSourceBuilder;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceBuilder;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.table.ArcticTable;

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/LogKafkaPartitionSplitReaderTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/LogKafkaPartitionSplitReaderTest.java
@@ -20,8 +20,8 @@ package com.netease.arctic.flink.read.hidden.kafka;
 
 import com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate;
 import com.netease.arctic.flink.kafka.testutils.KafkaContainerTest;
-import com.netease.arctic.flink.read.source.log.LogKafkaPartitionSplitReader;
-import com.netease.arctic.flink.read.source.log.LogRecordWithRetractInfo;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplitReader;
+import com.netease.arctic.flink.read.source.log.kafka.LogRecordWithRetractInfo;
 import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.log.FormatVersion;

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden.kafka;
 
-import com.netease.arctic.flink.read.source.log.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
@@ -29,13 +29,10 @@ import com.netease.arctic.utils.IdGenerator;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
-import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.operators.collect.ClientAndIterator;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/LogSourceHelper.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/LogSourceHelper.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.read.source.log;
 
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitReader.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitReader.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaPartitionSplitReader;
+import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.log.LogData;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitState.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplitState.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
@@ -91,7 +91,8 @@ public class LogKafkaPartitionSplitState extends KafkaPartitionSplitState {
     } else {
       setCurrentOffset(record.offset() + 1);
     }
-    initEpicStartOffsetIfEmpty(record.getLogData().getUpstreamId(), record.getLogData().getEpicNo(), record.offset());
+    initEpicStartOffsetIfEmpty(record.getLogData().getUpstreamId(), record.getLogData().getEpicNo(),
+        record.offset());
     
     // todo: clear useless epic start offset in state
     retracting = record.isRetracting();

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaRecordEmitter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaRecordEmitter.java
@@ -16,25 +16,29 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.api.connector.source.SourceOutput;
-import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
 import org.apache.flink.table.data.RowData;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-public class LogKafkaRecordEmitter
-    implements RecordEmitter<ConsumerRecord<byte[], byte[]>, RowData, KafkaPartitionSplitState> {
+public class LogKafkaRecordEmitter extends KafkaRecordEmitter<RowData> {
+
+  public LogKafkaRecordEmitter(KafkaRecordDeserializationSchema<RowData> deserializationSchema) {
+    super(deserializationSchema);
+  }
 
   @Override
   public void emitRecord(
-      ConsumerRecord<byte[], byte[]> element,
+      ConsumerRecord<byte[], byte[]> consumerRecord,
       SourceOutput<RowData> output,
       KafkaPartitionSplitState splitState)
       throws Exception {
-    LogRecordWithRetractInfo<RowData> record = ((LogRecordWithRetractInfo<RowData>) element);
-    output.collect(record.getActualValue(), record.timestamp());
-    ((LogKafkaPartitionSplitState) splitState).updateState(record);
+    LogRecordWithRetractInfo<RowData> element = (LogRecordWithRetractInfo) consumerRecord;
+    output.collect(element.getActualValue(), element.timestamp());
+    ((LogKafkaPartitionSplitState) splitState).updateState(element);
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaSource;
+import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.kafka.source.KafkaSource;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaSourceReader;
+import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogRecordWithRetractInfo.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogRecordWithRetractInfo.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.netease.arctic.flink.read.source.log;
+package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.log.LogData;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -18,8 +18,8 @@
 
 package com.netease.arctic.flink.table;
 
-import com.netease.arctic.flink.read.source.log.LogKafkaSource;
-import com.netease.arctic.flink.read.source.log.LogKafkaSourceBuilder;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceBuilder;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.table.ArcticTable;

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/LogKafkaPartitionSplitReaderTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/LogKafkaPartitionSplitReaderTest.java
@@ -20,8 +20,8 @@ package com.netease.arctic.flink.read.hidden.kafka;
 
 import com.netease.arctic.flink.kafka.testutils.KafkaConfigGenerate;
 import com.netease.arctic.flink.kafka.testutils.KafkaContainerTest;
-import com.netease.arctic.flink.read.source.log.LogKafkaPartitionSplitReader;
-import com.netease.arctic.flink.read.source.log.LogRecordWithRetractInfo;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplitReader;
+import com.netease.arctic.flink.read.source.log.kafka.LogRecordWithRetractInfo;
 import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.log.FormatVersion;

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden.kafka;
 
-import com.netease.arctic.flink.read.source.log.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
 import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;


### PR DESCRIPTION
## Why are the changes needed?
To support setting pulsar as log-store, it's necessary to move kafka source class to a new package to distinguish pulsar and kafka.

Resolve #1023 

## Brief change log
  - *Move class*
  - *The flink 1.12 and 1.14, 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
