### PR TITLE
[ARCTIC-1029][FLINK] Make sure the LogKafka SQL job compatibility after refactor

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumer.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumer.java
@@ -67,6 +67,8 @@ import static org.apache.flink.util.PropertiesUtil.getLong;
  *
  * <p>Please refer to Kafka's documentation for the available configuration properties:
  * http://kafka.apache.org/documentation.html#newconsumerconfigs
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class FlinkKafkaConsumer<T> extends FlinkKafkaConsumerBase<T> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumerBase.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumerBase.java
@@ -89,6 +89,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * AbstractFetcher}.
  *
  * @param <T> The type of records produced by this data source
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogEpicStateHandler.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogEpicStateHandler.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 
 /**
  * This Handler contains the topic offsets of upstream job id, epicNo, topic.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogEpicStateHandler implements Serializable {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumer.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumer.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read;
 
 import com.netease.arctic.flink.read.internals.AbstractFetcher;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.ReadableConfig;
@@ -47,6 +48,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
 
 /**
  * An arctic log consumer that consume arctic log data from kafka.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0; use {@link LogKafkaSource} instead.
  */
 @Deprecated
 public class LogKafkaConsumer extends FlinkKafkaConsumer<RowData> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumerThread.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumerThread.java
@@ -36,6 +36,8 @@ import java.util.Properties;
 /**
  * This thread is an extent of {@link KafkaConsumerThread} added an abstract method
  * {@link KafkaConsumerThread#reSeekPartitionOffsets()} to reSeek the offset of kafka topic partitions.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogKafkaConsumerThread<T> extends KafkaConsumerThread<T> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaFetcher.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaFetcher.java
@@ -56,6 +56,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * The fetcher runs in {@link LogKafkaConsumer} and fetches messages from kafka, and retracts message as handling a
  * Flip message that {@link LogData#getFlip()} is true.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogKafkaFetcher extends KafkaFetcher<RowData> {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogReadHelper.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/LogReadHelper.java
@@ -46,6 +46,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * According to upstreamId and partition topic dealing with the flip message, when should begin to retract message and
  * when to end it.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
+ * use {@link com.netease.arctic.flink.read.source.log.LogSourceHelper} instead.
  */
 @Deprecated
 public class LogReadHelper implements Serializable {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/AbstractFetcher.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/AbstractFetcher.java
@@ -67,6 +67,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type of elements deserialized from Kafka's byte records, and emitted into the
  *            Flink data streams.
  * @param <K> The type of topic/partition identifier used by Kafka in the specific version.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaConsumerThread.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaConsumerThread.java
@@ -61,6 +61,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Implementation Note: This code is written to be reusable in later versions of the
  * KafkaConsumer. Because Kafka is not maintaining binary compatibility, we use a "call bridge" as
  * an indirection to the KafkaConsumer calls that change signature.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaFetcher.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaFetcher.java
@@ -52,6 +52,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  * A fetcher that fetches data from Kafka brokers via the Kafka consumer API.
  *
  * @param <T> The type of elements produced by the fetcher.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
@@ -59,7 +59,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
  *    .build();
  * }</pre>
  *
- * <p>See {@link KafkaSourceBuilder} for more details.
+ * <p>See {@link LogKafkaSourceBuilder} for more details.
  */
 public class LogKafkaSource extends KafkaSource<RowData> {
   private static final long serialVersionUID = 1L;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -27,21 +27,28 @@ import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.streaming.connectors.kafka.table.KafkaOptions;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -60,19 +67,26 @@ import java.util.Set;
 import static com.netease.arctic.flink.FlinkSchemaUtil.getPhysicalSchema;
 import static com.netease.arctic.flink.catalog.descriptors.ArcticCatalogValidator.METASTORE_URL;
 import static com.netease.arctic.flink.catalog.descriptors.ArcticCatalogValidator.METASTORE_URL_OPTION;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS_PREFIX;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FORMAT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.PROPS_GROUP_ID;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCAN_TOPIC_PARTITION_DISCOVERY;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SINK_PARTITIONER;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.TOPIC;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.VALUE_FORMAT;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createKeyFormatProjection;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createValueFormatProjection;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getKafkaProperties;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getSourceTopicPattern;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getSourceTopics;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.validateSourceTopic;
@@ -219,10 +233,11 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     options.add(ArcticValidator.ARCTIC_DATABASE);
     options.add(ArcticValidator.DIM_TABLE_ENABLE);
     options.add(METASTORE_URL_OPTION);
+    options.add(ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE);
     return options;
   }
 
