### PR TITLE
[ARCTIC-1039][FLINK] Datastream API optimize

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -30,7 +30,6 @@ import com.netease.arctic.table.TableBuilder;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
-import org.apache.flink.streaming.connectors.kafka.table.KafkaOptions;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -240,23 +239,6 @@ public class ArcticCatalog extends AbstractCatalog {
       tableProperties.putIfAbsent(FactoryUtil.FORMAT.key(), tableProperties.getOrDefault(
           TableProperties.LOG_STORE_DATA_FORMAT,
           TableProperties.LOG_STORE_DATA_FORMAT_DEFAULT));
-      if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
-        tableProperties.putIfAbsent(KafkaOptions.TOPIC.key(),
-            tableProperties.get(TableProperties.LOG_STORE_MESSAGE_TOPIC));
-      }
-
-      if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
-        tableProperties.putIfAbsent(KafkaOptions.PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
-            TableProperties.LOG_STORE_ADDRESS));
-      }
-      tableProperties.putIfAbsent("properties.key.serializer",
-          "org.apache.kafka.common.serialization.ByteArraySerializer");
-      tableProperties.putIfAbsent("properties.value.serializer",
-          "org.apache.kafka.common.serialization.ByteArraySerializer");
-      tableProperties.putIfAbsent("properties.key.deserializer",
-          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-      tableProperties.putIfAbsent("properties.value.deserializer",
-          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
     }
   }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -19,7 +19,6 @@
 package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
-import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.kafka.source.KafkaSource;
@@ -55,6 +54,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_ST
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -387,11 +388,11 @@ public class LogKafkaSourceBuilder {
   }
 
   private void convertArcticProperties() {
-    if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
+    if (tableProperties.containsKey(LOG_STORE_ADDRESS)) {
       props.put(KafkaOptions.PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
-          TableProperties.LOG_STORE_ADDRESS));
+          LOG_STORE_ADDRESS));
     }
-    if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
+    if (tableProperties.containsKey(LOG_STORE_MESSAGE_TOPIC)) {
       setTopics(getLogTopic(tableProperties));
     }
 
