### PR TITLE
[ARCTIC-924][Hive] When AMS runs for a period of time and then cannot connect to HMS

### DIFF
--- a/hive/src/main/java/com/netease/arctic/hive/ArcticHiveClientPool.java
+++ b/hive/src/main/java/com/netease/arctic/hive/ArcticHiveClientPool.java
@@ -47,7 +47,7 @@ public class ArcticHiveClientPool extends ClientPoolImpl<HMSClient, TException> 
       .build();
 
   public ArcticHiveClientPool(TableMetaStore tableMetaStore, int poolSize) {
-    super(poolSize, TTransportException.class, false);
+    super(poolSize, TTransportException.class, true);
     this.hiveConf = new HiveConf(tableMetaStore.getConfiguration(), ArcticHiveClientPool.class);
     this.hiveConf.addResource(tableMetaStore.getConfiguration());
     this.hiveConf.addResource(tableMetaStore.getHiveSiteLocation().orElse(null));

--- a/hive/src/main/java/com/netease/arctic/hive/CachedHiveClientPool.java
+++ b/hive/src/main/java/com/netease/arctic/hive/CachedHiveClientPool.java
@@ -73,7 +73,7 @@ public class CachedHiveClientPool implements HMSClientPool, Serializable {
   @Override
   public <R> R run(Action<R, HMSClient, TException> action) throws TException, InterruptedException {
     try {
-      return tableMetaStore.doAs(() -> clientPool().run(action));
+      return tableMetaStore.doAs(() -> clientPool().run(action, true));
     } catch (RuntimeException e) {
       throw throwTException(e);
     }

--- a/hive/src/main/java/com/netease/arctic/hive/CachedHiveClientPool.java
+++ b/hive/src/main/java/com/netease/arctic/hive/CachedHiveClientPool.java
@@ -73,7 +73,7 @@ public class CachedHiveClientPool implements HMSClientPool, Serializable {
   @Override
   public <R> R run(Action<R, HMSClient, TException> action) throws TException, InterruptedException {
     try {
-      return tableMetaStore.doAs(() -> clientPool().run(action, true));
+      return tableMetaStore.doAs(() -> clientPool().run(action));
     } catch (RuntimeException e) {
       throw throwTException(e);
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
fix #924 

## Brief change log

  - Set the default retry to true when the CachedHiveClientPool executes an HMS-related operation

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? ( no)