-  private LogDynamicSource createLogSource(ArcticTable arcticTable, Context context, ReadableConfig tableOptions) {
+  private ScanTableSource createLogSource(ArcticTable arcticTable, Context context, ReadableConfig tableOptions) {
     CatalogTable catalogTable = context.getCatalogTable();
     TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
     Schema schema = FlinkSchemaUtil.convert(physicalSchema);
@@ -252,7 +267,12 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    return new LogDynamicSource(valueProjection,
+    if (useOldAPI(arcticTable)) {
+      return createOldLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
+          startupTimestampMillis, arcticTable, schema);
+    }
+    return new LogDynamicSource(
+        valueProjection,
         getSourceTopics(tableOptions),
         getSourceTopicPattern(tableOptions),
         properties,
@@ -263,4 +283,89 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         arcticTable);
   }
 
+  private ScanTableSource createOldLogDynamicSource(DataType physicalDataType,
+                                                    int[] valueProjection,
+                                                    Properties properties,
+                                                    Context context,
+                                                    ReadableConfig tableOptions,
+                                                    long startupTimestampMillis,
+                                                    ArcticTable arcticTable,
+                                                    Schema schema) {
+    FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+        getKeyDecodingFormat(helper);
+    final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat = getValueDecodingFormat(helper);
+
+    final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+    final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+    String startupMode = tableOptions.get(SCAN_STARTUP_MODE);
+
+    LOG.info("create log source with deprecated API");
+    return new KafkaDynamicSource(
+        physicalDataType,
+        keyDecodingFormat.orElse(null),
+        valueDecodingFormat,
+        keyProjection,
+        valueProjection,
+        keyPrefix,
+        KafkaOptions.getSourceTopics(tableOptions),
+        KafkaOptions.getSourceTopicPattern(tableOptions),
+        properties,
+        startupMode,
+        startupTimestampMillis,
+        false,
+        schema,
+        tableOptions,
+        arcticTable.name());
+  }
+
+  private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
+      FactoryUtil.TableFactoryHelper helper) {
+    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+        helper.discoverOptionalDecodingFormat(
+            DeserializationFormatFactory.class, KEY_FORMAT);
+    keyDecodingFormat.ifPresent(
+        format -> {
+          if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            throw new ValidationException(
+                String.format(
+                    "A key format should only deal with INSERT-only records. " +
+                        "But %s has a changelog mode of %s.",
+                    helper.getOptions().get(KEY_FORMAT),
+                    format.getChangelogMode()));
+          }
+        });
+    return keyDecodingFormat;
+  }
+
+  /**
+   * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
+   * {@link LOG_STORE_TYPE} is kafka.
+   */
+  private static boolean useOldAPI(ArcticTable arcticTable) {
+    boolean useOldAPI = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
+    if (useOldAPI) {
+      String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
+          LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
+      if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {
+        LOG.warn("{} option only take effect for {} = {}.",
+            ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(), LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_KAFKA);
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(
+      FactoryUtil.TableFactoryHelper helper) {
+    return helper.discoverOptionalDecodingFormat(
+            DeserializationFormatFactory.class, FactoryUtil.FORMAT)
+        .orElseGet(
+            () ->
+                helper.discoverDecodingFormat(
+                    DeserializationFormatFactory.class, VALUE_FORMAT));
+  }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -267,7 +267,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    if (adaptLegacySourc(arcticTable)) {
+    if (adaptLegacySource(arcticTable)) {
       return createLegacyLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
           startupTimestampMillis, arcticTable, schema);
     }
@@ -342,7 +342,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
    * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
    * {@link LOG_STORE_TYPE} is kafka.
    */
-  private static boolean adaptLegacySourc(ArcticTable arcticTable) {
+  private static boolean adaptLegacySource(ArcticTable arcticTable) {
     boolean legacySourceEnabled = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -267,8 +267,8 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    if (useOldAPI(arcticTable)) {
-      return createOldLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
+    if (adaptLegacySourc(arcticTable)) {
+      return createLegacyLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
           startupTimestampMillis, arcticTable, schema);
     }
     return new LogDynamicSource(
@@ -283,7 +283,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         arcticTable);
   }
 
-  private ScanTableSource createOldLogDynamicSource(DataType physicalDataType,
+  private ScanTableSource createLegacyLogDynamicSource(DataType physicalDataType,
                                                     int[] valueProjection,
                                                     Properties properties,
                                                     Context context,
@@ -342,11 +342,11 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
    * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
    * {@link LOG_STORE_TYPE} is kafka.
    */
-  private static boolean useOldAPI(ArcticTable arcticTable) {
-    boolean useOldAPI = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
+  private static boolean adaptLegacySourc(ArcticTable arcticTable) {
+    boolean legacySourceEnabled = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
-    if (useOldAPI) {
+    if (legacySourceEnabled) {
       String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
           LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
       if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/KafkaDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/KafkaDynamicSource.java
@@ -460,6 +460,7 @@ public class KafkaDynamicSource
             tableOptions);
     copy.producedDataType = producedDataType;
     copy.metadataKeys = metadataKeys;
+    copy.projectedFields = projectedFields;
     copy.watermarkStrategy = watermarkStrategy;
     return copy;
   }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -28,7 +28,6 @@ import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -92,6 +92,13 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           .defaultValue(false)
           .withDescription("Flag hidden kafka read retraction enable or not.");
 
+  public static final ConfigOption<Boolean> ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE =
+      ConfigOptions.key("log-store.kafka.compatible.enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Flag hidden kafka read compatible with old API enable or not." +
+              " If a task should be restored from checkpoint which made in Arctic version less than 0.4.1");
+
   public static final ConfigOption<String> ARCTIC_LOG_CONSUMER_CHANGELOG_MODE =
       ConfigOptions.key("log.consumer.changelog.modes")
           .stringType()

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -92,6 +92,7 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           .defaultValue(false)
           .withDescription("Flag hidden kafka read retraction enable or not.");
 
+  @Deprecated
   public static final ConfigOption<Boolean> ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE =
       ConfigOptions.key("log-store.kafka.compatible.enabled")
           .booleanType()

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -97,7 +97,8 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
       ConfigOptions.key("log-store.kafka.compatible.enabled")
           .booleanType()
           .defaultValue(false)
-          .withDescription("Flag hidden kafka read compatible with old API enable or not." +
+          .withDescription("Flag hidden kafka reading compatible with legacy Kafka Source API enable or not" +
+              " when restoring Flink application from a checkpoint." +
               " If a task should be restored from checkpoint which made in Arctic version less than 0.4.1");
 
   public static final ConfigOption<String> ARCTIC_LOG_CONSUMER_CHANGELOG_MODE =

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumer.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumer.java
@@ -66,6 +66,8 @@ import static org.apache.flink.util.PropertiesUtil.getLong;
  *
  * <p>Please refer to Kafka's documentation for the available configuration properties:
  * http://kafka.apache.org/documentation.html#newconsumerconfigs
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class FlinkKafkaConsumer<T> extends FlinkKafkaConsumerBase<T> {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumerBase.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumerBase.java
@@ -88,6 +88,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * AbstractFetcher}.
  *
  * @param <T> The type of records produced by this data source
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogEpicStateHandler.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogEpicStateHandler.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 
 /**
  * This Handler contains the topic offsets of upstream job id, epicNo, topic.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogEpicStateHandler implements Serializable {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumer.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumer.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read;
 
 import com.netease.arctic.flink.read.internals.AbstractFetcher;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.ReadableConfig;
@@ -47,6 +48,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
 
 /**
  * An arctic log consumer that consume arctic log data from kafka.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0; use {@link LogKafkaSource} instead.
  */
 @Deprecated
 public class LogKafkaConsumer extends FlinkKafkaConsumer<RowData> {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumerThread.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumerThread.java
@@ -36,6 +36,8 @@ import java.util.Properties;
 /**
  * This thread is an extent of {@link KafkaConsumerThread} added an abstract method
  * {@link KafkaConsumerThread#reSeekPartitionOffsets()} to reSeek the offset of kafka topic partitions.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogKafkaConsumerThread<T> extends KafkaConsumerThread<T> {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaFetcher.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaFetcher.java
@@ -56,6 +56,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * The fetcher runs in {@link LogKafkaConsumer} and fetches messages from kafka, and retracts message as handling a
  * Flip message that {@link LogData#getFlip()} is true.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogKafkaFetcher extends KafkaFetcher<RowData> {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogReadHelper.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/LogReadHelper.java
@@ -46,6 +46,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * According to upstreamId and partition topic dealing with the flip message, when should begin to retract message and
  * when to end it.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
+ * use {@link com.netease.arctic.flink.read.source.log.LogSourceHelper} instead.
  */
 @Deprecated
 public class LogReadHelper implements Serializable {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/AbstractFetcher.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/AbstractFetcher.java
@@ -67,6 +67,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type of elements deserialized from Kafka's byte records, and emitted into the
  *            Flink data streams.
  * @param <K> The type of topic/partition identifier used by Kafka in the specific version.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaConsumerThread.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaConsumerThread.java
@@ -61,6 +61,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Implementation Note: This code is written to be reusable in later versions of the
  * KafkaConsumer. Because Kafka is not maintaining binary compatibility, we use a "call bridge" as
  * an indirection to the KafkaConsumer calls that change signature.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaFetcher.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaFetcher.java
@@ -51,6 +51,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  * A fetcher that fetches data from Kafka brokers via the Kafka consumer API.
  *
  * @param <T> The type of elements produced by the fetcher.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
@@ -61,7 +61,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
  *    .build();
  * }</pre>
  *
- * <p>See {@link KafkaSourceBuilder} for more details.
+ * <p>See {@link LogKafkaSourceBuilder} for more details.
  */
 public class LogKafkaSource extends KafkaSource<RowData> {
   private static final long serialVersionUID = 1L;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -27,21 +27,27 @@ import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -59,14 +65,21 @@ import java.util.Set;
 
 import static com.netease.arctic.flink.FlinkSchemaUtil.getPhysicalSchema;
 import static com.netease.arctic.flink.catalog.factories.ArcticCatalogFactoryOptions.METASTORE_URL;
+import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createKeyFormatProjection;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createValueFormatProjection;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getKafkaProperties;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getSourceTopicPattern;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getSourceTopics;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.validateSourceTopic;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FIELDS_PREFIX;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FORMAT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_GROUP_ID;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SCAN_STARTUP_MODE;
@@ -74,6 +87,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOp
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SCAN_TOPIC_PARTITION_DISCOVERY;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SINK_PARTITIONER;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.VALUE_FORMAT;
 
 /**
  * A factory generates {@link ArcticDynamicSource} and {@link ArcticDynamicSink}
@@ -219,10 +233,11 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     options.add(ArcticValidator.ARCTIC_DATABASE);
     options.add(ArcticValidator.DIM_TABLE_ENABLE);
     options.add(METASTORE_URL);
+    options.add(ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE);
     return options;
   }
 
-  private LogDynamicSource createLogSource(ArcticTable arcticTable, Context context, ReadableConfig tableOptions) {
+  private ScanTableSource createLogSource(ArcticTable arcticTable, Context context, ReadableConfig tableOptions) {
     CatalogTable catalogTable = context.getCatalogTable();
     TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
     Schema schema = FlinkSchemaUtil.convert(physicalSchema);
@@ -253,7 +268,12 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    return new LogDynamicSource(valueProjection,
+    if (useOldAPI(arcticTable)) {
+      return createOldLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
+          startupTimestampMillis, arcticTable, schema);
+    }
+    return new LogDynamicSource(
+        valueProjection,
         getSourceTopics(tableOptions),
         getSourceTopicPattern(tableOptions),
         properties,
@@ -262,6 +282,92 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         schema,
         tableOptions,
         arcticTable);
+  }
+
+  private ScanTableSource createOldLogDynamicSource(DataType physicalDataType,
+                                                    int[] valueProjection,
+                                                    Properties properties,
+                                                    Context context,
+                                                    ReadableConfig tableOptions,
+                                                    long startupTimestampMillis,
+                                                    ArcticTable arcticTable,
+                                                    Schema schema) {
+    FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+        getKeyDecodingFormat(helper);
+    final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat = getValueDecodingFormat(helper);
+
+    final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+    final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+    String startupMode = tableOptions.get(ArcticValidator.SCAN_STARTUP_MODE);
+
+    LOG.info("create log source with deprecated API");
+    return new KafkaDynamicSource(
+        physicalDataType,
+        keyDecodingFormat.orElse(null),
+        valueDecodingFormat,
+        keyProjection,
+        valueProjection,
+        keyPrefix,
+        KafkaConnectorOptionsUtil.getSourceTopics(tableOptions),
+        KafkaConnectorOptionsUtil.getSourceTopicPattern(tableOptions),
+        properties,
+        startupMode,
+        startupTimestampMillis,
+        false,
+        schema,
+        tableOptions,
+        arcticTable.name());
+  }
+
+  private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
+      FactoryUtil.TableFactoryHelper helper) {
+    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+        helper.discoverOptionalDecodingFormat(
+            DeserializationFormatFactory.class, KEY_FORMAT);
+    keyDecodingFormat.ifPresent(
+        format -> {
+          if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            throw new ValidationException(
+                String.format(
+                    "A key format should only deal with INSERT-only records. " +
+                        "But %s has a changelog mode of %s.",
+                    helper.getOptions().get(KEY_FORMAT),
+                    format.getChangelogMode()));
+          }
+        });
+    return keyDecodingFormat;
+  }
+
+  /**
+   * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
+   * {@link LOG_STORE_TYPE} is kafka.
+   */
+  private static boolean useOldAPI(ArcticTable arcticTable) {
+    boolean useOldAPI = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
+    if (useOldAPI) {
+      String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
+          LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
+      if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {
+        LOG.warn("{} option only take effect for {} = {}.",
+            ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(), LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_KAFKA);
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(
+      FactoryUtil.TableFactoryHelper helper) {
+    return helper.discoverOptionalDecodingFormat(
+            DeserializationFormatFactory.class, FactoryUtil.FORMAT)
+        .orElseGet(
+            () ->
+                helper.discoverDecodingFormat(
+                    DeserializationFormatFactory.class, VALUE_FORMAT));
   }
 
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -268,7 +268,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    if (adaptLegacySourc(arcticTable)) {
+    if (adaptLegacySource(arcticTable)) {
       return createLegacyLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
           startupTimestampMillis, arcticTable, schema);
     }
@@ -343,7 +343,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
    * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
    * {@link LOG_STORE_TYPE} is kafka.
    */
-  private static boolean adaptLegacySourc(ArcticTable arcticTable) {
+  private static boolean adaptLegacySource(ArcticTable arcticTable) {
     boolean legacySourceEnabled = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -268,8 +268,8 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    if (useOldAPI(arcticTable)) {
-      return createOldLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
+    if (adaptLegacySourc(arcticTable)) {
+      return createLegacyLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
           startupTimestampMillis, arcticTable, schema);
     }
     return new LogDynamicSource(
@@ -284,7 +284,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         arcticTable);
   }
 
-  private ScanTableSource createOldLogDynamicSource(DataType physicalDataType,
+  private ScanTableSource createLegacyLogDynamicSource(DataType physicalDataType,
                                                     int[] valueProjection,
                                                     Properties properties,
                                                     Context context,
@@ -343,11 +343,11 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
    * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
    * {@link LOG_STORE_TYPE} is kafka.
    */
-  private static boolean useOldAPI(ArcticTable arcticTable) {
-    boolean useOldAPI = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
+  private static boolean adaptLegacySourc(ArcticTable arcticTable) {
+    boolean legacySourceEnabled = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
-    if (useOldAPI) {
+    if (legacySourceEnabled) {
       String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
           LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
       if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/KafkaDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/KafkaDynamicSource.java
@@ -19,16 +19,22 @@
 package com.netease.arctic.flink.table;
 
 import com.netease.arctic.flink.read.FlinkKafkaConsumer;
+import com.netease.arctic.flink.read.LogKafkaConsumer;
+import com.netease.arctic.flink.table.descriptors.ArcticValidator;
+import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.flink.util.Projection;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaDeserializationSchemaWrapper;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
@@ -43,7 +49,10 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 
@@ -63,12 +72,35 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSUMER_CHANGELOG_MODE;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_ALL_KINDS;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
+import static org.apache.flink.table.connector.ChangelogMode.insertOnly;
+
 /**
  * A version-agnostic Kafka {@link ScanTableSource}.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 public class KafkaDynamicSource
     implements ScanTableSource, SupportsReadingMetadata, SupportsProjectionPushDown, SupportsWatermarkPushDown {
+
+  private final Schema schema;
+  private final ReadableConfig tableOptions;
+  private final String consumerChangelogMode;
+  private final boolean logRetractionEnable;
+
+  private static final ChangelogMode ALL_KINDS = ChangelogMode.newBuilder()
+      .addContainedKind(RowKind.INSERT)
+      .addContainedKind(RowKind.UPDATE_BEFORE)
+      .addContainedKind(RowKind.UPDATE_AFTER)
+      .addContainedKind(RowKind.DELETE)
+      .build();
 
   // --------------------------------------------------------------------------------------------
   // Mutable attributes
@@ -185,11 +217,65 @@ public class KafkaDynamicSource
       @Nullable List<String> topics,
       @Nullable Pattern topicPattern,
       Properties properties,
+      String startupMode,
+      long startupTimestampMillis,
+      boolean upsertMode,
+      Schema schema,
+      ReadableConfig tableOptions,
+      String sourceName) {
+    this(
+        physicalDataType,
+        keyDecodingFormat,
+        valueDecodingFormat,
+        keyProjection,
+        valueProjection,
+        keyPrefix,
+        topics,
+        topicPattern,
+        properties,
+        toInternal(startupMode),
+        new HashMap<>(),
+        startupTimestampMillis,
+        upsertMode,
+        sourceName,
+        schema,
+        tableOptions
+    );
+  }
+
+  public static StartupMode toInternal(String startupMode) {
+    startupMode = startupMode.toLowerCase();
+    switch (startupMode) {
+      case SCAN_STARTUP_MODE_LATEST:
+        return StartupMode.LATEST;
+      case SCAN_STARTUP_MODE_EARLIEST:
+        return StartupMode.EARLIEST;
+      case SCAN_STARTUP_MODE_TIMESTAMP:
+        return StartupMode.TIMESTAMP;
+      default:
+        throw new ValidationException(String.format(
+            "%s only support '%s', '%s'. But input is '%s'", ArcticValidator.SCAN_STARTUP_MODE,
+            SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST, startupMode));
+    }
+  }
+
+  public KafkaDynamicSource(
+      DataType physicalDataType,
+      @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+      DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+      int[] keyProjection,
+      int[] valueProjection,
+      @Nullable String keyPrefix,
+      @Nullable List<String> topics,
+      @Nullable Pattern topicPattern,
+      Properties properties,
       StartupMode startupMode,
       Map<KafkaTopicPartition, Long> specificStartupOffsets,
       long startupTimestampMillis,
       boolean upsertMode,
-      String sourceName) {
+      String sourceName,
+      Schema schema,
+      ReadableConfig tableOptions) {
     // Format attributes
     this.physicalDataType =
         Preconditions.checkNotNull(
@@ -224,11 +310,37 @@ public class KafkaDynamicSource
     this.startupTimestampMillis = startupTimestampMillis;
     this.upsertMode = upsertMode;
     this.sourceName = sourceName;
+
+    this.schema = schema;
+    this.tableOptions = tableOptions;
+    this.consumerChangelogMode = tableOptions.get(ARCTIC_LOG_CONSUMER_CHANGELOG_MODE);
+    this.logRetractionEnable = CompatibleFlinkPropertyUtil.propertyAsBoolean(tableOptions,
+        ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE);
   }
 
   @Override
   public ChangelogMode getChangelogMode() {
-    return valueDecodingFormat.getChangelogMode();
+    switch (consumerChangelogMode) {
+      case LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY:
+        if (logRetractionEnable) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Only %s is false when %s is %s",
+                  ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.key(),
+                  ARCTIC_LOG_CONSUMER_CHANGELOG_MODE.key(),
+                  LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY));
+        }
+        return insertOnly();
+      case LOG_CONSUMER_CHANGELOG_MODE_ALL_KINDS:
+        return ALL_KINDS;
+      default:
+        throw new UnsupportedOperationException(
+            String.format(
+                "As of now, %s can't support this option %s.",
+                ARCTIC_LOG_CONSUMER_CHANGELOG_MODE.key(),
+                consumerChangelogMode
+            ));
+    }
   }
 
   @Override
@@ -343,7 +455,9 @@ public class KafkaDynamicSource
             specificStartupOffsets,
             startupTimestampMillis,
             upsertMode,
-            sourceName);
+            sourceName,
+            schema,
+            tableOptions);
     copy.producedDataType = producedDataType;
     copy.metadataKeys = metadataKeys;
     copy.projectedFields = projectedFields;
@@ -353,7 +467,7 @@ public class KafkaDynamicSource
 
   @Override
   public String asSummaryString() {
-    return "Kafka table source";
+    return "arctic";
   }
 
   @Override
@@ -412,7 +526,57 @@ public class KafkaDynamicSource
       DeserializationSchema<RowData> keyDeserialization,
       DeserializationSchema<RowData> valueDeserialization,
       TypeInformation<RowData> producedTypeInfo) {
-    throw new UnsupportedOperationException("cloud not create kafka consumer.");
+    final FlinkKafkaConsumer<RowData> kafkaConsumer;
+
+    final KafkaDeserializationSchemaWrapper<RowData> deserializationSchemaWrapper =
+        new KafkaDeserializationSchemaWrapper<>(valueDeserialization);
+    Schema projectedSchema = schema;
+    if (projectedFields != null) {
+      final List<Types.NestedField> columns = schema.columns();
+      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(columns::get).collect(Collectors.toList()));
+    }
+    if (topics != null) {
+      kafkaConsumer =
+          new LogKafkaConsumer(
+              topics,
+              deserializationSchemaWrapper,
+              properties,
+              projectedSchema,
+              tableOptions);
+    } else {
+      kafkaConsumer =
+          new LogKafkaConsumer(
+              topicPattern,
+              deserializationSchemaWrapper,
+              properties,
+              projectedSchema,
+              tableOptions);
+    }
+
+    switch (startupMode) {
+      case EARLIEST:
+        kafkaConsumer.setStartFromEarliest();
+        break;
+      case LATEST:
+        kafkaConsumer.setStartFromLatest();
+        break;
+      case GROUP_OFFSETS:
+        kafkaConsumer.setStartFromGroupOffsets();
+        break;
+      case SPECIFIC_OFFSETS:
+        kafkaConsumer.setStartFromSpecificOffsets(specificStartupOffsets);
+        break;
+      case TIMESTAMP:
+        kafkaConsumer.setStartFromTimestamp(startupTimestampMillis);
+        break;
+    }
+
+    kafkaConsumer.setCommitOffsetsOnCheckpoints(properties.getProperty("group.id") != null);
+
+    if (watermarkStrategy != null) {
+      kafkaConsumer.assignTimestampsAndWatermarks(watermarkStrategy);
+    }
+    return kafkaConsumer;
   }
 
   @Nullable

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -92,6 +92,14 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           .defaultValue(false)
           .withDescription("Flag hidden kafka read retraction enable or not.");
 
+  @Deprecated
+  public static final ConfigOption<Boolean> ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE =
+      ConfigOptions.key("log-store.kafka.compatible.enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Flag hidden kafka read compatible with old API enable or not." +
+              " If a task should be restored from checkpoint which made in Arctic version less than 0.4.1");
+
   public static final ConfigOption<String> ARCTIC_LOG_CONSUMER_CHANGELOG_MODE =
       ConfigOptions.key("log.consumer.changelog.modes")
           .stringType()

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -97,7 +97,8 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
       ConfigOptions.key("log-store.kafka.compatible.enabled")
           .booleanType()
           .defaultValue(false)
-          .withDescription("Flag hidden kafka read compatible with old API enable or not." +
+          .withDescription("Flag hidden kafka reading compatible with legacy Kafka Source API enable or not" +
+              " when restoring Flink application from a checkpoint." +
               " If a task should be restored from checkpoint which made in Arctic version less than 0.4.1");
 
   public static final ConfigOption<String> ARCTIC_LOG_CONSUMER_CHANGELOG_MODE =

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -37,11 +37,12 @@ import org.apache.flink.util.CloseableIterator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
@@ -60,10 +61,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.netease.arctic.ams.api.MockArcticMetastoreServer.TEST_CATALOG_NAME;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.LOCATION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
 import static org.apache.flink.table.api.Expressions.$;
 
 @RunWith(Parameterized.class)
@@ -73,6 +77,8 @@ public class TestKeyed extends FlinkTestBase {
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule
+  public TestName testName = new TestName();
 
   private static final String DB = PK_TABLE_ID.getDatabase();
   private static final String TABLE = "test_keyed";
@@ -81,13 +87,19 @@ public class TestKeyed extends FlinkTestBase {
   private String db;
   private String topic;
   private HiveTableTestBase hiveTableTestBase = new HiveTableTestBase();
-
+  private Map<String, String> tableProperties = new HashMap<>();
   @Parameterized.Parameter
   public boolean isHive;
+  @Parameterized.Parameter(1)
+  public boolean kafkaLegacyEnable;
 
-  @Parameterized.Parameters(name = "isHive = {0}")
-  public static Collection<Boolean> parameters() {
-    return Arrays.asList(false);
+  @Parameterized.Parameters(name = "isHive = {0}, kafkaLegacyEnable = {2}")
+  public static Collection parameters() {
+    return Arrays.asList(
+        new Object[][]{
+            {false, true},
+            {false, false},
+        });
   }
 
   @BeforeClass
@@ -111,8 +123,24 @@ public class TestKeyed extends FlinkTestBase {
       db = DB;
       super.before();
     }
-    topic = String.join(".", catalog, db, TABLE);
+    prepareLog();
+
     super.config(catalog);
+  }
+
+  private void prepareLog() {
+    topic = TestUtil.getUtMethodName(testName) + isHive + kafkaLegacyEnable;
+    tableProperties.clear();
+    tableProperties.put(ENABLE_LOG_STORE, "true");
+    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
+
+    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
+    tableProperties.put(LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_KAFKA);
+    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
+
+    if (kafkaLegacyEnable) {
+      tableProperties.put(ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(), "true");
+    }
   }
 
   @After
@@ -125,6 +153,7 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testSinkSourceFile() throws IOException {
+    Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0"),
         LocalDateTime.parse("2022-06-17T10:10:11.0").atZone(ZoneId.systemDefault()).toInstant()});
@@ -192,9 +221,6 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testUnpartitionLogSinkSource() throws Exception {
-    String topic = this.topic + "testUnpartitionLogSinkSource";
-    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
-
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a"});
     data.add(new Object[]{1000015, "b"});
@@ -215,10 +241,6 @@ public class TestKeyed extends FlinkTestBase {
 
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
 
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(ENABLE_LOG_STORE, "true");
-    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
-    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
@@ -249,9 +271,6 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testUnPartitionDoubleSink() throws Exception {
-    String topic = this.topic + "testUnPartitionDoubleSink";
-    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
-
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a"});
     data.add(new Object[]{1000015, "b"});
@@ -271,10 +290,6 @@ public class TestKeyed extends FlinkTestBase {
     getTableEnv().createTemporaryView("input", input);
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
 
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(ENABLE_LOG_STORE, "true");
-    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
-    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
@@ -302,6 +317,7 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testPartitionSinkFile() throws IOException {
+    Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
@@ -340,6 +356,7 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testFileUpsert() throws IOException {
+    Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.DELETE, 1000015, "b", LocalDateTime.parse("2022-06-17T10:08:11.0")});
@@ -384,21 +401,20 @@ public class TestKeyed extends FlinkTestBase {
             ") */")));
   }
 
-  // Ignore this case because of ci blocking problem in Github
-  @Ignore
   @Test
   public void testFileUpsertWithSamePrimaryKey() throws Exception {
+    Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000004, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000011, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000011, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
-      InternalTypeInfo.ofFields(
-        DataTypes.INT().getLogicalType(),
-        DataTypes.VARCHAR(100).getLogicalType(),
-        DataTypes.TIMESTAMP().getLogicalType()
-      ));
+        InternalTypeInfo.ofFields(
+            DataTypes.INT().getLogicalType(),
+            DataTypes.VARCHAR(100).getLogicalType(),
+            DataTypes.TIMESTAMP().getLogicalType()
+        ));
 
     getEnv().setParallelism(4);
     Table input = getTableEnv().fromDataStream(source, $("id"), $("name"), $("op_time"));
@@ -410,17 +426,17 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
-      ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+        ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
-      "/*+ OPTIONS(" +
-      "'arctic.emit.mode'='file'" +
-      ")*/" + " select * from input");
+        "/*+ OPTIONS(" +
+        "'arctic.emit.mode'='file'" +
+        ")*/" + " select * from input");
 
     TableResult result = exec("select * from arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
-      "'streaming'='false'" +
-      ") */");
+        "'streaming'='false'" +
+        ") */");
     LinkedList<Row> actual = new LinkedList<>();
     try (CloseableIterator<Row> iterator = result.collect()) {
       while (iterator.hasNext()) {
@@ -444,15 +460,12 @@ public class TestKeyed extends FlinkTestBase {
     Map<Object, List<Row>> expectedMap = DataUtil.groupByPrimaryKey(DataUtil.toRowList(expected), 0);
 
     for (Object key : actualMap.keySet()) {
-      Assert.assertTrue(CollectionUtils.isEqualCollection(actualMap.get(key),expectedMap.get(key)));
+      Assert.assertTrue(CollectionUtils.isEqualCollection(actualMap.get(key), expectedMap.get(key)));
     }
   }
 
   @Test
   public void testPartitionLogSinkSource() throws Exception {
-    String topic = this.topic + "testPartitionLogSinkSource";
-    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
-
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
@@ -475,10 +488,6 @@ public class TestKeyed extends FlinkTestBase {
 
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
 
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(ENABLE_LOG_STORE, "true");
-    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
-    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
@@ -509,9 +518,6 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testPartitionDoubleSink() throws Exception {
-    String topic = this.topic + "testPartitionDoubleSink";
-    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
-
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
@@ -533,10 +539,6 @@ public class TestKeyed extends FlinkTestBase {
     getTableEnv().createTemporaryView("input", input);
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
 
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(ENABLE_LOG_STORE, "true");
-    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
-    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -93,7 +93,7 @@ public class TestKeyed extends FlinkTestBase {
   @Parameterized.Parameter(1)
   public boolean kafkaLegacyEnable;
 
-  @Parameterized.Parameters(name = "isHive = {0}, kafkaLegacyEnable = {2}")
+  @Parameterized.Parameters(name = "isHive = {0}, kafkaLegacyEnable = {1}")
   public static Collection parameters() {
     return Arrays.asList(
         new Object[][]{

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
@@ -20,12 +20,24 @@ package com.netease.arctic.flink.util;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.execution.JobClient;
+import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TestUtil {
 
   public static final Logger LOG = LoggerFactory.getLogger(TestUtil.class);
+
+  /**
+   * get ut method name without parameters.
+   */
+  public static String getUtMethodName(TestName testName) {
+    int i = testName.getMethodName().indexOf("[");
+    if (i == -1) {
+      return testName.getMethodName();
+    }
+    return testName.getMethodName().substring(0, i);
+  }
 
   public static void cancelJob(JobClient jobClient) {
     if (isJobTerminated(jobClient)) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumer.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumer.java
@@ -66,6 +66,8 @@ import static org.apache.flink.util.PropertiesUtil.getLong;
  *
  * <p>Please refer to Kafka's documentation for the available configuration properties:
  * http://kafka.apache.org/documentation.html#newconsumerconfigs
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class FlinkKafkaConsumer<T> extends FlinkKafkaConsumerBase<T> {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumerBase.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/FlinkKafkaConsumerBase.java
@@ -88,6 +88,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * AbstractFetcher}.
  *
  * @param <T> The type of records produced by this data source
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogEpicStateHandler.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogEpicStateHandler.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 
 /**
  * This Handler contains the topic offsets of upstream job id, epicNo, topic.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogEpicStateHandler implements Serializable {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumer.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumer.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read;
 
 import com.netease.arctic.flink.read.internals.AbstractFetcher;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.ReadableConfig;
@@ -47,6 +48,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
 
 /**
  * An arctic log consumer that consume arctic log data from kafka.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0; use {@link LogKafkaSource} instead.
  */
 @Deprecated
 public class LogKafkaConsumer extends FlinkKafkaConsumer<RowData> {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumerThread.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaConsumerThread.java
@@ -36,6 +36,8 @@ import java.util.Properties;
 /**
  * This thread is an extent of {@link KafkaConsumerThread} added an abstract method
  * {@link KafkaConsumerThread#reSeekPartitionOffsets()} to reSeek the offset of kafka topic partitions.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogKafkaConsumerThread<T> extends KafkaConsumerThread<T> {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaFetcher.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogKafkaFetcher.java
@@ -56,6 +56,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * The fetcher runs in {@link LogKafkaConsumer} and fetches messages from kafka, and retracts message as handling a
  * Flip message that {@link LogData#getFlip()} is true.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Deprecated
 public class LogKafkaFetcher extends KafkaFetcher<RowData> {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogReadHelper.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/LogReadHelper.java
@@ -46,6 +46,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * According to upstreamId and partition topic dealing with the flip message, when should begin to retract message and
  * when to end it.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
+ * use {@link com.netease.arctic.flink.read.source.log.LogSourceHelper} instead.
  */
 @Deprecated
 public class LogReadHelper implements Serializable {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/AbstractFetcher.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/AbstractFetcher.java
@@ -67,6 +67,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type of elements deserialized from Kafka's byte records, and emitted into the
  *            Flink data streams.
  * @param <K> The type of topic/partition identifier used by Kafka in the specific version.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaConsumerThread.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaConsumerThread.java
@@ -61,6 +61,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Implementation Note: This code is written to be reusable in later versions of the
  * KafkaConsumer. Because Kafka is not maintaining binary compatibility, we use a "call bridge" as
  * an indirection to the KafkaConsumer calls that change signature.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaFetcher.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaFetcher.java
@@ -51,6 +51,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  * A fetcher that fetches data from Kafka brokers via the Kafka consumer API.
  *
  * @param <T> The type of elements produced by the fetcher.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 @Deprecated

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
@@ -61,7 +61,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
  *    .build();
  * }</pre>
  *
- * <p>See {@link KafkaSourceBuilder} for more details.
+ * <p>See {@link LogKafkaSourceBuilder} for more details.
  */
 public class LogKafkaSource extends KafkaSource<RowData> {
   private static final long serialVersionUID = 1L;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -27,21 +27,27 @@ import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -59,14 +65,21 @@ import java.util.Set;
 
 import static com.netease.arctic.flink.FlinkSchemaUtil.getPhysicalSchema;
 import static com.netease.arctic.flink.catalog.factories.ArcticCatalogFactoryOptions.METASTORE_URL;
+import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createKeyFormatProjection;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createValueFormatProjection;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getKafkaProperties;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getSourceTopicPattern;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getSourceTopics;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.validateSourceTopic;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FIELDS_PREFIX;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FORMAT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_GROUP_ID;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SCAN_STARTUP_MODE;
@@ -74,6 +87,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOp
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SCAN_TOPIC_PARTITION_DISCOVERY;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SINK_PARTITIONER;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.VALUE_FORMAT;
 
 /**
  * A factory generates {@link ArcticDynamicSource} and {@link ArcticDynamicSink}
@@ -219,10 +233,11 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     options.add(ArcticValidator.ARCTIC_DATABASE);
     options.add(ArcticValidator.DIM_TABLE_ENABLE);
     options.add(METASTORE_URL);
+    options.add(ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE);
     return options;
   }
 
-  private LogDynamicSource createLogSource(ArcticTable arcticTable, Context context, ReadableConfig tableOptions) {
+  private ScanTableSource createLogSource(ArcticTable arcticTable, Context context, ReadableConfig tableOptions) {
     CatalogTable catalogTable = context.getCatalogTable();
     TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
     Schema schema = FlinkSchemaUtil.convert(physicalSchema);
@@ -253,7 +268,12 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    return new LogDynamicSource(valueProjection,
+    if (useOldAPI(arcticTable)) {
+      return createOldLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
+          startupTimestampMillis, arcticTable, schema);
+    }
+    return new LogDynamicSource(
+        valueProjection,
         getSourceTopics(tableOptions),
         getSourceTopicPattern(tableOptions),
         properties,
@@ -262,6 +282,92 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         schema,
         tableOptions,
         arcticTable);
+  }
+
+  private ScanTableSource createOldLogDynamicSource(DataType physicalDataType,
+                                                    int[] valueProjection,
+                                                    Properties properties,
+                                                    Context context,
+                                                    ReadableConfig tableOptions,
+                                                    long startupTimestampMillis,
+                                                    ArcticTable arcticTable,
+                                                    Schema schema) {
+    FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+        getKeyDecodingFormat(helper);
+    final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat = getValueDecodingFormat(helper);
+
+    final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
+    final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
+    String startupMode = tableOptions.get(ArcticValidator.SCAN_STARTUP_MODE);
+
+    LOG.info("create log source with deprecated API");
+    return new KafkaDynamicSource(
+        physicalDataType,
+        keyDecodingFormat.orElse(null),
+        valueDecodingFormat,
+        keyProjection,
+        valueProjection,
+        keyPrefix,
+        KafkaConnectorOptionsUtil.getSourceTopics(tableOptions),
+        KafkaConnectorOptionsUtil.getSourceTopicPattern(tableOptions),
+        properties,
+        startupMode,
+        startupTimestampMillis,
+        false,
+        schema,
+        tableOptions,
+        arcticTable.name());
+  }
+
+  private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
+      FactoryUtil.TableFactoryHelper helper) {
+    final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+        helper.discoverOptionalDecodingFormat(
+            DeserializationFormatFactory.class, KEY_FORMAT);
+    keyDecodingFormat.ifPresent(
+        format -> {
+          if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            throw new ValidationException(
+                String.format(
+                    "A key format should only deal with INSERT-only records. " +
+                        "But %s has a changelog mode of %s.",
+                    helper.getOptions().get(KEY_FORMAT),
+                    format.getChangelogMode()));
+          }
+        });
+    return keyDecodingFormat;
+  }
+
+  /**
+   * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
+   * {@link LOG_STORE_TYPE} is kafka.
+   */
+  private static boolean useOldAPI(ArcticTable arcticTable) {
+    boolean useOldAPI = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
+        ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
+    if (useOldAPI) {
+      String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
+          LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
+      if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {
+        LOG.warn("{} option only take effect for {} = {}.",
+            ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(), LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_KAFKA);
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(
+      FactoryUtil.TableFactoryHelper helper) {
+    return helper.discoverOptionalDecodingFormat(
+            DeserializationFormatFactory.class, FactoryUtil.FORMAT)
+        .orElseGet(
+            () ->
+                helper.discoverDecodingFormat(
+                    DeserializationFormatFactory.class, VALUE_FORMAT));
   }
 
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -268,7 +268,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    if (adaptLegacySourc(arcticTable)) {
+    if (adaptLegacySource(arcticTable)) {
       return createLegacyLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
           startupTimestampMillis, arcticTable, schema);
     }
@@ -343,7 +343,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
    * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
    * {@link LOG_STORE_TYPE} is kafka.
    */
-  private static boolean adaptLegacySourc(ArcticTable arcticTable) {
+  private static boolean adaptLegacySource(ArcticTable arcticTable) {
     boolean legacySourceEnabled = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -268,8 +268,8 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     }
 
     LOG.info("build log source");
-    if (useOldAPI(arcticTable)) {
-      return createOldLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
+    if (adaptLegacySourc(arcticTable)) {
+      return createLegacyLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
           startupTimestampMillis, arcticTable, schema);
     }
     return new LogDynamicSource(
@@ -284,7 +284,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         arcticTable);
   }
 
-  private ScanTableSource createOldLogDynamicSource(DataType physicalDataType,
+  private ScanTableSource createLegacyLogDynamicSource(DataType physicalDataType,
                                                     int[] valueProjection,
                                                     Properties properties,
                                                     Context context,
@@ -343,11 +343,11 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
    * Return true only if {@link ArcticValidator#ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE} is true and
    * {@link LOG_STORE_TYPE} is kafka.
    */
-  private static boolean useOldAPI(ArcticTable arcticTable) {
-    boolean useOldAPI = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
+  private static boolean adaptLegacySourc(ArcticTable arcticTable) {
+    boolean legacySourceEnabled = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(),
         ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.defaultValue());
-    if (useOldAPI) {
+    if (legacySourceEnabled) {
       String logType = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
           LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT).toLowerCase();
       if (!Objects.equals(LOG_STORE_STORAGE_TYPE_KAFKA, logType)) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/KafkaDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/KafkaDynamicSource.java
@@ -19,19 +19,23 @@
 package com.netease.arctic.flink.table;
 
 import com.netease.arctic.flink.read.FlinkKafkaConsumer;
+import com.netease.arctic.flink.read.LogKafkaConsumer;
+import com.netease.arctic.flink.table.descriptors.ArcticValidator;
+import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.flink.util.Projection;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaDeserializationSchemaWrapper;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -45,7 +49,10 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 
@@ -65,14 +72,35 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSUMER_CHANGELOG_MODE;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_ALL_KINDS;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
+import static org.apache.flink.table.connector.ChangelogMode.insertOnly;
+
 /**
  * A version-agnostic Kafka {@link ScanTableSource}.
+ * <p>
+ * @deprecated since 0.4.1, will be removed in 0.7.0;
  */
 @Internal
 public class KafkaDynamicSource
     implements ScanTableSource, SupportsReadingMetadata, SupportsProjectionPushDown, SupportsWatermarkPushDown {
 
-  private static final String KAFKA_TRANSFORMATION = "kafka";
+  private final Schema schema;
+  private final ReadableConfig tableOptions;
+  private final String consumerChangelogMode;
+  private final boolean logRetractionEnable;
+
+  private static final ChangelogMode ALL_KINDS = ChangelogMode.newBuilder()
+      .addContainedKind(RowKind.INSERT)
+      .addContainedKind(RowKind.UPDATE_BEFORE)
+      .addContainedKind(RowKind.UPDATE_AFTER)
+      .addContainedKind(RowKind.DELETE)
+      .build();
 
   // --------------------------------------------------------------------------------------------
   // Mutable attributes
@@ -189,11 +217,65 @@ public class KafkaDynamicSource
       @Nullable List<String> topics,
       @Nullable Pattern topicPattern,
       Properties properties,
+      String startupMode,
+      long startupTimestampMillis,
+      boolean upsertMode,
+      Schema schema,
+      ReadableConfig tableOptions,
+      String sourceName) {
+    this(
+        physicalDataType,
+        keyDecodingFormat,
+        valueDecodingFormat,
+        keyProjection,
+        valueProjection,
+        keyPrefix,
+        topics,
+        topicPattern,
+        properties,
+        toInternal(startupMode),
+        new HashMap<>(),
+        startupTimestampMillis,
+        upsertMode,
+        sourceName,
+        schema,
+        tableOptions
+    );
+  }
+
+  public static StartupMode toInternal(String startupMode) {
+    startupMode = startupMode.toLowerCase();
+    switch (startupMode) {
+      case SCAN_STARTUP_MODE_LATEST:
+        return StartupMode.LATEST;
+      case SCAN_STARTUP_MODE_EARLIEST:
+        return StartupMode.EARLIEST;
+      case SCAN_STARTUP_MODE_TIMESTAMP:
+        return StartupMode.TIMESTAMP;
+      default:
+        throw new ValidationException(String.format(
+            "%s only support '%s', '%s'. But input is '%s'", ArcticValidator.SCAN_STARTUP_MODE,
+            SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST, startupMode));
+    }
+  }
+
+  public KafkaDynamicSource(
+      DataType physicalDataType,
+      @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+      DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+      int[] keyProjection,
+      int[] valueProjection,
+      @Nullable String keyPrefix,
+      @Nullable List<String> topics,
+      @Nullable Pattern topicPattern,
+      Properties properties,
       StartupMode startupMode,
       Map<KafkaTopicPartition, Long> specificStartupOffsets,
       long startupTimestampMillis,
       boolean upsertMode,
-      String sourceName) {
+      String sourceName,
+      Schema schema,
+      ReadableConfig tableOptions) {
     // Format attributes
     this.physicalDataType =
         Preconditions.checkNotNull(
@@ -228,11 +310,37 @@ public class KafkaDynamicSource
     this.startupTimestampMillis = startupTimestampMillis;
     this.upsertMode = upsertMode;
     this.sourceName = sourceName;
+
+    this.schema = schema;
+    this.tableOptions = tableOptions;
+    this.consumerChangelogMode = tableOptions.get(ARCTIC_LOG_CONSUMER_CHANGELOG_MODE);
+    this.logRetractionEnable = CompatibleFlinkPropertyUtil.propertyAsBoolean(tableOptions,
+        ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE);
   }
 
   @Override
   public ChangelogMode getChangelogMode() {
-    return valueDecodingFormat.getChangelogMode();
+    switch (consumerChangelogMode) {
+      case LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY:
+        if (logRetractionEnable) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Only %s is false when %s is %s",
+                  ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.key(),
+                  ARCTIC_LOG_CONSUMER_CHANGELOG_MODE.key(),
+                  LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY));
+        }
+        return insertOnly();
+      case LOG_CONSUMER_CHANGELOG_MODE_ALL_KINDS:
+        return ALL_KINDS;
+      default:
+        throw new UnsupportedOperationException(
+            String.format(
+                "As of now, %s can't support this option %s.",
+                ARCTIC_LOG_CONSUMER_CHANGELOG_MODE.key(),
+                consumerChangelogMode
+            ));
+    }
   }
 
   @Override
@@ -253,12 +361,8 @@ public class KafkaDynamicSource
 
     return new DataStreamScanProvider() {
       @Override
-      public DataStream<RowData> produceDataStream(
-          ProviderContext providerContext,
-          StreamExecutionEnvironment execEnv) {
-        DataStreamSource<RowData> sourceStream = execEnv.addSource(kafkaConsumer, sourceName, producedTypeInfo);
-        providerContext.generateUid(KAFKA_TRANSFORMATION).ifPresent(sourceStream::uid);
-        return sourceStream;
+      public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
+        return execEnv.addSource(kafkaConsumer, sourceName, producedTypeInfo);
       }
 
       @Override
@@ -351,7 +455,9 @@ public class KafkaDynamicSource
             specificStartupOffsets,
             startupTimestampMillis,
             upsertMode,
-            sourceName);
+            sourceName,
+            schema,
+            tableOptions);
     copy.producedDataType = producedDataType;
     copy.metadataKeys = metadataKeys;
     copy.projectedFields = projectedFields;
@@ -361,7 +467,7 @@ public class KafkaDynamicSource
 
   @Override
   public String asSummaryString() {
-    return "Kafka table source";
+    return "arctic";
   }
 
   @Override
@@ -420,7 +526,57 @@ public class KafkaDynamicSource
       DeserializationSchema<RowData> keyDeserialization,
       DeserializationSchema<RowData> valueDeserialization,
       TypeInformation<RowData> producedTypeInfo) {
-    throw new UnsupportedOperationException("cloud not create kafka consumer.");
+    final FlinkKafkaConsumer<RowData> kafkaConsumer;
+
+    final KafkaDeserializationSchemaWrapper<RowData> deserializationSchemaWrapper =
+        new KafkaDeserializationSchemaWrapper<>(valueDeserialization);
+    Schema projectedSchema = schema;
+    if (projectedFields != null) {
+      final List<Types.NestedField> columns = schema.columns();
+      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(columns::get).collect(Collectors.toList()));
+    }
+    if (topics != null) {
+      kafkaConsumer =
+          new LogKafkaConsumer(
+              topics,
+              deserializationSchemaWrapper,
+              properties,
+              projectedSchema,
+              tableOptions);
+    } else {
+      kafkaConsumer =
+          new LogKafkaConsumer(
+              topicPattern,
+              deserializationSchemaWrapper,
+              properties,
+              projectedSchema,
+              tableOptions);
+    }
+
+    switch (startupMode) {
+      case EARLIEST:
+        kafkaConsumer.setStartFromEarliest();
+        break;
+      case LATEST:
+        kafkaConsumer.setStartFromLatest();
+        break;
+      case GROUP_OFFSETS:
+        kafkaConsumer.setStartFromGroupOffsets();
+        break;
+      case SPECIFIC_OFFSETS:
+        kafkaConsumer.setStartFromSpecificOffsets(specificStartupOffsets);
+        break;
+      case TIMESTAMP:
+        kafkaConsumer.setStartFromTimestamp(startupTimestampMillis);
+        break;
+    }
+
+    kafkaConsumer.setCommitOffsetsOnCheckpoints(properties.getProperty("group.id") != null);
+
+    if (watermarkStrategy != null) {
+      kafkaConsumer.assignTimestampsAndWatermarks(watermarkStrategy);
+    }
+    return kafkaConsumer;
   }
 
   @Nullable

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -97,7 +97,8 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
       ConfigOptions.key("log-store.kafka.compatible.enabled")
           .booleanType()
           .defaultValue(false)
-          .withDescription("Flag hidden kafka read compatible with old API enable or not." +
+          .withDescription("Flag hidden kafka reading compatible with legacy Kafka Source API enable or not" +
+              " when restoring Flink application from a checkpoint." +
               " If a task should be restored from checkpoint which made in Arctic version less than 0.4.1");
   
   public static final ConfigOption<String> ARCTIC_LOG_CONSUMER_CHANGELOG_MODE =

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -92,6 +92,14 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           .defaultValue(false)
           .withDescription("Flag hidden kafka read retraction enable or not.");
 
+  @Deprecated
+  public static final ConfigOption<Boolean> ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE =
+      ConfigOptions.key("log-store.kafka.compatible.enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Flag hidden kafka read compatible with old API enable or not." +
+              " If a task should be restored from checkpoint which made in Arctic version less than 0.4.1");
+  
   public static final ConfigOption<String> ARCTIC_LOG_CONSUMER_CHANGELOG_MODE =
       ConfigOptions.key("log.consumer.changelog.modes")
           .stringType()

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -37,11 +37,12 @@ import org.apache.flink.util.CloseableIterator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
@@ -60,10 +61,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.netease.arctic.ams.api.MockArcticMetastoreServer.TEST_CATALOG_NAME;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.LOCATION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
 import static org.apache.flink.table.api.Expressions.$;
 
 @RunWith(Parameterized.class)
@@ -73,6 +77,8 @@ public class TestKeyed extends FlinkTestBase {
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule
+  public TestName testName = new TestName();
 
   private static final String DB = PK_TABLE_ID.getDatabase();
   private static final String TABLE = "test_keyed";
@@ -81,13 +87,19 @@ public class TestKeyed extends FlinkTestBase {
   private String db;
   private String topic;
   private HiveTableTestBase hiveTableTestBase = new HiveTableTestBase();
-
+  private Map<String, String> tableProperties = new HashMap<>();
   @Parameterized.Parameter
   public boolean isHive;
+  @Parameterized.Parameter(1)
+  public boolean kafkaLegacyEnable;
 
-  @Parameterized.Parameters(name = "isHive = {0}")
-  public static Collection<Boolean> parameters() {
-    return Arrays.asList(false);
+  @Parameterized.Parameters(name = "isHive = {0}, kafkaLegacyEnable = {2}")
+  public static Collection parameters() {
+    return Arrays.asList(
+        new Object[][]{
+            {false, true},
+            {false, false},
+        });
   }
 
   @BeforeClass
@@ -111,8 +123,24 @@ public class TestKeyed extends FlinkTestBase {
       db = DB;
       super.before();
     }
-    topic = String.join(".", catalog, db, TABLE);
+    prepareLog();
+
     super.config(catalog);
+  }
+
+  private void prepareLog() {
+    topic = TestUtil.getUtMethodName(testName) + isHive + kafkaLegacyEnable;
+    tableProperties.clear();
+    tableProperties.put(ENABLE_LOG_STORE, "true");
+    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
+
+    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
+    tableProperties.put(LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_KAFKA);
+    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
+
+    if (kafkaLegacyEnable) {
+      tableProperties.put(ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE.key(), "true");
+    }
   }
 
   @After
@@ -125,6 +153,7 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testSinkSourceFile() throws IOException {
+    Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0"),
         LocalDateTime.parse("2022-06-17T10:10:11.0").atZone(ZoneId.systemDefault()).toInstant()});
@@ -192,9 +221,6 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testUnpartitionLogSinkSource() throws Exception {
-    String topic = this.topic + "testUnpartitionLogSinkSource";
-    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
-
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a"});
     data.add(new Object[]{1000015, "b"});
@@ -215,10 +241,6 @@ public class TestKeyed extends FlinkTestBase {
 
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
 
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(ENABLE_LOG_STORE, "true");
-    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
-    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
@@ -249,9 +271,6 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testUnPartitionDoubleSink() throws Exception {
-    String topic = this.topic + "testUnPartitionDoubleSink";
-    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
-
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a"});
     data.add(new Object[]{1000015, "b"});
@@ -271,10 +290,6 @@ public class TestKeyed extends FlinkTestBase {
     getTableEnv().createTemporaryView("input", input);
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
 
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(ENABLE_LOG_STORE, "true");
-    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
-    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
@@ -302,6 +317,7 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testPartitionSinkFile() throws IOException {
+    Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
@@ -340,6 +356,7 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testFileUpsert() throws IOException {
+    Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.DELETE, 1000015, "b", LocalDateTime.parse("2022-06-17T10:08:11.0")});
@@ -384,21 +401,20 @@ public class TestKeyed extends FlinkTestBase {
             ") */")));
   }
 
-  // Ignore this case because of ci blocking problem in Github
-  @Ignore
   @Test
   public void testFileUpsertWithSamePrimaryKey() throws Exception {
+    Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000004, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000011, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000011, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
-      InternalTypeInfo.ofFields(
-        DataTypes.INT().getLogicalType(),
-        DataTypes.VARCHAR(100).getLogicalType(),
-        DataTypes.TIMESTAMP().getLogicalType()
-      ));
+        InternalTypeInfo.ofFields(
+            DataTypes.INT().getLogicalType(),
+            DataTypes.VARCHAR(100).getLogicalType(),
+            DataTypes.TIMESTAMP().getLogicalType()
+        ));
 
     getEnv().setParallelism(4);
     Table input = getTableEnv().fromDataStream(source, $("id"), $("name"), $("op_time"));
@@ -410,17 +426,17 @@ public class TestKeyed extends FlinkTestBase {
     tableProperties.put(TableProperties.UPSERT_ENABLED, "true");
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
-      ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+        ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE +
-      "/*+ OPTIONS(" +
-      "'arctic.emit.mode'='file'" +
-      ")*/" + " select * from input");
+        "/*+ OPTIONS(" +
+        "'arctic.emit.mode'='file'" +
+        ")*/" + " select * from input");
 
     TableResult result = exec("select * from arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
-      "'streaming'='false'" +
-      ") */");
+        "'streaming'='false'" +
+        ") */");
     LinkedList<Row> actual = new LinkedList<>();
     try (CloseableIterator<Row> iterator = result.collect()) {
       while (iterator.hasNext()) {
@@ -444,15 +460,12 @@ public class TestKeyed extends FlinkTestBase {
     Map<Object, List<Row>> expectedMap = DataUtil.groupByPrimaryKey(DataUtil.toRowList(expected), 0);
 
     for (Object key : actualMap.keySet()) {
-      Assert.assertTrue(CollectionUtils.isEqualCollection(actualMap.get(key),expectedMap.get(key)));
+      Assert.assertTrue(CollectionUtils.isEqualCollection(actualMap.get(key), expectedMap.get(key)));
     }
   }
 
   @Test
   public void testPartitionLogSinkSource() throws Exception {
-    String topic = this.topic + "testPartitionLogSinkSource";
-    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
-
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
@@ -475,10 +488,6 @@ public class TestKeyed extends FlinkTestBase {
 
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
 
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(ENABLE_LOG_STORE, "true");
-    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
-    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
@@ -509,9 +518,6 @@ public class TestKeyed extends FlinkTestBase {
 
   @Test
   public void testPartitionDoubleSink() throws Exception {
-    String topic = this.topic + "testPartitionDoubleSink";
-    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
-
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
@@ -533,10 +539,6 @@ public class TestKeyed extends FlinkTestBase {
     getTableEnv().createTemporaryView("input", input);
     sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
 
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put(ENABLE_LOG_STORE, "true");
-    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
-    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
         " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -93,7 +93,7 @@ public class TestKeyed extends FlinkTestBase {
   @Parameterized.Parameter(1)
   public boolean kafkaLegacyEnable;
 
-  @Parameterized.Parameters(name = "isHive = {0}, kafkaLegacyEnable = {2}")
+  @Parameterized.Parameters(name = "isHive = {0}, kafkaLegacyEnable = {1}")
   public static Collection parameters() {
     return Arrays.asList(
         new Object[][]{

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/util/TestUtil.java
@@ -20,6 +20,7 @@ package com.netease.arctic.flink.util;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.execution.JobClient;
+import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,17 @@ public class TestUtil {
 
   public static final Logger LOG = LoggerFactory.getLogger(TestUtil.class);
 
+  /**
+   * get ut method name without parameters.
+   */
+  public static String getUtMethodName(TestName testName) {
+    int i = testName.getMethodName().indexOf("[");
+    if (i == -1) {
+      return testName.getMethodName();
+    }
+    return testName.getMethodName().substring(0, i);
+  }
+  
   public static void cancelJob(JobClient jobClient) {
     if (isJobTerminated(jobClient)) {
       return;

--- a/site/config/ch/mkdocs.yml
+++ b/site/config/ch/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
     - Flink DataStream: flink/flink-ds.md
     - Using Kafka as Logstore: flink/hidden-kafka.md
     - Flink CDC to Arctic: flink/flink-cdc-to-arctic.md
+    - Upgrading Arctic Flink: flink/upgrading-arctic-flink.md
   - Spark Integration:
     - Getting Started: spark/spark-get-started.md
     - Spark DDL: spark/spark-ddl.md

--- a/site/docs/ch/flink/flink-dml.md
+++ b/site/docs/ch/flink/flink-dml.md
@@ -92,6 +92,7 @@ SELECT * FROM test_table /*+ OPTIONS('arctic.read.mode'='log') */;
 |properties.group.id| (none) |String|Logstore 是 kafka 并且是查询时必填，否则可不填| 读取 Kafka Topic 时使用的 group id|
 |properties.pulsar.admin.adminUrl| (none) |String|Logstore 是 pulsar 时必填，否则可不填| Pulsar admin 的 HTTP URL，如：http://my-broker.example.com:8080|
 |properties.*| (none) |String|否| Logstore的参数。<br><br>对于 Logstore 为 Kafka ('log-store.type'='kafka' 默认值)时，Kafka Consumer 支持的其他所有参数都可以通过在前面拼接 `properties.` 的前缀来设置，<br>如：`'properties.batch.size'='16384'`，<br>完整的参数信息可以参考 [Kafka官方手册](https://kafka.apache.org/documentation/#consumerconfigs); <br><br>对于 Logstore 为 Pulsar ('log-store.type'='pulsar')时，Pulsar 支持的相关配置都可以通过在前面拼接 `properties.` 的前缀来设置，<br>如：`'properties.pulsar.client.requestTimeoutMs'='60000'`，<br>完整的参数信息可以参考 [Flink-Pulsar-Connector文档](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/connectors/datastream/pulsar)|
+|log-store.kafka.compatible.enabled| false | Boolean | 否 | 兼容 Logstore Kafka 废弃的 API。当 Flink 任务（使用 >= 0.4.1 Arctic 版本）需要从低于此版本的状态恢复启动时，必须将该参数设为 true。该参数将于 0.7.0 版本删除。
 
 **注意事项**
 

--- a/site/docs/ch/flink/flink-dml.md
+++ b/site/docs/ch/flink/flink-dml.md
@@ -92,7 +92,7 @@ SELECT * FROM test_table /*+ OPTIONS('arctic.read.mode'='log') */;
 |properties.group.id| (none) |String|Logstore 是 kafka 并且是查询时必填，否则可不填| 读取 Kafka Topic 时使用的 group id|
 |properties.pulsar.admin.adminUrl| (none) |String|Logstore 是 pulsar 时必填，否则可不填| Pulsar admin 的 HTTP URL，如：http://my-broker.example.com:8080|
 |properties.*| (none) |String|否| Logstore的参数。<br><br>对于 Logstore 为 Kafka ('log-store.type'='kafka' 默认值)时，Kafka Consumer 支持的其他所有参数都可以通过在前面拼接 `properties.` 的前缀来设置，<br>如：`'properties.batch.size'='16384'`，<br>完整的参数信息可以参考 [Kafka官方手册](https://kafka.apache.org/documentation/#consumerconfigs); <br><br>对于 Logstore 为 Pulsar ('log-store.type'='pulsar')时，Pulsar 支持的相关配置都可以通过在前面拼接 `properties.` 的前缀来设置，<br>如：`'properties.pulsar.client.requestTimeoutMs'='60000'`，<br>完整的参数信息可以参考 [Flink-Pulsar-Connector文档](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/connectors/datastream/pulsar)|
-|log-store.kafka.compatible.enabled| false | Boolean | 否 | 兼容 Logstore Kafka 废弃的 API。当 Flink 任务（使用 >= 0.4.1 Arctic 版本）需要从低于此版本的状态恢复启动时，必须将该参数设为 true。该参数将于 0.7.0 版本删除。
+|log-store.kafka.compatible.enabled| false | Boolean | 否 | 兼容 Logstore Kafka 废弃的 Source API。当读取 logstore kafka 的 Flink 任务需要带状态升级到 0.4.1 及以上 Arctic 版本时，必须将该参数设为 true，否则会遇到状态不兼容的异常。<br>该参数将于 0.7.0 版本删除，届时废弃的 Source API 也会被删除。|
 
 **注意事项**
 

--- a/site/docs/ch/flink/upgrading-arctic-flink.md
+++ b/site/docs/ch/flink/upgrading-arctic-flink.md
@@ -1,0 +1,14 @@
+# Upgrading Arctic Flink And Compatibility
+
+Arctic Flink 任务通常需要长时间地运行。而 Arctic Flink 版本需要不断迭代升级优化，如 Bug 修复、Feature 支持、API 优化等。
+
+本文档描述了如何将线上运行的 Arctic Flink 任务迁移至新的版本，及版本间的兼容性。
+
+## API 废弃规则
+注释 Deprecated 的类、方法、变量等代码，将保留三个大的 Arctic 版本，并在第四个版本删除。请保证在此期间升级至最新的 API。
+
+## 版本兼容及迁移
+
+- 0.4.1 开始对 Log-store 的 API 进行重构，迁移至 Flink FLIP-27 的新接口。对于使用 Arctic Flink 版本 <= 0.4.0 的读 Arctic Log-store（Kafka） 任务，在使用旧的 checkpoint 状态升级到新的版本时，需注意：
+    1. 需要设置 Sql Hint 参数来使用废弃的 API 运行：log-store.kafka.compatible.enabled = true，见 [读 Logstore](flink-dml.md#Logstore 实时数据)。否则可能出现部分数据重复的现象。
+    2. 如有条件，可以升级至新的 API 来运行。在使用旧版本 Arctic Flink 的任务运行时，将 Kafka 的数据断流一小断时间，即在一段时间内，不往 Log-store Kafka 中写入数据来保证任务已经成功 checkpoint 并完成 Kafka Offset 的提交。然后停止任务，升级至 Arctic Flink 新的版本，从前面的状态中恢复任务。之后再恢复上游 Log-store Kafka 的正常写入。

--- a/site/docs/ch/flink/upgrading-arctic-flink.md
+++ b/site/docs/ch/flink/upgrading-arctic-flink.md
@@ -9,6 +9,6 @@ Arctic Flink 任务通常需要长时间地运行。而 Arctic Flink 版本需�
 
 ## 版本兼容及迁移
 
-- 0.4.1 开始对 Log-store 的 API 进行重构，迁移至 Flink FLIP-27 的新接口。对于使用 Arctic Flink 版本 <= 0.4.0 的读 Arctic Log-store（Kafka） 任务，在使用旧的 checkpoint 状态升级到新的版本时，需注意：
+- 0.4.1 版本开始对 Logstore 的 API 进行重构，迁移至 Flink FLIP-27 的新接口。对于使用 Arctic Flink 版本 <= 0.4.0 的读 Arctic Log-store（Kafka） 任务，在使用旧的 checkpoint 状态升级到新的版本时，需注意：
     1. 需要设置 Sql Hint 参数来使用废弃的 API 运行：log-store.kafka.compatible.enabled = true，见 [读 Logstore](flink-dml.md#Logstore 实时数据)。否则可能出现部分数据重复的现象。
-    2. 如有条件，可以升级至新的 API 来运行。在使用旧版本 Arctic Flink 的任务运行时，将 Kafka 的数据断流一小断时间，即在一段时间内，不往 Log-store Kafka 中写入数据来保证任务已经成功 checkpoint 并完成 Kafka Offset 的提交。然后停止任务，升级至 Arctic Flink 新的版本，从前面的状态中恢复任务。之后再恢复上游 Log-store Kafka 的正常写入。
+    2. 如有条件，可以升级至新的 API 来运行。在使用旧版本 Arctic Flink 的任务运行时，将 Kafka 的数据断流一小断时间，即在一段时间内，不往 Logstore Kafka 中写入数据来保证任务已经成功 checkpoint 并完成 Kafka Offset 的提交。然后停止任务，升级至 Arctic Flink 新的版本，从前面的状态中恢复任务。之后再恢复上游 Logstore Kafka 的正常写入。


### PR DESCRIPTION
## Why are the changes needed?
- Sql in deprecated LogKafkaSource api should be able to restore from ckp after bumping arctic-flink to new version.
- annotate the deprecated version and removed version.
- Adopt LogStoreAddress config in LogKafkaSourceBuilder.

## Brief change log

  - *Add the 'log-store.kafka.compatible.enabled' configuration to the Arctic log source in the flink modules*
  - *The flink 1.12 and 1.14, 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable**/ docs / JavaDocs / not documented)