@@ -494,10 +495,10 @@ public class LogKafkaSourceBuilder {
     // Check required configs.
     checkNotNull(
         props.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
-        String.format("Property %s is required but not provided", ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        String.format("Property %s is required but not provided", LOG_STORE_ADDRESS));
     // Check required settings.
     checkNotNull(
         subscriber,
-        "No subscribe mode is specified, should be one of topics, topic pattern and partition set.");
+        String.format("No topic is specified, '%s' should be set.", LOG_STORE_MESSAGE_TOPIC));
   }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -84,14 +84,14 @@ public class LogKafkaSourceBuilder {
   private Boundedness boundedness;
   private KafkaRecordDeserializer deserializationSchema;
   // The configurations.
-  protected Properties props;
+  protected Properties kafkaProperties;
 
   private Schema schema;
   private Map<String, String> tableProperties;
 
   /**
    * @param schema          read schema, only contains the selected fields
-   * @param tableProperties arctic table properties with sql hints
+   * @param tableProperties arctic table properties, maybe include Flink SQL hints.
    */
   LogKafkaSourceBuilder(Schema schema, Map<String, String> tableProperties) {
     this.subscriber = null;
@@ -99,10 +99,10 @@ public class LogKafkaSourceBuilder {
     this.stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
     this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
     this.deserializationSchema = null;
-    this.props = getLogStoreProperties(tableProperties);
+    this.kafkaProperties = getLogStoreProperties(tableProperties);
     this.schema = schema;
     this.tableProperties = tableProperties;
-    convertArcticProperties();
+    setupKafkaProperties();
   }
 
   /**
@@ -337,7 +337,7 @@ public class LogKafkaSourceBuilder {
    * @return this LogKafkaSourceBuilder.
    */
   public LogKafkaSourceBuilder setProperty(String key, String value) {
-    props.setProperty(key, value);
+    kafkaProperties.setProperty(key, value);
     return this;
   }
 
@@ -364,7 +364,7 @@ public class LogKafkaSourceBuilder {
    * @return this LogKafkaSourceBuilder.
    */
   public LogKafkaSourceBuilder setProperties(Properties props) {
-    this.props.putAll(props);
+    this.kafkaProperties.putAll(props);
     return this;
   }
 
@@ -382,28 +382,28 @@ public class LogKafkaSourceBuilder {
         stoppingOffsetsInitializer,
         boundedness,
         deserializationSchema,
-        props,
+        kafkaProperties,
         schema,
         tableProperties);
   }
 
-  private void convertArcticProperties() {
+  private void setupKafkaProperties() {
     if (tableProperties.containsKey(LOG_STORE_ADDRESS)) {
-      props.put(BOOTSTRAP_SERVERS_CONFIG, tableProperties.get(LOG_STORE_ADDRESS));
+      kafkaProperties.put(BOOTSTRAP_SERVERS_CONFIG, tableProperties.get(LOG_STORE_ADDRESS));
     }
     if (tableProperties.containsKey(LOG_STORE_MESSAGE_TOPIC)) {
       setTopics(getLogTopic(tableProperties));
     }
 
-    props.putIfAbsent("properties.key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    props.putIfAbsent("properties.value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    props.putIfAbsent("properties.key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-    props.putIfAbsent("properties.value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    kafkaProperties.putIfAbsent("properties.key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+    kafkaProperties.putIfAbsent("properties.value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+    kafkaProperties.putIfAbsent("properties.key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    kafkaProperties.putIfAbsent("properties.value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 
-    setStartupMode();
+    setupStartupMode();
   }
 
-  private void setStartupMode() {
+  private void setupStartupMode() {
     String startupMode = CompatiblePropertyUtil.propertyAsString(tableProperties, SCAN_STARTUP_MODE.key(),
         SCAN_STARTUP_MODE.defaultValue()).toLowerCase();
     long startupTimestampMillis = 0L;
@@ -468,24 +468,24 @@ public class LogKafkaSourceBuilder {
     // If the client id prefix is not set, reuse the consumer group id as the client id prefix.
     maybeOverride(
         KafkaSourceOptions.CLIENT_ID_PREFIX.key(),
-        props.getProperty(ConsumerConfig.GROUP_ID_CONFIG),
+        kafkaProperties.getProperty(ConsumerConfig.GROUP_ID_CONFIG),
         false);
   }
 
   private boolean maybeOverride(String key, String value, boolean override) {
     boolean overridden = false;
-    String userValue = props.getProperty(key);
+    String userValue = kafkaProperties.getProperty(key);
     if (userValue != null) {
       if (override) {
         LOG.warn(
             String.format(
                 "Property %s is provided but will be overridden from %s to %s",
                 key, userValue, value));
-        props.setProperty(key, value);
+        kafkaProperties.setProperty(key, value);
         overridden = true;
       }
     } else {
-      props.setProperty(key, value);
+      kafkaProperties.setProperty(key, value);
     }
     return overridden;
   }
@@ -493,7 +493,7 @@ public class LogKafkaSourceBuilder {
   private void sanityCheck() {
     // Check required configs.
     checkNotNull(
-        props.getProperty(BOOTSTRAP_SERVERS_CONFIG),
+        kafkaProperties.getProperty(BOOTSTRAP_SERVERS_CONFIG),
         String.format("Property %s is required but not provided", LOG_STORE_ADDRESS));
     // Check required settings.
     checkNotNull(

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -28,7 +28,6 @@ import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStopping
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
-import org.apache.flink.streaming.connectors.kafka.table.KafkaOptions;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
@@ -57,6 +56,7 @@ import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTo
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
 /**
  * The @builder class for {@link LogKafkaSource} to make it easier for the users to construct a {@link
@@ -389,8 +389,7 @@ public class LogKafkaSourceBuilder {
 
   private void convertArcticProperties() {
     if (tableProperties.containsKey(LOG_STORE_ADDRESS)) {
-      props.put(KafkaOptions.PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
-          LOG_STORE_ADDRESS));
+      props.put(BOOTSTRAP_SERVERS_CONFIG, tableProperties.get(LOG_STORE_ADDRESS));
     }
     if (tableProperties.containsKey(LOG_STORE_MESSAGE_TOPIC)) {
       setTopics(getLogTopic(tableProperties));
@@ -494,7 +493,7 @@ public class LogKafkaSourceBuilder {
   private void sanityCheck() {
     // Check required configs.
     checkNotNull(
-        props.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
+        props.getProperty(BOOTSTRAP_SERVERS_CONFIG),
         String.format("Property %s is required but not provided", LOG_STORE_ADDRESS));
     // Check required settings.
     checkNotNull(

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -395,10 +395,14 @@ public class LogKafkaSourceBuilder {
       setTopics(getLogTopic(tableProperties));
     }
 
-    kafkaProperties.putIfAbsent("properties.key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    kafkaProperties.putIfAbsent("properties.value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    kafkaProperties.putIfAbsent("properties.key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-    kafkaProperties.putIfAbsent("properties.value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    kafkaProperties.putIfAbsent("properties.key.serializer",
+        "org.apache.kafka.common.serialization.ByteArraySerializer");
+    kafkaProperties.putIfAbsent("properties.value.serializer",
+        "org.apache.kafka.common.serialization.ByteArraySerializer");
+    kafkaProperties.putIfAbsent("properties.key.deserializer",
+        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    kafkaProperties.putIfAbsent("properties.value.deserializer",
+        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 
     setupStartupMode();
   }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -51,7 +51,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_ST
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
-import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.fetchLogstorePrefixProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
@@ -99,7 +99,7 @@ public class LogKafkaSourceBuilder {
     this.stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
     this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
     this.deserializationSchema = null;
-    this.kafkaProperties = getLogStoreProperties(tableProperties);
+    this.kafkaProperties = fetchLogstorePrefixProperties(tableProperties);
     this.schema = schema;
     this.tableProperties = tableProperties;
     setupKafkaProperties();

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -18,6 +18,9 @@
 
 package com.netease.arctic.flink.read.source.log.kafka;
 
+import com.netease.arctic.flink.table.descriptors.ArcticValidator;
+import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.utils.CompatiblePropertyUtil;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
@@ -26,6 +29,9 @@ import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStopping
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
+import org.apache.flink.streaming.connectors.kafka.table.KafkaOptions;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
@@ -36,11 +42,19 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -84,9 +98,10 @@ public class LogKafkaSourceBuilder {
     this.stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
     this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
     this.deserializationSchema = null;
-    this.props = new Properties();
+    this.props = getLogStoreProperties(tableProperties);
     this.schema = schema;
     this.tableProperties = tableProperties;
+    convertArcticProperties();
   }
 
   /**
@@ -369,6 +384,51 @@ public class LogKafkaSourceBuilder {
         props,
         schema,
         tableProperties);
+  }
+
+  private void convertArcticProperties() {
+    if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
+      props.put(KafkaOptions.PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
+          TableProperties.LOG_STORE_ADDRESS));
+    }
+    if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
+      setTopics(getLogTopic(tableProperties));
+    }
+
+    props.putIfAbsent("properties.key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+    props.putIfAbsent("properties.value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+    props.putIfAbsent("properties.key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    props.putIfAbsent("properties.value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+    setStartupMode();
+  }
+
+  private void setStartupMode() {
+    String startupMode = CompatiblePropertyUtil.propertyAsString(tableProperties, SCAN_STARTUP_MODE.key(),
+        SCAN_STARTUP_MODE.defaultValue()).toLowerCase();
+    long startupTimestampMillis = 0L;
+    if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
+      startupTimestampMillis = Long.parseLong(Preconditions.checkNotNull(
+          tableProperties.get(SCAN_STARTUP_TIMESTAMP_MILLIS.key()),
+          String.format("'%s' should be set in '%s' mode",
+              SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP)));
+    }
+
+    switch (startupMode) {
+      case SCAN_STARTUP_MODE_EARLIEST:
+        setStartingOffsets(OffsetsInitializer.earliest());
+        break;
+      case SCAN_STARTUP_MODE_LATEST:
+        setStartingOffsets(OffsetsInitializer.latest());
+        break;
+      case SCAN_STARTUP_MODE_TIMESTAMP:
+        setStartingOffsets(OffsetsInitializer.timestamp(startupTimestampMillis));
+        break;
+      default:
+        throw new ValidationException(String.format(
+            "%s only support '%s', '%s', '%s'. But input is '%s'", ArcticValidator.SCAN_STARTUP_MODE,
+            SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST, SCAN_STARTUP_MODE_TIMESTAMP, startupMode));
+    }
   }
 
   // ------------- private helpers  --------------

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/pulsar/LogPulsarSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/pulsar/LogPulsarSourceBuilder.java
@@ -18,7 +18,9 @@
 
 package com.netease.arctic.flink.read.source.log.pulsar;
 
+import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.utils.CompatiblePropertyUtil;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.pulsar.source.PulsarSourceBuilder;
@@ -26,16 +28,26 @@ import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.FullRangeGenerator;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.SplitRangeGenerator;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
 
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static java.lang.Boolean.FALSE;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ENABLE_TRANSACTION;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_CONSUMER_NAME;
@@ -89,11 +101,51 @@ public class LogPulsarSourceBuilder extends PulsarSourceBuilder<RowData> {
     super();
     this.schema = schema;
     this.tableProperties = tableProperties;
+    this.setProperties(getLogStoreProperties(tableProperties));
+    convertArcticProperties();
   }
 
   public LogPulsarSourceBuilder setProperties(Properties properties) {
     configBuilder.set(properties);
     return this;
+  }
+
+  private void convertArcticProperties() {
+    if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
+      this.setServiceUrl(tableProperties.get(TableProperties.LOG_STORE_ADDRESS));
+    }
+    if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
+      setTopics(getLogTopic(tableProperties));
+    }
+
+    setStartupMode();
+  }
+
+  private void setStartupMode() {
+    String startupMode = CompatiblePropertyUtil.propertyAsString(tableProperties, SCAN_STARTUP_MODE.key(),
+        SCAN_STARTUP_MODE.defaultValue()).toLowerCase();
+    long startupTimestampMillis = 0L;
+    if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
+      startupTimestampMillis = Long.parseLong(Preconditions.checkNotNull(
+          tableProperties.get(SCAN_STARTUP_TIMESTAMP_MILLIS.key()),
+          String.format("'%s' should be set in '%s' mode",
+              SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP)));
+    }
+    switch (startupMode) {
+      case SCAN_STARTUP_MODE_EARLIEST:
+        this.setStartCursor(StartCursor.earliest());
+        break;
+      case SCAN_STARTUP_MODE_LATEST:
+        this.setStartCursor(StartCursor.latest());
+        break;
+      case SCAN_STARTUP_MODE_TIMESTAMP:
+        this.setStartCursor(StartCursor.fromPublishTime(startupTimestampMillis));
+        break;
+      default:
+        throw new ValidationException(String.format(
+            "%s only support '%s', '%s', '%s'. But input is '%s'", ArcticValidator.SCAN_STARTUP_MODE,
+            SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST, SCAN_STARTUP_MODE_TIMESTAMP, startupMode));
+    }
   }
 
   /**
@@ -103,9 +155,6 @@ public class LogPulsarSourceBuilder extends PulsarSourceBuilder<RowData> {
    */
   @SuppressWarnings("java:S3776")
   public LogPulsarSource build() {
-    if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
-      this.setServiceUrl(tableProperties.get(TableProperties.LOG_STORE_ADDRESS));
-    }
     buildOfficial();
 
     // If subscription name is not set, set a random value.

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/pulsar/LogPulsarSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/pulsar/LogPulsarSourceBuilder.java
@@ -102,7 +102,7 @@ public class LogPulsarSourceBuilder extends PulsarSourceBuilder<RowData> {
     this.schema = schema;
     this.tableProperties = tableProperties;
     this.setProperties(getLogStoreProperties(tableProperties));
-    convertArcticProperties();
+    setupPulsarProperties();
   }
 
   public LogPulsarSourceBuilder setProperties(Properties properties) {
@@ -110,7 +110,7 @@ public class LogPulsarSourceBuilder extends PulsarSourceBuilder<RowData> {
     return this;
   }
 
-  private void convertArcticProperties() {
+  private void setupPulsarProperties() {
     if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
       this.setServiceUrl(tableProperties.get(TableProperties.LOG_STORE_ADDRESS));
     }
@@ -118,10 +118,10 @@ public class LogPulsarSourceBuilder extends PulsarSourceBuilder<RowData> {
       setTopics(getLogTopic(tableProperties));
     }
 
-    setStartupMode();
+    setuptartupMode();
   }
 
-  private void setStartupMode() {
+  private void setuptartupMode() {
     String startupMode = CompatiblePropertyUtil.propertyAsString(tableProperties, SCAN_STARTUP_MODE.key(),
         SCAN_STARTUP_MODE.defaultValue()).toLowerCase();
     long startupTimestampMillis = 0L;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/pulsar/LogPulsarSourceBuilder.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/pulsar/LogPulsarSourceBuilder.java
@@ -46,7 +46,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_ST
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
-import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.fetchLogstorePrefixProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static java.lang.Boolean.FALSE;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ENABLE_TRANSACTION;
@@ -101,7 +101,7 @@ public class LogPulsarSourceBuilder extends PulsarSourceBuilder<RowData> {
     super();
     this.schema = schema;
     this.tableProperties = tableProperties;
-    this.setProperties(getLogStoreProperties(tableProperties));
+    this.setProperties(fetchLogstorePrefixProperties(tableProperties));
     setupPulsarProperties();
   }
 
@@ -118,10 +118,10 @@ public class LogPulsarSourceBuilder extends PulsarSourceBuilder<RowData> {
       setTopics(getLogTopic(tableProperties));
     }
 
-    setuptartupMode();
+    setupStartupMode();
   }
 
-  private void setuptartupMode() {
+  private void setupStartupMode() {
     String startupMode = CompatiblePropertyUtil.propertyAsString(tableProperties, SCAN_STARTUP_MODE.key(),
         SCAN_STARTUP_MODE.defaultValue()).toLowerCase();
     long startupTimestampMillis = 0L;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSink.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSink.java
@@ -34,9 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.Properties;
-
-import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 
 /**
  * Flink table api that generates sink operators.
@@ -47,18 +44,15 @@ public class ArcticDynamicSink implements DynamicTableSink, SupportsPartitioning
 
   private final ArcticTableLoader tableLoader;
   private final CatalogTable flinkTable;
-  private final String topic;
   private final boolean primaryKeyExisted;
   private boolean overwrite = false;
 
   ArcticDynamicSink(
       CatalogTable flinkTable,
       ArcticTableLoader tableLoader,
-      String topic,
       boolean primaryKeyExisted) {
     this.tableLoader = tableLoader;
     this.flinkTable = flinkTable;
-    this.topic = topic;
     this.primaryKeyExisted = primaryKeyExisted;
   }
 
@@ -76,15 +70,12 @@ public class ArcticDynamicSink implements DynamicTableSink, SupportsPartitioning
   @Override
   public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
     ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
-    Properties producerConfig = getLogStoreProperties(table.properties());
 
     return (DataStreamSinkProvider) dataStream -> {
       DataStreamSink<?> ds = FlinkSink
           .forRowData(dataStream)
           .table(table)
           .flinkSchema(flinkTable.getSchema())
-          .producerConfig(producerConfig)
-          .topic(topic)
           .tableLoader(tableLoader)
           .overwrite(overwrite)
           .build();

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -179,8 +179,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     ObjectIdentifier identifier = context.getObjectIdentifier();
     Map<String, String> options = catalogTable.getOptions();
 
-    final String topic = options.get(TableProperties.LOG_STORE_MESSAGE_TOPIC);
-
     ArcticTableLoader tableLoader = createTableLoader(
         new ObjectPath(identifier.getDatabaseName(), identifier.getObjectName()),
         internalCatalogName, internalCatalogBuilder, options);
@@ -189,7 +187,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     return new ArcticDynamicSink(
         catalogTable,
         tableLoader,
-        topic,
         table.isKeyedTable()
     );
   }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -71,7 +71,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
-import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.fetchLogstorePrefixProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
@@ -238,7 +238,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
     Schema schema = FlinkSchemaUtil.convert(physicalSchema);
 
-    final Properties properties = getLogStoreProperties(arcticTable.properties());
+    final Properties properties = fetchLogstorePrefixProperties(arcticTable.properties());
 
     // add topic-partition discovery
     final Optional<Long> partitionDiscoveryInterval =

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -87,8 +87,6 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.TOP
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.VALUE_FORMAT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createKeyFormatProjection;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createValueFormatProjection;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getSourceTopicPattern;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getSourceTopics;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.validateSourceTopic;
 
 /**
@@ -253,44 +251,30 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(),
         partitionDiscoveryInterval.orElse(-1L).toString());
 
-    final DataType physicalDataType =
-        catalogTable.getSchema().toPhysicalRowDataType();
+    final DataType physicalDataType = catalogTable.getSchema().toPhysicalRowDataType();
 
     final int[] valueProjection = createValueFormatProjection(tableOptions, physicalDataType);
-
-    String startupMode = tableOptions.get(SCAN_STARTUP_MODE);
-    long startupTimestampMillis = 0L;
-    if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
-      startupTimestampMillis = Preconditions.checkNotNull(tableOptions.get(SCAN_STARTUP_TIMESTAMP_MILLIS),
-          String.format("'%s' should be set in '%s' mode",
-              SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP));
-    }
 
     LOG.info("build log source");
     if (adaptLegacySource(arcticTable)) {
       return createLegacyLogDynamicSource(physicalDataType, valueProjection, properties, context, tableOptions,
-          startupTimestampMillis, arcticTable, schema);
+          arcticTable, schema);
     }
     return new LogDynamicSource(
         valueProjection,
-        getSourceTopics(tableOptions),
-        getSourceTopicPattern(tableOptions),
         properties,
-        startupMode,
-        startupTimestampMillis,
         schema,
         tableOptions,
         arcticTable);
   }
 
   private ScanTableSource createLegacyLogDynamicSource(DataType physicalDataType,
-                                                    int[] valueProjection,
-                                                    Properties properties,
-                                                    Context context,
-                                                    ReadableConfig tableOptions,
-                                                    long startupTimestampMillis,
-                                                    ArcticTable arcticTable,
-                                                    Schema schema) {
+                                                       int[] valueProjection,
+                                                       Properties properties,
+                                                       Context context,
+                                                       ReadableConfig tableOptions,
+                                                       ArcticTable arcticTable,
+                                                       Schema schema) {
     FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
     final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
         getKeyDecodingFormat(helper);
@@ -299,7 +283,12 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     final int[] keyProjection = createKeyFormatProjection(tableOptions, physicalDataType);
     final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
     String startupMode = tableOptions.get(SCAN_STARTUP_MODE);
-
+    long startupTimestampMillis = 0L;
+    if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
+      startupTimestampMillis = Preconditions.checkNotNull(tableOptions.get(SCAN_STARTUP_TIMESTAMP_MILLIS),
+          String.format("'%s' should be set in '%s' mode",
+              SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP));
+    }
     LOG.info("create log source with deprecated API");
     return new KafkaDynamicSource(
         physicalDataType,

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -240,8 +240,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
     Schema schema = FlinkSchemaUtil.convert(physicalSchema);
 
-    validateSourceTopic(tableOptions);
-
     final Properties properties = getLogStoreProperties(arcticTable.properties());
 
     // add topic-partition discovery

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -22,19 +22,14 @@ import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceBuilder;
 import com.netease.arctic.flink.read.source.log.pulsar.LogPulsarSource;
 import com.netease.arctic.flink.read.source.log.pulsar.LogPulsarSourceBuilder;
-import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
-import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
-import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -52,16 +47,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSUMER_CHANGELOG_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_ALL_KINDS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.LOG_CONSUMER_CHANGELOG_MODE_APPEND_ONLY;
-import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
-import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
-import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_PULSAR;
@@ -74,7 +65,7 @@ import static org.apache.flink.table.connector.ChangelogMode.insertOnly;
 public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown {
 
   private static final Logger LOG = LoggerFactory.getLogger(LogDynamicSource.class);
-  
+
   private final ArcticTable arcticTable;
   private final Schema schema;
   private final ReadableConfig tableOptions;
@@ -85,7 +76,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
    * Watermark strategy that is used to generate per-partition watermark.
    */
   protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
-  
+
   /** Data type to configure the formats. */
 
   /**
@@ -94,30 +85,9 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   protected final int[] valueProjection;
 
   /**
-   * The logStore message queue's topics
-   */
-  protected final List<String> topics;
-
-  /**
-   * The logStore topic pattern to consume.
-   */
-  protected final Pattern topicPattern;
-
-  /**
    * Properties for the logStore consumer.
    */
   protected final Properties properties;
-
-  /**
-   * The startup mode for the contained consumer (default is {@link StartupMode#GROUP_OFFSETS}).
-   */
-  protected final StartupMode startupMode;
-
-  /**
-   * The start timestamp to locate partition offsets; only relevant when startup mode is {@link
-   * StartupMode#TIMESTAMP}.
-   */
-  protected final long startupTimestampMillis;
 
   private static final ChangelogMode ALL_KINDS = ChangelogMode.newBuilder()
       .addContainedKind(RowKind.INSERT)
@@ -126,29 +96,9 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       .addContainedKind(RowKind.DELETE)
       .build();
 
-  public static StartupMode toInternal(String startupMode) {
-    startupMode = startupMode.toLowerCase();
-    switch (startupMode) {
-      case SCAN_STARTUP_MODE_LATEST:
-        return StartupMode.LATEST;
-      case SCAN_STARTUP_MODE_EARLIEST:
-        return StartupMode.EARLIEST;
-      case SCAN_STARTUP_MODE_TIMESTAMP:
-        return StartupMode.TIMESTAMP;
-      default:
-        throw new ValidationException(String.format(
-            "%s only support '%s', '%s'. But input is '%s'", ArcticValidator.SCAN_STARTUP_MODE,
-            SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST, startupMode));
-    }
-  }
-
   public LogDynamicSource(
       int[] valueProjection,
-      @Nullable List<String> topics,
-      @Nullable Pattern topicPattern,
       Properties properties,
-      String startupMode,
-      long startupTimestampMillis,
       Schema schema,
       ReadableConfig tableOptions,
       ArcticTable arcticTable) {
@@ -159,20 +109,12 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
         ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.key(), ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.defaultValue());
     this.arcticTable = arcticTable;
     this.valueProjection = valueProjection;
-    this.topics = topics;
-    this.topicPattern = topicPattern;
     this.properties = properties;
-    this.startupMode = toInternal(startupMode);
-    this.startupTimestampMillis = startupTimestampMillis;
   }
 
   public LogDynamicSource(
       int[] valueProjection,
-      @Nullable List<String> topics,
-      @Nullable Pattern topicPattern,
       Properties properties,
-      StartupMode startupMode,
-      long startupTimestampMillis,
       Schema schema,
       ReadableConfig tableOptions,
       ArcticTable arcticTable,
@@ -184,11 +126,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.logRetractionEnable = logRetractionEnable;
     this.arcticTable = arcticTable;
     this.valueProjection = valueProjection;
-    this.topics = topics;
-    this.topicPattern = topicPattern;
     this.properties = properties;
-    this.startupMode = startupMode;
-    this.startupTimestampMillis = startupTimestampMillis;
   }
 
   protected LogKafkaSource createKafkaSource() {
@@ -199,29 +137,8 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     }
 
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
-    if (topics != null) {
-      kafkaSourceBuilder.setTopics(topics);
-    } else {
-      kafkaSourceBuilder.setTopicPattern(topicPattern);
-    }
-
-    switch (startupMode) {
-      case EARLIEST:
-        kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.earliest());
-        break;
-      case LATEST:
-        kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.latest());
-        break;
-      case GROUP_OFFSETS:
-        kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.committedOffsets());
-        break;
-      case TIMESTAMP:
-        kafkaSourceBuilder.setStartingOffsets(
-            OffsetsInitializer.timestamp(startupTimestampMillis));
-        break;
-    }
     kafkaSourceBuilder.setProperties(properties);
-    
+
     LOG.info("build log kafka source");
     return kafkaSourceBuilder.build();
   }
@@ -234,23 +151,6 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     }
 
     LogPulsarSourceBuilder pulsarSourceBuilder = LogPulsarSource.builder(projectedSchema, arcticTable.properties());
-    if (topics != null) {
-      pulsarSourceBuilder.setTopics(topics);
-    } else {
-      pulsarSourceBuilder.setTopicPattern(topicPattern);
-    }
-
-    switch (startupMode) {
-      case EARLIEST:
-        pulsarSourceBuilder.setStartCursor(StartCursor.earliest());
-        break;
-      case LATEST:
-        pulsarSourceBuilder.setStartCursor(StartCursor.latest());
-        break;
-      case TIMESTAMP:
-        pulsarSourceBuilder.setStartCursor(StartCursor.fromPublishTime(startupTimestampMillis));
-        break;
-    }
     pulsarSourceBuilder.setProperties(properties);
 
     LOG.info("build log pulsar source");
@@ -322,11 +222,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   public DynamicTableSource copy() {
     return new LogDynamicSource(
         this.valueProjection,
-        this.topics,
-        this.topicPattern,
         this.properties,
-        this.startupMode,
-        this.startupTimestampMillis,
         this.schema,
         this.tableOptions,
         this.arcticTable,

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/PulsarConfigurationConverter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/PulsarConfigurationConverter.java
@@ -25,8 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
 
-import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
-
 /**
  * It's used for converting Arctic log-store related properties in {@link com.netease.arctic.table.TableProperties}
  * to Flink official pulsar configuration.
@@ -37,13 +35,10 @@ public class PulsarConfigurationConverter {
 
   /**
    * @param arcticProperties The key has been trimmed of Arctic prefix
-   * @param serviceUrl       e.g. pulsar://localhost:6650
    * @return Properties with Flink Pulsar source keys
    */
-  public static SinkConfiguration toSinkConf(Properties arcticProperties, String serviceUrl) {
+  public static SinkConfiguration toSinkConf(Properties arcticProperties) {
     Configuration conf = new Configuration();
-    conf.setString(PULSAR_SERVICE_URL.key(), serviceUrl);
-
     arcticProperties.stringPropertyNames().forEach(k -> {
       String v = (String) arcticProperties.get(k);
       conf.setString(k, v);

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.fetchLogstorePrefixProperties;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION;
@@ -161,7 +161,7 @@ public class ArcticUtils {
     Preconditions.checkNotNull(topic, String.format("Topic should be specified. It can be set by '%s'",
         LOG_STORE_MESSAGE_TOPIC));
 
-    producerConfig = combineArcticProperties(properties, producerConfig);
+    producerConfig = combineTableAndUnderlyingLogstoreProperties(properties, producerConfig);
     String logType = CompatibleFlinkPropertyUtil.propertyAsString(properties, LOG_STORE_TYPE,
         LOG_STORE_STORAGE_TYPE_DEFAULT);
 
@@ -196,14 +196,21 @@ public class ArcticUtils {
         "'. only support 'v1' or empty");
   }
 
-  private static Properties combineArcticProperties(Map<String, String> tableProperties,
+  /**
+   * Extract and combine the properties for underlying log store queue.
+   * @param tableProperties arctic table properties
+   * @param producerConfig can be set by java API
+   * @return properties with tableProperties and producerConfig which has higher priority.
+   */
+  private static Properties combineTableAndUnderlyingLogstoreProperties(Map<String, String> tableProperties,
                                                     Properties producerConfig) {
     Properties finalProp;
-    Properties props = getLogStoreProperties(tableProperties);
+    Properties underlyingLogStoreProps = fetchLogstorePrefixProperties(tableProperties);
     if (producerConfig == null) {
-      finalProp = props;
+      finalProp = underlyingLogStoreProps;
     } else {
-      props.stringPropertyNames().forEach(k -> producerConfig.putIfAbsent(k, props.get(k)));
+      underlyingLogStoreProps.stringPropertyNames()
+          .forEach(k -> producerConfig.putIfAbsent(k, underlyingLogStoreProps.get(k)));
       finalProp = producerConfig;
     }
     

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -39,28 +39,37 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_PROPERTIES_PREFIX;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_PULSAR;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
 /**
  * An util that loads arctic table, build arctic log writer and so on.
@@ -135,8 +144,8 @@ public class ArcticUtils {
    * @return ArcticLogWriter
    */
   public static ArcticLogWriter buildArcticLogWriter(Map<String, String> properties,
-                                                     Properties producerConfig,
-                                                     String topic,
+                                                     @Nullable Properties producerConfig,
+                                                     @Nullable String topic,
                                                      TableSchema tableSchema,
                                                      String arcticEmitMode,
                                                      ShuffleHelper helper,
@@ -146,6 +155,16 @@ public class ArcticUtils {
       return null;
     }
 
+    if (topic == null) {
+      topic = CompatibleFlinkPropertyUtil.propertyAsString(properties, LOG_STORE_MESSAGE_TOPIC, null);
+    }
+    Preconditions.checkNotNull(topic, String.format("Topic should be specified. It can be set by '%s'",
+        LOG_STORE_MESSAGE_TOPIC));
+
+    producerConfig = combineArcticProperties(properties, producerConfig);
+    String logType = CompatibleFlinkPropertyUtil.propertyAsString(properties, LOG_STORE_TYPE,
+        LOG_STORE_STORAGE_TYPE_DEFAULT);
+
     String version = properties.getOrDefault(LOG_STORE_DATA_VERSION, LOG_STORE_DATA_VERSION_DEFAULT);
     if (LOG_STORE_DATA_VERSION_DEFAULT.equals(version)) {
       if (arcticEmitMode.equals(ArcticValidator.ARCTIC_EMIT_AUTO)) {
@@ -154,7 +173,7 @@ public class ArcticUtils {
             FlinkSchemaUtil.convert(tableSchema),
             producerConfig,
             topic,
-            buildLogMsgFactory(properties),
+            buildLogMsgFactory(logType),
             LogRecordV1.fieldGetterFactory,
             IdGenerator.generateUpstreamId(),
             helper,
@@ -168,7 +187,7 @@ public class ArcticUtils {
           FlinkSchemaUtil.convert(tableSchema),
           producerConfig,
           topic,
-          buildLogMsgFactory(properties),
+          buildLogMsgFactory(logType),
           LogRecordV1.fieldGetterFactory,
           IdGenerator.generateUpstreamId(),
           helper);
@@ -177,17 +196,58 @@ public class ArcticUtils {
         "'. only support 'v1' or empty");
   }
 
-  public static <T> LogMsgFactory<T> buildLogMsgFactory(Map<String, String> tableProperties) {
+  private static Properties combineArcticProperties(Map<String, String> tableProperties,
+                                                    Properties producerConfig) {
+    Properties finalProp;
+    Properties props = getLogStoreProperties(tableProperties);
+    if (producerConfig == null) {
+      finalProp = props;
+    } else {
+      props.stringPropertyNames().forEach(k -> producerConfig.putIfAbsent(k, props.get(k)));
+      finalProp = producerConfig;
+    }
+    
+    String logStoreAddress = CompatibleFlinkPropertyUtil.propertyAsString(tableProperties,
+        LOG_STORE_ADDRESS, null);
+    
     String logType = CompatibleFlinkPropertyUtil.propertyAsString(tableProperties, LOG_STORE_TYPE,
         LOG_STORE_STORAGE_TYPE_DEFAULT);
+    if (logType.equals(LOG_STORE_STORAGE_TYPE_KAFKA)) {
+      finalProp.putIfAbsent("key.serializer",
+          "org.apache.kafka.common.serialization.ByteArraySerializer");
+      finalProp.putIfAbsent("value.serializer",
+          "org.apache.kafka.common.serialization.ByteArraySerializer");
+      finalProp.putIfAbsent("key.deserializer",
+          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+      finalProp.putIfAbsent("value.deserializer",
+          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+      if (logStoreAddress != null) {
+        finalProp.putIfAbsent(BOOTSTRAP_SERVERS_CONFIG, logStoreAddress);
+      }
+
+      Preconditions.checkArgument(finalProp.containsKey(BOOTSTRAP_SERVERS_CONFIG), String.format("%s should be set",
+          LOG_STORE_ADDRESS));
+    } else {
+      if (logStoreAddress != null) {
+        finalProp.putIfAbsent(PULSAR_SERVICE_URL.key(), logStoreAddress);
+      }
+
+      Preconditions.checkArgument(finalProp.containsKey(PULSAR_SERVICE_URL.key()), String.format("%s should be set",
+          LOG_STORE_ADDRESS));
+    }
+
+    return finalProp;
+  }
+
+  public static <T> LogMsgFactory<T> buildLogMsgFactory(String logType) {
     LogMsgFactory<T> factory;
     switch (logType) {
       case LOG_STORE_STORAGE_TYPE_KAFKA:
         factory = new HiddenKafkaFactory<>();
         break;
       case LOG_STORE_STORAGE_TYPE_PULSAR:
-        factory = new HiddenPulsarFactory<>(
-            CompatibleFlinkPropertyUtil.propertyAsString(tableProperties, LOG_STORE_ADDRESS, null));
+        factory = new HiddenPulsarFactory<>();
         break;
       default:
         throw new UnsupportedOperationException("only support 'kafka' or 'pulsar' now, but input is " + logType);

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
@@ -126,7 +126,7 @@ public class CompatibleFlinkPropertyUtil {
    * @param tableOptions including table properties and flink options
    * @return Properties. The keys in it have no {@link TableProperties#LOG_STORE_PROPERTIES_PREFIX}.
    */
-  public static Properties getLogStoreProperties(Map<String, String> tableOptions) {
+  public static Properties fetchLogstorePrefixProperties(Map<String, String> tableOptions) {
     final Properties properties = new Properties();
 
     if (hasPrefix(tableOptions, TableProperties.LOG_STORE_PROPERTIES_PREFIX)) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
@@ -21,9 +21,12 @@ package com.netease.arctic.flink.util;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.table.TableProperties;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.connectors.kafka.table.KafkaOptions;
 import org.apache.iceberg.util.PropertyUtil;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -144,6 +147,12 @@ public class CompatibleFlinkPropertyUtil {
           CompatibleFlinkPropertyUtil.propertyAsString(tableOptions, LOG_STORE_ADDRESS, null));
     }
     return properties;
+  }
+
+  public static List<String> getLogTopic(Map<String, String> tableProperties) {
+    Configuration conf = new Configuration();
+    conf.setString(KafkaOptions.TOPIC.key(), tableProperties.get(TableProperties.LOG_STORE_MESSAGE_TOPIC));
+    return conf.get(KafkaOptions.TOPIC);
   }
 
   public static boolean hasPrefix(Map<String, String> tableOptions, String prefix) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
@@ -139,13 +139,7 @@ public class CompatibleFlinkPropertyUtil {
                 properties.put(subKey, value);
               });
     }
-
-    // convert the key to support create client in writer
-    if (CompatibleFlinkPropertyUtil.propertyAsString(tableOptions, LOG_STORE_TYPE, LOG_STORE_STORAGE_TYPE_DEFAULT)
-        .equals(LOG_STORE_STORAGE_TYPE_PULSAR)) {
-      properties.put(PULSAR_SERVICE_URL.key(),
-          CompatibleFlinkPropertyUtil.propertyAsString(tableOptions, LOG_STORE_ADDRESS, null));
-    }
+    
     return properties;
   }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/pulsar/HiddenPulsarFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/pulsar/HiddenPulsarFactory.java
@@ -35,10 +35,7 @@ import static org.apache.iceberg.relocated.com.google.common.base.Preconditions.
 public class HiddenPulsarFactory<T> implements LogMsgFactory<T> {
   private static final long serialVersionUID = -1L;
 
-  private final String serviceUrl;
-
-  public HiddenPulsarFactory(String serviceUrl) {
-    this.serviceUrl = serviceUrl;
+  public HiddenPulsarFactory() {
   }
 
   @Override
@@ -48,7 +45,7 @@ public class HiddenPulsarFactory<T> implements LogMsgFactory<T> {
       LogDataJsonSerialization<T> logDataJsonSerialization,
       ShuffleHelper helper) {
     checkNotNull(topic);
-    SinkConfiguration conf = toSinkConf(producerConfig, serviceUrl);
+    SinkConfiguration conf = toSinkConf(producerConfig);
 
     return new HiddenPulsarProducer<>(
         conf,

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/HiddenLogOperatorsTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/HiddenLogOperatorsTest.java
@@ -89,6 +89,7 @@ import static com.netease.arctic.flink.write.hidden.BaseLogTest.userSchema;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_PULSAR;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
 
 /**
  * Hidden log operator tests.
@@ -557,9 +558,10 @@ public class HiddenLogOperatorsTest {
         properties = getPropertiesByTopic(topic);
         break;
       case LOG_STORE_STORAGE_TYPE_PULSAR:
-        logMsgFactory = new HiddenPulsarFactory(pulsarHelper.op().serviceUrl());
+        logMsgFactory = new HiddenPulsarFactory();
         properties = new Properties();
         properties.put(PULSAR_ADMIN_URL.key(), pulsarHelper.op().adminUrl());
+        properties.put(PULSAR_SERVICE_URL.key(), pulsarHelper.op().serviceUrl());
         break;
       default:
         throw new UnsupportedOperationException(type);

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -71,8 +71,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.FlinkSchemaUtil.toSchema;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC;
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 
 /**
@@ -242,28 +240,6 @@ public class ArcticCatalog extends AbstractCatalog {
       tableProperties.putIfAbsent(FactoryUtil.FORMAT.key(), tableProperties.getOrDefault(
           TableProperties.LOG_STORE_DATA_FORMAT,
           TableProperties.LOG_STORE_DATA_FORMAT_DEFAULT));
-      if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
-        tableProperties.putIfAbsent(
-            TOPIC.key(),
-            tableProperties.get(TableProperties.LOG_STORE_MESSAGE_TOPIC));
-      }
-
-      if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
-        tableProperties.putIfAbsent(PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
-            TableProperties.LOG_STORE_ADDRESS));
-      }
-      tableProperties.putIfAbsent(
-          "properties.key.serializer",
-          "org.apache.kafka.common.serialization.ByteArraySerializer");
-      tableProperties.putIfAbsent(
-          "properties.value.serializer",
-          "org.apache.kafka.common.serialization.ByteArraySerializer");
-      tableProperties.putIfAbsent(
-          "properties.key.deserializer",
-          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-      tableProperties.putIfAbsent(
-          "properties.value.deserializer",
-          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
     }
   }
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -57,8 +57,8 @@ import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogSt
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
 /**
  * The @builder class for {@link LogKafkaSource} to make it easier for the users to construct a {@link
@@ -298,7 +298,7 @@ public class LogKafkaSourceBuilder {
    * org.apache.kafka.clients.consumer.ConsumerRecord ConsumerRecord} for LogKafkaSource.
    *
    * @param recordDeserializer the deserializer for Kafka {@link
-   *     org.apache.kafka.clients.consumer.ConsumerRecord ConsumerRecord}.
+   *                           org.apache.kafka.clients.consumer.ConsumerRecord ConsumerRecord}.
    * @return this LogKafkaSourceBuilder.
    */
   public LogKafkaSourceBuilder setDeserializer(
@@ -388,10 +388,10 @@ public class LogKafkaSourceBuilder {
         schema,
         tableProperties);
   }
-  
+
   private void convertArcticProperties() {
     if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
-      props.put(PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
+      props.put(BOOTSTRAP_SERVERS_CONFIG, tableProperties.get(
           TableProperties.LOG_STORE_ADDRESS));
     }
     if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
@@ -496,7 +496,7 @@ public class LogKafkaSourceBuilder {
   private void sanityCheck() {
     // Check required configs.
     checkNotNull(
-        props.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
+        props.getProperty(BOOTSTRAP_SERVERS_CONFIG),
         String.format("Property %s is required but not provided", LOG_STORE_ADDRESS));
     // Check required settings.
     checkNotNull(

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -398,10 +398,14 @@ public class LogKafkaSourceBuilder {
       setTopics(getLogTopic(tableProperties));
     }
 
-    kafkaProperties.putIfAbsent("properties.key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    kafkaProperties.putIfAbsent("properties.value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    kafkaProperties.putIfAbsent("properties.key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-    kafkaProperties.putIfAbsent("properties.value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    kafkaProperties.putIfAbsent("properties.key.serializer",
+        "org.apache.kafka.common.serialization.ByteArraySerializer");
+    kafkaProperties.putIfAbsent("properties.value.serializer",
+        "org.apache.kafka.common.serialization.ByteArraySerializer");
+    kafkaProperties.putIfAbsent("properties.key.deserializer",
+        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    kafkaProperties.putIfAbsent("properties.value.deserializer",
+        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 
     setupStartupMode();
   }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -18,6 +18,9 @@
 
 package com.netease.arctic.flink.read.source.log.kafka;
 
+import com.netease.arctic.flink.table.descriptors.ArcticValidator;
+import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.utils.CompatiblePropertyUtil;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
@@ -26,7 +29,9 @@ import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStopping
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
@@ -37,11 +42,20 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -85,9 +99,10 @@ public class LogKafkaSourceBuilder {
     this.stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
     this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
     this.deserializationSchema = null;
-    this.props = new Properties();
+    this.props = getLogStoreProperties(tableProperties);
     this.schema = schema;
     this.tableProperties = tableProperties;
+    convertArcticProperties();
   }
 
   /**
@@ -370,6 +385,51 @@ public class LogKafkaSourceBuilder {
         props,
         schema,
         tableProperties);
+  }
+  
+  private void convertArcticProperties() {
+    if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
+      props.put(PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
+          TableProperties.LOG_STORE_ADDRESS));
+    }
+    if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
+      setTopics(getLogTopic(tableProperties));
+    }
+
+    props.putIfAbsent("properties.key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+    props.putIfAbsent("properties.value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+    props.putIfAbsent("properties.key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    props.putIfAbsent("properties.value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+    setStartupMode();
+  }
+
+  private void setStartupMode() {
+    String startupMode = CompatiblePropertyUtil.propertyAsString(tableProperties, SCAN_STARTUP_MODE.key(),
+        SCAN_STARTUP_MODE.defaultValue()).toLowerCase();
+    long startupTimestampMillis = 0L;
+    if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
+      startupTimestampMillis = Long.parseLong(Preconditions.checkNotNull(
+          tableProperties.get(SCAN_STARTUP_TIMESTAMP_MILLIS.key()),
+          String.format("'%s' should be set in '%s' mode",
+              SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP)));
+    }
+
+    switch (startupMode) {
+      case SCAN_STARTUP_MODE_EARLIEST:
+        setStartingOffsets(OffsetsInitializer.earliest());
+        break;
+      case SCAN_STARTUP_MODE_LATEST:
+        setStartingOffsets(OffsetsInitializer.latest());
+        break;
+      case SCAN_STARTUP_MODE_TIMESTAMP:
+        setStartingOffsets(OffsetsInitializer.timestamp(startupTimestampMillis));
+        break;
+      default:
+        throw new ValidationException(String.format(
+            "%s only support '%s', '%s', '%s'. But input is '%s'", ArcticValidator.SCAN_STARTUP_MODE,
+            SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST, SCAN_STARTUP_MODE_TIMESTAMP, startupMode));
+    }
   }
 
   // ------------- private helpers  --------------

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -53,7 +53,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_ST
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
-import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.fetchLogstorePrefixProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
@@ -101,7 +101,7 @@ public class LogKafkaSourceBuilder {
     this.stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
     this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
     this.deserializationSchema = null;
-    this.kafkaProperties = getLogStoreProperties(tableProperties);
+    this.kafkaProperties = fetchLogstorePrefixProperties(tableProperties);
     this.schema = schema;
     this.tableProperties = tableProperties;
     setupKafkaProperties();

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -55,6 +55,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_ST
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -495,10 +497,10 @@ public class LogKafkaSourceBuilder {
     // Check required configs.
     checkNotNull(
         props.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
-        String.format("Property %s is required but not provided", ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        String.format("Property %s is required but not provided", LOG_STORE_ADDRESS));
     // Check required settings.
     checkNotNull(
         subscriber,
-        "No subscribe mode is specified, should be one of topics, topic pattern and partition set.");
+        String.format("No topic is specified, '%s' should be set.", LOG_STORE_MESSAGE_TOPIC));
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSink.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSink.java
@@ -48,18 +48,15 @@ public class ArcticDynamicSink implements DynamicTableSink, SupportsPartitioning
 
   private final ArcticTableLoader tableLoader;
   private final CatalogTable flinkTable;
-  private final String topic;
   private final boolean primaryKeyExisted;
   private boolean overwrite = false;
 
   ArcticDynamicSink(
       CatalogTable flinkTable,
       ArcticTableLoader tableLoader,
-      String topic,
       boolean primaryKeyExisted) {
     this.tableLoader = tableLoader;
     this.flinkTable = flinkTable;
-    this.topic = topic;
     this.primaryKeyExisted = primaryKeyExisted;
   }
 
@@ -77,15 +74,12 @@ public class ArcticDynamicSink implements DynamicTableSink, SupportsPartitioning
   @Override
   public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
     ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
-    Properties producerConfig = getKafkaProperties(table.properties());
 
     return (DataStreamSinkProvider) dataStream -> {
       DataStreamSink<?> ds = FlinkSink
           .forRowData(dataStream)
           .table(table)
           .flinkSchema(flinkTable.getSchema())
-          .producerConfig(producerConfig)
-          .topic(topic)
           .tableLoader(tableLoader)
           .overwrite(overwrite)
           .build();

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -25,7 +25,6 @@ import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
-import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ConfigOption;
@@ -177,8 +176,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     ObjectIdentifier identifier = context.getObjectIdentifier();
     Map<String, String> options = catalogTable.getOptions();
 
-    final String topic = options.get(TableProperties.LOG_STORE_MESSAGE_TOPIC);
-
     ArcticTableLoader tableLoader = createTableLoader(
         new ObjectPath(identifier.getDatabaseName(), identifier.getObjectName()),
         internalCatalogName, internalCatalogBuilder, options);
@@ -187,7 +184,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     return new ArcticDynamicSink(
         catalogTable,
         tableLoader,
-        topic,
         table.isKeyedTable()
     );
   }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -68,7 +68,6 @@ import static com.netease.arctic.flink.catalog.factories.ArcticCatalogFactoryOpt
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createKeyFormatProjection;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createValueFormatProjection;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getKafkaProperties;
-import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.validateSourceTopic;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
@@ -239,8 +238,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     CatalogTable catalogTable = context.getCatalogTable();
     TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
     Schema schema = FlinkSchemaUtil.convert(physicalSchema);
-
-    validateSourceTopic(tableOptions);
 
     final Properties properties = getKafkaProperties(arcticTable.properties());
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -25,6 +25,7 @@ import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
+import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ConfigOption;
@@ -69,6 +70,7 @@ import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createVal
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getKafkaProperties;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE_DEFAULT;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
@@ -84,6 +86,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOp
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SINK_PARTITIONER;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.VALUE_FORMAT;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
 /**
  * A factory generates {@link ArcticDynamicSource} and {@link ArcticDynamicSink}
@@ -278,10 +281,18 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     String startupMode = tableOptions.get(ArcticValidator.SCAN_STARTUP_MODE);
     long startupTimestampMillis = 0L;
     if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
-      startupTimestampMillis = Preconditions.checkNotNull(tableOptions.get(ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS),
+      startupTimestampMillis = Preconditions.checkNotNull(
+          tableOptions.get(ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS),
           String.format("'%s' should be set in '%s' mode",
               ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP));
     }
+
+    String logStoreAddress = CompatibleFlinkPropertyUtil.propertyAsString(arcticTable.properties(),
+        TableProperties.LOG_STORE_ADDRESS, null);
+    if (logStoreAddress != null) {
+      properties.putIfAbsent(BOOTSTRAP_SERVERS_CONFIG, logStoreAddress);
+    }
+    
     LOG.info("create log source with deprecated API");
     return new KafkaDynamicSource(
         physicalDataType,
@@ -290,7 +301,7 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
         keyProjection,
         valueProjection,
         keyPrefix,
-        KafkaConnectorOptionsUtil.getSourceTopics(tableOptions),
+        getLogTopic(arcticTable.properties()),
         KafkaConnectorOptionsUtil.getSourceTopicPattern(tableOptions),
         properties,
         startupMode,

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -37,11 +37,13 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
@@ -51,9 +53,16 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
 /**
  * An util that loads arctic table, build arctic log writer and so on.
@@ -131,8 +140,8 @@ public class ArcticUtils {
    * @return ArcticLogWriter
    */
   public static ArcticLogWriter buildArcticLogWriter(Map<String, String> properties,
-                                                     Properties producerConfig,
-                                                     String topic,
+                                                     @Nullable Properties producerConfig,
+                                                     @Nullable String topic,
                                                      TableSchema tableSchema,
                                                      String arcticEmitMode,
                                                      ShuffleHelper helper,
@@ -141,6 +150,14 @@ public class ArcticUtils {
     if (!arcticWALWriterEnable(properties, arcticEmitMode)) {
       return null;
     }
+
+    if (topic == null) {
+      topic = CompatibleFlinkPropertyUtil.propertyAsString(properties, LOG_STORE_MESSAGE_TOPIC, null);
+    }
+    Preconditions.checkNotNull(topic, String.format("Topic should be specified. It can be set by '%s'",
+        LOG_STORE_MESSAGE_TOPIC));
+
+    producerConfig = combineArcticProperties(properties, producerConfig);
 
     String version = properties.getOrDefault(LOG_STORE_DATA_VERSION, LOG_STORE_DATA_VERSION_DEFAULT);
     if (LOG_STORE_DATA_VERSION_DEFAULT.equals(version)) {
@@ -171,6 +188,43 @@ public class ArcticUtils {
     }
     throw new UnsupportedOperationException("don't support log version '" + version +
         "'. only support 'v1' or empty");
+  }
+
+  private static Properties combineArcticProperties(Map<String, String> tableProperties,
+                                                    Properties producerConfig) {
+    Properties finalProp;
+    Properties props = getLogStoreProperties(tableProperties);
+    if (producerConfig == null) {
+      finalProp = props;
+    } else {
+      props.stringPropertyNames().forEach(k -> producerConfig.putIfAbsent(k, props.get(k)));
+      finalProp = producerConfig;
+    }
+
+    String logStoreAddress = CompatibleFlinkPropertyUtil.propertyAsString(tableProperties,
+        LOG_STORE_ADDRESS, null);
+
+    String logType = CompatibleFlinkPropertyUtil.propertyAsString(tableProperties, LOG_STORE_TYPE,
+        LOG_STORE_STORAGE_TYPE_DEFAULT);
+    if (logType.equals(LOG_STORE_STORAGE_TYPE_KAFKA)) {
+      finalProp.putIfAbsent("key.serializer",
+          "org.apache.kafka.common.serialization.ByteArraySerializer");
+      finalProp.putIfAbsent("value.serializer",
+          "org.apache.kafka.common.serialization.ByteArraySerializer");
+      finalProp.putIfAbsent("key.deserializer",
+          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+      finalProp.putIfAbsent("value.deserializer",
+          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+      if (logStoreAddress != null) {
+        finalProp.putIfAbsent(BOOTSTRAP_SERVERS_CONFIG, logStoreAddress);
+      }
+
+      Preconditions.checkArgument(finalProp.containsKey(BOOTSTRAP_SERVERS_CONFIG), String.format("%s should be set",
+          LOG_STORE_ADDRESS));
+    }
+
+    return finalProp;
   }
 
   public static boolean arcticFileWriterEnable(String arcticEmitMode) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
@@ -19,11 +19,21 @@
 package com.netease.arctic.flink.util;
 
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
+import com.netease.arctic.table.TableProperties;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.util.PropertyUtil;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
+import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_PULSAR;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC;
 
 /**
  * PropertyUtil compatible with legacy flink properties
@@ -106,5 +116,38 @@ public class CompatibleFlinkPropertyUtil {
       return ArcticValidator.DIM_TABLE_ENABLE_LEGACY;
     }
     return null;
+  }
+
+  /**
+   * Get log-store properties from table properties and flink options, whose prefix is
+   * {@link TableProperties#LOG_STORE_PROPERTIES_PREFIX}.
+   *
+   * @param tableOptions including table properties and flink options
+   * @return Properties. The keys in it have no {@link TableProperties#LOG_STORE_PROPERTIES_PREFIX}.
+   */
+  public static Properties getLogStoreProperties(Map<String, String> tableOptions) {
+    final Properties properties = new Properties();
+
+    if (hasPrefix(tableOptions, TableProperties.LOG_STORE_PROPERTIES_PREFIX)) {
+      tableOptions.keySet().stream()
+          .filter(key -> key.startsWith(TableProperties.LOG_STORE_PROPERTIES_PREFIX))
+          .forEach(
+              key -> {
+                final String value = tableOptions.get(key);
+                final String subKey = key.substring((TableProperties.LOG_STORE_PROPERTIES_PREFIX).length());
+                properties.put(subKey, value);
+              });
+    }
+    return properties;
+  }
+
+  public static boolean hasPrefix(Map<String, String> tableOptions, String prefix) {
+    return tableOptions.keySet().stream().anyMatch(k -> k.startsWith(prefix));
+  }
+
+  public static List<String> getLogTopic(Map<String, String> tableProperties) {
+    Configuration conf = new Configuration();
+    conf.setString(TOPIC.key(), tableProperties.get(TableProperties.LOG_STORE_MESSAGE_TOPIC));
+    return conf.get(TOPIC);
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
@@ -125,7 +125,7 @@ public class CompatibleFlinkPropertyUtil {
    * @param tableOptions including table properties and flink options
    * @return Properties. The keys in it have no {@link TableProperties#LOG_STORE_PROPERTIES_PREFIX}.
    */
-  public static Properties getLogStoreProperties(Map<String, String> tableOptions) {
+  public static Properties fetchLogstorePrefixProperties(Map<String, String> tableOptions) {
     final Properties properties = new Properties();
 
     if (hasPrefix(tableOptions, TableProperties.LOG_STORE_PROPERTIES_PREFIX)) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/catalog/ArcticCatalog.java
@@ -71,8 +71,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.netease.arctic.flink.FlinkSchemaUtil.toSchema;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC;
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 
 /**
@@ -242,28 +240,6 @@ public class ArcticCatalog extends AbstractCatalog {
       tableProperties.putIfAbsent(FactoryUtil.FORMAT.key(), tableProperties.getOrDefault(
           TableProperties.LOG_STORE_DATA_FORMAT,
           TableProperties.LOG_STORE_DATA_FORMAT_DEFAULT));
-      if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
-        tableProperties.putIfAbsent(
-            TOPIC.key(),
-            tableProperties.get(TableProperties.LOG_STORE_MESSAGE_TOPIC));
-      }
-
-      if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
-        tableProperties.putIfAbsent(PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
-            TableProperties.LOG_STORE_ADDRESS));
-      }
-      tableProperties.putIfAbsent(
-          "properties.key.serializer",
-          "org.apache.kafka.common.serialization.ByteArraySerializer");
-      tableProperties.putIfAbsent(
-          "properties.value.serializer",
-          "org.apache.kafka.common.serialization.ByteArraySerializer");
-      tableProperties.putIfAbsent(
-          "properties.key.deserializer",
-          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-      tableProperties.putIfAbsent(
-          "properties.value.deserializer",
-          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
     }
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -57,8 +57,8 @@ import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogSt
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
 /**
  * The @builder class for {@link LogKafkaSource} to make it easier for the users to construct a {@link
@@ -391,7 +391,7 @@ public class LogKafkaSourceBuilder {
 
   private void convertArcticProperties() {
     if (tableProperties.containsKey(TableProperties.LOG_STORE_ADDRESS)) {
-      props.put(PROPS_BOOTSTRAP_SERVERS.key(), tableProperties.get(
+      props.put(BOOTSTRAP_SERVERS_CONFIG, tableProperties.get(
           TableProperties.LOG_STORE_ADDRESS));
     }
     if (tableProperties.containsKey(TableProperties.LOG_STORE_MESSAGE_TOPIC)) {
@@ -496,7 +496,7 @@ public class LogKafkaSourceBuilder {
   private void sanityCheck() {
     // Check required configs.
     checkNotNull(
-        props.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
+        props.getProperty(BOOTSTRAP_SERVERS_CONFIG),
         String.format("Property %s is required but not provided", LOG_STORE_ADDRESS));
     // Check required settings.
     checkNotNull(

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -398,10 +398,14 @@ public class LogKafkaSourceBuilder {
       setTopics(getLogTopic(tableProperties));
     }
 
-    kafkaProperties.putIfAbsent("properties.key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    kafkaProperties.putIfAbsent("properties.value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    kafkaProperties.putIfAbsent("properties.key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-    kafkaProperties.putIfAbsent("properties.value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    kafkaProperties.putIfAbsent("properties.key.serializer",
+        "org.apache.kafka.common.serialization.ByteArraySerializer");
+    kafkaProperties.putIfAbsent("properties.value.serializer",
+        "org.apache.kafka.common.serialization.ByteArraySerializer");
+    kafkaProperties.putIfAbsent("properties.key.deserializer",
+        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    kafkaProperties.putIfAbsent("properties.value.deserializer",
+        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 
     setupStartupMode();
   }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -53,7 +53,7 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_ST
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
-import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.fetchLogstorePrefixProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
@@ -101,7 +101,7 @@ public class LogKafkaSourceBuilder {
     this.stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
     this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
     this.deserializationSchema = null;
-    this.kafkaProperties = getLogStoreProperties(tableProperties);
+    this.kafkaProperties = fetchLogstorePrefixProperties(tableProperties);
     this.schema = schema;
     this.tableProperties = tableProperties;
     setupKafkaProperties();

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -55,6 +55,8 @@ import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_ST
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -495,10 +497,10 @@ public class LogKafkaSourceBuilder {
     // Check required configs.
     checkNotNull(
         props.getProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
-        String.format("Property %s is required but not provided", ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+        String.format("Property %s is required but not provided", LOG_STORE_ADDRESS));
     // Check required settings.
     checkNotNull(
         subscriber,
-        "No subscribe mode is specified, should be one of topics, topic pattern and partition set.");
+        String.format("No topic is specified, '%s' should be set.", LOG_STORE_MESSAGE_TOPIC));
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSink.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSink.java
@@ -37,9 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.Properties;
-
-import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getKafkaProperties;
 
 
 /**
@@ -51,18 +48,15 @@ public class ArcticDynamicSink implements DynamicTableSink, SupportsPartitioning
 
   private final ArcticTableLoader tableLoader;
   private final CatalogTable flinkTable;
-  private final String topic;
   private final boolean primaryKeyExisted;
   private boolean overwrite = false;
 
   ArcticDynamicSink(
       CatalogTable flinkTable,
       ArcticTableLoader tableLoader,
-      String topic,
       boolean primaryKeyExisted) {
     this.tableLoader = tableLoader;
     this.flinkTable = flinkTable;
-    this.topic = topic;
     this.primaryKeyExisted = primaryKeyExisted;
   }
 
@@ -80,7 +74,6 @@ public class ArcticDynamicSink implements DynamicTableSink, SupportsPartitioning
   @Override
   public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
     ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
-    Properties producerConfig = getKafkaProperties(table.properties());
 
     return new DataStreamSinkProvider() {
       @Override
@@ -91,8 +84,6 @@ public class ArcticDynamicSink implements DynamicTableSink, SupportsPartitioning
             .context(providerContext)
             .table(table)
             .flinkSchema(flinkTable.getSchema())
-            .producerConfig(producerConfig)
-            .topic(topic)
             .tableLoader(tableLoader)
             .overwrite(overwrite)
             .build();

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -25,7 +25,6 @@ import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
-import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.ConfigOption;
@@ -177,8 +176,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     ObjectIdentifier identifier = context.getObjectIdentifier();
     Map<String, String> options = catalogTable.getOptions();
 
-    final String topic = options.get(TableProperties.LOG_STORE_MESSAGE_TOPIC);
-
     ArcticTableLoader tableLoader = createTableLoader(
         new ObjectPath(identifier.getDatabaseName(), identifier.getObjectName()),
         internalCatalogName, internalCatalogBuilder, options);
@@ -187,7 +184,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     return new ArcticDynamicSink(
         catalogTable,
         tableLoader,
-        topic,
         table.isKeyedTable()
     );
   }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -68,7 +68,6 @@ import static com.netease.arctic.flink.catalog.factories.ArcticCatalogFactoryOpt
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createKeyFormatProjection;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.createValueFormatProjection;
 import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.getKafkaProperties;
-import static com.netease.arctic.flink.table.KafkaConnectorOptionsUtil.validateSourceTopic;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_KAFKA_COMPATIBLE_ENABLE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
@@ -239,8 +238,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
     CatalogTable catalogTable = context.getCatalogTable();
     TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
     Schema schema = FlinkSchemaUtil.convert(physicalSchema);
-
-    validateSourceTopic(tableOptions);
 
     final Properties properties = getKafkaProperties(arcticTable.properties());
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -37,11 +37,13 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
@@ -51,9 +53,16 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogStoreProperties;
 import static com.netease.arctic.table.TableProperties.ENABLE_LOG_STORE;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_DATA_VERSION_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_DEFAULT;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
 /**
  * An util that loads arctic table, build arctic log writer and so on.
@@ -131,8 +140,8 @@ public class ArcticUtils {
    * @return ArcticLogWriter
    */
   public static ArcticLogWriter buildArcticLogWriter(Map<String, String> properties,
-                                                     Properties producerConfig,
-                                                     String topic,
+                                                     @Nullable Properties producerConfig,
+                                                     @Nullable String topic,
                                                      TableSchema tableSchema,
                                                      String arcticEmitMode,
                                                      ShuffleHelper helper,
@@ -141,6 +150,14 @@ public class ArcticUtils {
     if (!arcticWALWriterEnable(properties, arcticEmitMode)) {
       return null;
     }
+
+    if (topic == null) {
+      topic = CompatibleFlinkPropertyUtil.propertyAsString(properties, LOG_STORE_MESSAGE_TOPIC, null);
+    }
+    Preconditions.checkNotNull(topic, String.format("Topic should be specified. It can be set by '%s'",
+        LOG_STORE_MESSAGE_TOPIC));
+
+    producerConfig = combineArcticProperties(properties, producerConfig);
 
     String version = properties.getOrDefault(LOG_STORE_DATA_VERSION, LOG_STORE_DATA_VERSION_DEFAULT);
     if (LOG_STORE_DATA_VERSION_DEFAULT.equals(version)) {
@@ -171,6 +188,43 @@ public class ArcticUtils {
     }
     throw new UnsupportedOperationException("don't support log version '" + version +
         "'. only support 'v1' or empty");
+  }
+
+  private static Properties combineArcticProperties(Map<String, String> tableProperties,
+                                                    Properties producerConfig) {
+    Properties finalProp;
+    Properties props = getLogStoreProperties(tableProperties);
+    if (producerConfig == null) {
+      finalProp = props;
+    } else {
+      props.stringPropertyNames().forEach(k -> producerConfig.putIfAbsent(k, props.get(k)));
+      finalProp = producerConfig;
+    }
+
+    String logStoreAddress = CompatibleFlinkPropertyUtil.propertyAsString(tableProperties,
+        LOG_STORE_ADDRESS, null);
+
+    String logType = CompatibleFlinkPropertyUtil.propertyAsString(tableProperties, LOG_STORE_TYPE,
+        LOG_STORE_STORAGE_TYPE_DEFAULT);
+    if (logType.equals(LOG_STORE_STORAGE_TYPE_KAFKA)) {
+      finalProp.putIfAbsent("key.serializer",
+          "org.apache.kafka.common.serialization.ByteArraySerializer");
+      finalProp.putIfAbsent("value.serializer",
+          "org.apache.kafka.common.serialization.ByteArraySerializer");
+      finalProp.putIfAbsent("key.deserializer",
+          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+      finalProp.putIfAbsent("value.deserializer",
+          "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+      if (logStoreAddress != null) {
+        finalProp.putIfAbsent(BOOTSTRAP_SERVERS_CONFIG, logStoreAddress);
+      }
+
+      Preconditions.checkArgument(finalProp.containsKey(BOOTSTRAP_SERVERS_CONFIG), String.format("%s should be set",
+          LOG_STORE_ADDRESS));
+    }
+
+    return finalProp;
   }
 
   public static boolean arcticFileWriterEnable(String arcticEmitMode) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
@@ -121,7 +121,7 @@ public class CompatibleFlinkPropertyUtil {
    * @param tableOptions including table properties and flink options
    * @return Properties. The keys in it have no {@link TableProperties#LOG_STORE_PROPERTIES_PREFIX}.
    */
-  public static Properties getLogStoreProperties(Map<String, String> tableOptions) {
+  public static Properties fetchLogstorePrefixProperties(Map<String, String> tableOptions) {
     final Properties properties = new Properties();
 
     if (hasPrefix(tableOptions, TableProperties.LOG_STORE_PROPERTIES_PREFIX)) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/CompatibleFlinkPropertyUtil.java
@@ -19,11 +19,17 @@
 package com.netease.arctic.flink.util;
 
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
+import com.netease.arctic.table.TableProperties;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.util.PropertyUtil;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TOPIC;
 
 /**
  * PropertyUtil compatible with legacy flink properties
@@ -106,5 +112,38 @@ public class CompatibleFlinkPropertyUtil {
       return ArcticValidator.DIM_TABLE_ENABLE_LEGACY;
     }
     return null;
+  }
+
+  /**
+   * Get log-store properties from table properties and flink options, whose prefix is
+   * {@link TableProperties#LOG_STORE_PROPERTIES_PREFIX}.
+   *
+   * @param tableOptions including table properties and flink options
+   * @return Properties. The keys in it have no {@link TableProperties#LOG_STORE_PROPERTIES_PREFIX}.
+   */
+  public static Properties getLogStoreProperties(Map<String, String> tableOptions) {
+    final Properties properties = new Properties();
+
+    if (hasPrefix(tableOptions, TableProperties.LOG_STORE_PROPERTIES_PREFIX)) {
+      tableOptions.keySet().stream()
+          .filter(key -> key.startsWith(TableProperties.LOG_STORE_PROPERTIES_PREFIX))
+          .forEach(
+              key -> {
+                final String value = tableOptions.get(key);
+                final String subKey = key.substring((TableProperties.LOG_STORE_PROPERTIES_PREFIX).length());
+                properties.put(subKey, value);
+              });
+    }
+    return properties;
+  }
+
+  public static boolean hasPrefix(Map<String, String> tableOptions, String prefix) {
+    return tableOptions.keySet().stream().anyMatch(k -> k.startsWith(prefix));
+  }
+
+  public static List<String> getLogTopic(Map<String, String> tableProperties) {
+    Configuration conf = new Configuration();
+    conf.setString(TOPIC.key(), tableProperties.get(TableProperties.LOG_STORE_MESSAGE_TOPIC));
+    return conf.get(TOPIC);
   }
 }

--- a/site/docs/ch/flink/flink-ds.md
+++ b/site/docs/ch/flink/flink-ds.md
@@ -69,42 +69,13 @@ ArcticTable table = ArcticUtils.load(tableLoader);
 // }});
 Schema schema = table.schema();
 
-List<String> topics = new ArrayList<>();
-topics.add("topic_name");
-
 // -----------Hidden Kafka--------------
-// 配置 kafka consumer 参数。详见 https://kafka.apache.org/documentation/#consumerconfigs
-Properties properties = new Properties();
-properties.put("group.id", groupId);
-properties.put("properties.bootstrap.servers", "broker1:port1, broker2:port2 ...");
+LogKafkaSource source = LogKafkaSource.builder(schema, table.properties()).build();
 
-Configuration configuration = new Configuration();
-// 开启保证数据一致性的低延迟读
-configuration.set(ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE, true);
-
-LogKafkaSource source = LogKafkaSource.builder(schema, configuration)
-    .setTopics(topics)
-    .setStartingOffsets(OffsetsInitializer.earliest())
-    .setProperties(properties)
-    .build();
-// -----------Hidden Kafka--------------
+or
 
 // -----------Hidden Pulsar--------------
-Map<String, String> tableProperties = new HashMap<>();
-tableProperties.put(TableProperties.LOG_STORE_ADDRESS, logPulsarHelper.op().serviceUrl());
-tableProperties.put(ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.key(), 
-    String.valueOf(logRetractionEnabled));
-
-Properties properties = new Properties();
-properties.put(PULSAR_ADMIN_URL.key(), logPulsarHelper.op().adminUrl());
-properties.put(PULSAR_SUBSCRIPTION_NAME.key(), "log-source");
-    
-LogPulsarSource source = LogPulsarSource.builder(schema, tableProperties)
-    .setProperties(properties)
-    .setTopics(topic)
-    .setStartCursor(StartCursor.earliest())
-    .build();
-// -----------Hidden Pulsar--------------
+LogPulsarSource source = LogPulsarSource.builder(schema, table.properties()).build();
 
 DataStream<RowData> stream = env.fromSource(source, WatermarkStrategy.noWatermarks(), "Log Source");
 // 打印读出的所有数据


### PR DESCRIPTION
Resolve #1039

## Why are the changes needed?

- Validation of table's properties is in catalog, it may cause unfriendly exception in datastream API.
- Some parameters of Datastream API is unfriendly, such as underlying log properties which can be parsed from tableProperties.
- The conversion of properties should be processed under datastream API, not in table API.

## Brief change log

  - *The flink 1.12 and 1.14, 1.15 versions are affected.*
  - *Add the documentation in the flink chapter*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
