### PR TITLE
[Arctic-620][Spark]: Support refresh table

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkCatalog.java
@@ -391,11 +391,6 @@ public class ArcticSparkCatalog implements TableCatalog, SupportsNamespaces {
   }
 
   @Override
-  public void invalidateTable(Identifier ident) {
-    throw new UnsupportedOperationException("Unsupported invalidateTable.");
-  }
-
-  @Override
   public Identifier[] listTables(String[] namespace) {
     List<String> database;
     if (namespace == null || namespace.length == 0) {

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestKeyedTableDML.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestKeyedTableDML.java
@@ -70,6 +70,7 @@ public class TestKeyedTableDML extends SparkTestBase {
         " options ( \n" +
         " ''props.test1'' = ''val1'', \n" +
         " ''props.test2'' = ''val2'' ) ", database, table);
+    sql("refresh table {0}.{1}", database, table);
     keyedTable = loadTable(TableIdentifier.of(catalogNameArctic, database, table)).asKeyedTable();
   }
 


### PR DESCRIPTION

## Why are the changes needed?

fix #620 to support `refresh table xxx` grammar for arctic catalog.

## Brief change log

- Remove useless implement method in ArcticSparkCatalog.

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? ( no)
