### PR TITLE
[AMS] set thrift client timeout

### DIFF
--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/AmsClientPools.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/AmsClientPools.java
@@ -15,6 +15,7 @@ public class AmsClientPools {
 
   private static final int CLIENT_POOL_MIN = 0;
   private static final int CLIENT_POOL_MAX = 5;
+  private static final int CLIENT_POOL_TIMEOUT = 5000;
 
   private static final LoadingCache<String, ThriftClientPool<ArcticTableMetastore.Client>> CLIENT_POOLS
       = Caffeine.newBuilder()
@@ -33,6 +34,7 @@ public class AmsClientPools {
     poolConfig.setFailover(true);
     poolConfig.setMinIdle(CLIENT_POOL_MIN);
     poolConfig.setMaxIdle(CLIENT_POOL_MAX);
+    poolConfig.setTimeout(CLIENT_POOL_TIMEOUT);
     return new ThriftClientPool<>(
         url,
         s -> {


### PR DESCRIPTION
## Why are the changes needed?
There are several UTs stuck in AMS thrift connection. Assigning a timeout value try to fix it.

## Brief change log

Set a timeout value to thrift client.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
