### PR TITLE
[ARCTIC-1052] fix close_wait problem caused by limit query

### DIFF
--- a/trino/src/main/java/com/netease/arctic/trino/keyed/KeyedConnectorPageSource.java
+++ b/trino/src/main/java/com/netease/arctic/trino/keyed/KeyedConnectorPageSource.java
@@ -206,6 +206,9 @@ public class KeyedConnectorPageSource implements ConnectorPageSource {
   @Override
   public void close() throws IOException {
     close = true;
+    if (current != null) {
+      current.close();
+    }
   }
 
   protected void closeWithSuppression(Throwable throwable) {


### PR DESCRIPTION
# Why are the changes needed?
**To fix #1052 **
When trino executes the limit statement, it will read the page through the driver. When the read page meets the limit number requirements, it will close the corresponding pagesource, that is, KeyedConnectorPageSource, no longer read subsequent pages, and call the close method.

```
@Override
public void close() throws IOException {
  close = true;
}
```

However, KeyedConnectorPageSource uses current (an instance of IcebergPageSource) to get the page. Current is closed only when all pages have been read. 

```
while (page == null) {
  page = current.getNextPage();
  if (page == null) {
    current.close();
    if (dataTasksIt.hasNext()) {
      completedPositions += current.getCompletedPositions().isPresent() ?
          current.getCompletedPositions().getAsLong() : 0L;
      completedBytes += current.getCompletedBytes();
      readTimeNanos += current.getReadTimeNanos();
      current = open(dataTasksIt.next());
    } else {
      return null;
    }
  }
}
```
Therefore, when the KeyedConnectorPageSource has been closed, the IcebergPageSource has not been closed. Thus close_wait is generated.


# Brief change log
close current in KeyedConnectorPageSource.close()

```
  public void close() throws IOException {
    close = true;
    if (current != null) {
      current.close();
    }
  }
```