### PR TITLE
[SPARK]Fix bug: when disable duplicate keys check, execute upsert will throw exception

### DIFF
--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/optimize/RewriteAppendArcticTable.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/optimize/RewriteAppendArcticTable.scala
@@ -55,7 +55,7 @@ case class RewriteAppendArcticTable(spark: SparkSession) extends Rule[LogicalPla
             if (checkDuplicatesEnabled()) {
               AppendArcticData(arcticRelation, newQuery, validateQuery, options)
             } else {
-              ReplaceArcticData(arcticRelation, query, writeOptions)
+              ReplaceArcticData(arcticRelation, newQuery, options)
             }
           } else {
             a

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestKeyedTableDml.java
@@ -346,4 +346,23 @@ public class TestKeyedTableDml extends SparkTestBase {
     Assert.assertEquals(2, rows.get(1)[0]);
     Assert.assertEquals(3, rows.get(2)[0]);
   }
+
+  @Test
+  public void testInsertUpsertTableWhenCloseDuplicateCheck() {
+    sql("set `{0}` = `false`", CHECK_SOURCE_DUPLICATES_ENABLE);
+    sql("use " + catalogNameHive);
+    sql(createUpsertTableTemplate, database, upsertTable);
+    sql("insert overwrite " + database + "." + upsertTable +
+        " values (1, 'aaa', 'aaaa' ) , " +
+        "(4, 'bbb', 'bbcd'), " +
+        "(5, 'ccc', 'cbcd') ");
+    sql("insert into " + database + "." + upsertTable +
+        " values (1, 'aaa', 'dddd' ) , " +
+        "(2, 'bbb', 'bbbb'), " +
+        "(3, 'ccc', 'cccc') ");
+
+    rows = sql("select * from {0}.{1} ", database, upsertTable);
+    Assert.assertEquals(5, rows.size());
+    sql("set `{0}` = `true`", CHECK_SOURCE_DUPLICATES_ENABLE);
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When set property: spark.sql.arctic.check-source-data-uniqueness.enabled = false
then execute upsert will throw exception

## Brief change log


## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

