### PR TITLE
[ARCTIC-994] fix read legacy transaction id when MOR

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizeCommit.java
@@ -258,11 +258,11 @@ public class BaseOptimizeCommit {
 
       if (arcticTable.spec().isUnpartitioned()) {
         if (maxTransactionIds.get(TablePropertyUtil.EMPTY_STRUCT) != null) {
-          overwriteBaseFiles.withTransactionId(TablePropertyUtil.EMPTY_STRUCT,
+          overwriteBaseFiles.updateMaxTransactionId(TablePropertyUtil.EMPTY_STRUCT,
               maxTransactionIds.get(TablePropertyUtil.EMPTY_STRUCT));
         }
       } else {
-        maxTransactionIds.forEach(overwriteBaseFiles::withTransactionId);
+        maxTransactionIds.forEach(overwriteBaseFiles::updateMaxTransactionId);
       }
       overwriteBaseFiles.commit();
 

--- a/core/src/main/java/com/netease/arctic/op/KeyedPartitionRewrite.java
+++ b/core/src/main/java/com/netease/arctic/op/KeyedPartitionRewrite.java
@@ -62,7 +62,7 @@ public class KeyedPartitionRewrite extends PartitionTransactionOperation impleme
     }
 
     Preconditions.checkNotNull(transactionId, "transaction-Id must be set.");
-    Preconditions.checkArgument(transactionId >= -1, "transaction-Id must >= -1.");
+    Preconditions.checkArgument(transactionId > 0, "transaction-Id must > 0.");
 
     ReplacePartitions replacePartitions = transaction.newReplacePartitions();
     addFiles.forEach(replacePartitions::addFile);
@@ -70,10 +70,19 @@ public class KeyedPartitionRewrite extends PartitionTransactionOperation impleme
 
     addFiles.forEach(f -> {
       StructLike pd = f.partition();
-      long txId = partitionMaxTxId.getOrDefault(pd, TableProperties.PARTITION_MAX_TRANSACTION_ID_DEFAULT);
-      txId = Math.max(txId, transactionId);
-      partitionMaxTxId.put(pd, txId);
+      Long maxTxId = max(partitionMaxTxId.get(pd), transactionId);
+      partitionMaxTxId.put(pd, maxTxId);
     });
     return partitionMaxTxId;
+  }
+
+  private Long max(Long a, Long b) {
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return Math.max(a, b);
   }
 }

--- a/core/src/main/java/com/netease/arctic/op/KeyedPartitionRewrite.java
+++ b/core/src/main/java/com/netease/arctic/op/KeyedPartitionRewrite.java
@@ -70,19 +70,8 @@ public class KeyedPartitionRewrite extends PartitionTransactionOperation impleme
 
     addFiles.forEach(f -> {
       StructLike pd = f.partition();
-      Long maxTxId = max(partitionMaxTxId.get(pd), transactionId);
-      partitionMaxTxId.put(pd, maxTxId);
+      partitionMaxTxId.put(pd, transactionId);
     });
     return partitionMaxTxId;
-  }
-
-  private Long max(Long a, Long b) {
-    if (a == null) {
-      return b;
-    }
-    if (b == null) {
-      return a;
-    }
-    return Math.max(a, b);
   }
 }

--- a/core/src/main/java/com/netease/arctic/op/OverwriteBaseFiles.java
+++ b/core/src/main/java/com/netease/arctic/op/OverwriteBaseFiles.java
@@ -134,9 +134,9 @@ public class OverwriteBaseFiles extends PartitionTransactionOperation {
 
   @Override
   protected StructLikeMap<Long> apply(Transaction transaction, StructLikeMap<Long> partitionMaxTxId) {
-    applyDeleteExpression();
     Preconditions.checkState(this.dynamic != null,
         "updateMaxTransactionId() or updateMaxTransactionIdDynamically() must be invoked");
+    applyDeleteExpression();
 
     StructLikeMap<Long> changedPartitionTransactionId = null;
     if (this.dynamic) {

--- a/core/src/main/java/com/netease/arctic/scan/BaseChangeTableIncrementalScan.java
+++ b/core/src/main/java/com/netease/arctic/scan/BaseChangeTableIncrementalScan.java
@@ -242,9 +242,13 @@ public class BaseChangeTableIncrementalScan implements ChangeTableIncrementalSca
       Long fromTransactionId = fromPartitionLegacyTransactionId.entrySet().iterator().next().getValue();
       return legacyTxId > fromTransactionId;
     } else {
-      Long partitionTransactionId = fromPartitionLegacyTransactionId.getOrDefault(partition,
-          TableProperties.PARTITION_MAX_TRANSACTION_ID_DEFAULT);
-      return legacyTxId > partitionTransactionId;
+      if (!fromPartitionLegacyTransactionId.containsKey(partition)) {
+        // if fromPartitionLegacyTransactionId not contains this partition, return all files of this partition
+        return true;
+      } else {
+        Long partitionTransactionId = fromPartitionLegacyTransactionId.get(partition);
+        return legacyTxId > partitionTransactionId;
+      }
     }
   }
 

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -39,7 +39,6 @@ public class TableProperties {
   public static final String BASE_TABLE_MAX_TRANSACTION_ID = "base.table.max-transaction-id";
 
   public static final String PARTITION_MAX_TRANSACTION_ID = "max-txId";
-  public static final long PARTITION_MAX_TRANSACTION_ID_DEFAULT = -1L;
 
   public static final String LOCATION = "location";
 

--- a/core/src/main/java/com/netease/arctic/utils/TablePropertyUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/TablePropertyUtil.java
@@ -109,9 +109,10 @@ public class TablePropertyUtil {
     partitionProperty.forEach((partitionKey, propertyValue) -> {
       Long maxTxId = (propertyValue == null ||
           propertyValue.get(TableProperties.PARTITION_MAX_TRANSACTION_ID) == null) ?
-          TableProperties.PARTITION_MAX_TRANSACTION_ID_DEFAULT :
-          Long.parseLong(propertyValue.get(TableProperties.PARTITION_MAX_TRANSACTION_ID));
-      baseTableMaxTransactionId.put(partitionKey, maxTxId);
+          null : Long.parseLong(propertyValue.get(TableProperties.PARTITION_MAX_TRANSACTION_ID));
+      if (maxTxId != null) {
+        baseTableMaxTransactionId.put(partitionKey, maxTxId);
+      }
     });
 
     return baseTableMaxTransactionId;

--- a/core/src/test/java/com/netease/arctic/op/OverwriteBaseFileTest.java
+++ b/core/src/test/java/com/netease/arctic/op/OverwriteBaseFileTest.java
@@ -50,7 +50,7 @@ public class OverwriteBaseFileTest extends TableDataTestBase {
     OverwriteBaseFiles overwrite = getArcticTable().asKeyedTable().newOverwriteBaseFiles();
     newFiles.forEach(overwrite::addFile);
     overwrite.overwriteByRowFilter(Expressions.alwaysTrue())
-        .withTransactionIdForChangedPartition(txId)
+        .updateMaxTransactionIdDynamically(txId)
         .commit();
     // overwrite all partition and add new data file
 
@@ -92,7 +92,7 @@ public class OverwriteBaseFileTest extends TableDataTestBase {
     List<DataFile> newFiles = DataTestHelpers.writeBaseStore(getArcticTable().asKeyedTable(), txId, newRecords);
     OverwriteBaseFiles overwrite = getArcticTable().asKeyedTable().newOverwriteBaseFiles();
     newFiles.forEach(overwrite::addFile);
-    overwrite.withTransactionIdForChangedPartition(txId);
+    overwrite.updateMaxTransactionIdDynamically(txId);
     overwrite.overwriteByRowFilter(
         Expressions.or(
             Expressions.or(

--- a/hive/src/main/java/com/netease/arctic/hive/utils/HiveMetaSynchronizer.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/HiveMetaSynchronizer.java
@@ -247,7 +247,7 @@ public class HiveMetaSynchronizer {
         overwriteBaseFiles.set(OverwriteHiveFiles.PROPERTIES_VALIDATE_LOCATION, "false");
         filesToDelete.forEach(overwriteBaseFiles::deleteFile);
         filesToAdd.forEach(overwriteBaseFiles::addFile);
-        overwriteBaseFiles.withTransactionIdForChangedPartition(txId);
+        overwriteBaseFiles.updateMaxTransactionIdDynamically(txId);
         overwriteBaseFiles.commit();
       } else {
         OverwriteFiles overwriteFiles = table.asUnkeyedTable().newOverwrite();

--- a/hive/src/test/java/com/netease/arctic/hive/op/TestOverwriteFiles.java
+++ b/hive/src/test/java/com/netease/arctic/hive/op/TestOverwriteFiles.java
@@ -87,7 +87,7 @@ public class TestOverwriteFiles extends HiveTableTestBase {
 
     OverwriteBaseFiles overwriteBaseFiles = table.newOverwriteBaseFiles();
     dataFiles.forEach(overwriteBaseFiles::addFile);
-    overwriteBaseFiles.withTransactionIdForChangedPartition(txId);
+    overwriteBaseFiles.updateMaxTransactionIdDynamically(txId);
     overwriteBaseFiles.commit();
 
     applyOverwrite(partitionAndLocations, s -> false, files);
@@ -104,7 +104,7 @@ public class TestOverwriteFiles extends HiveTableTestBase {
     overwriteBaseFiles = table.newOverwriteBaseFiles();
     dataFiles.forEach(overwriteBaseFiles::addFile);
     overwriteBaseFiles.overwriteByRowFilter(Expressions.alwaysTrue());
-    overwriteBaseFiles.withTransactionIdForChangedPartition(txId);
+    overwriteBaseFiles.updateMaxTransactionIdDynamically(txId);
     overwriteBaseFiles.commit();
 
     partitionAndLocations.clear();

--- a/hive/src/test/java/com/netease/arctic/hive/op/TestRewriteFiles.java
+++ b/hive/src/test/java/com/netease/arctic/hive/op/TestRewriteFiles.java
@@ -91,7 +91,7 @@ public class TestRewriteFiles extends HiveTableTestBase {
 
     OverwriteBaseFiles overwriteBaseFiles = table.newOverwriteBaseFiles();
     initDataFiles.forEach(overwriteBaseFiles::addFile);
-    overwriteBaseFiles.withTransactionIdForChangedPartition(txId);
+    overwriteBaseFiles.updateMaxTransactionIdDynamically(txId);
     overwriteBaseFiles.commit();
 
     applyUpdateHiveFiles(partitionAndLocations, s -> false, initFiles);

--- a/spark/v2.3/spark/src/main/java/com/netease/arctic/spark/writer/ArcticKeyedSparkOverwriteWriter.java
+++ b/spark/v2.3/spark/src/main/java/com/netease/arctic/spark/writer/ArcticKeyedSparkOverwriteWriter.java
@@ -25,7 +25,6 @@ import com.netease.arctic.spark.io.TaskWriters;
 import com.netease.arctic.spark.source.SupportsDynamicOverwrite;
 import com.netease.arctic.spark.source.SupportsOverwrite;
 import com.netease.arctic.table.KeyedTable;
-import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -172,7 +171,7 @@ public class ArcticKeyedSparkOverwriteWriter implements SupportsWriteInternalRow
   private void overwriteByFilter(WriterCommitMessage[] messages, Expression overwriteExpr) {
     OverwriteBaseFiles overwriteBaseFiles = table.newOverwriteBaseFiles();
     overwriteBaseFiles.overwriteByRowFilter(overwriteExpr);
-    overwriteBaseFiles.withTransactionIdForChangedPartition(txId);
+    overwriteBaseFiles.updateMaxTransactionIdDynamically(txId);
 
     for (DataFile file : files(messages)) {
       overwriteBaseFiles.addFile(file);

--- a/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v2.3/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -461,7 +461,7 @@ public class SparkTestContext extends ExternalResource {
       KeyedTable keyedTable = table.asKeyedTable();
       OverwriteBaseFiles overwriteBaseFiles = keyedTable.newOverwriteBaseFiles();
       Arrays.stream(dataFiles).forEach(overwriteBaseFiles::addFile);
-      overwriteBaseFiles.withTransactionIdForChangedPartition(txId);
+      overwriteBaseFiles.updateMaxTransactionIdDynamically(txId);
       overwriteBaseFiles.commit();
     } else if (table.isUnkeyedTable()) {
       UnkeyedTable unkeyedTable = table.asUnkeyedTable();

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/writer/KeyedSparkBatchWrite.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/writer/KeyedSparkBatchWrite.java
@@ -218,7 +218,7 @@ public class KeyedSparkBatchWrite implements ArcticSparkWriteBuilder.ArcticWrite
       checkBlocker(tableBlockerManager);
       OverwriteBaseFiles overwriteBaseFiles = table.newOverwriteBaseFiles();
       overwriteBaseFiles.overwriteByRowFilter(overwriteExpr);
-      overwriteBaseFiles.withTransactionIdForChangedPartition(txId);
+      overwriteBaseFiles.updateMaxTransactionIdDynamically(txId);
       overwriteBaseFiles.set(DELETE_UNTRACKED_HIVE_FILE, "true");
 
       for (DataFile file : files(messages)) {

--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/execution/AlterArcticTableDropPartitionExec.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/execution/AlterArcticTableDropPartitionExec.scala
@@ -85,7 +85,7 @@ case class AlterArcticTableDropPartitionExec(
           val txId = arctic.table().asKeyedTable().beginTransaction(null)
           val overwriteBaseFiles: OverwriteBaseFiles = arctic.table().asKeyedTable().newOverwriteBaseFiles()
           overwriteBaseFiles.overwriteByRowFilter(expression)
-          overwriteBaseFiles.withTransactionIdForChangedPartition(txId)
+          overwriteBaseFiles.updateMaxTransactionIdDynamically(txId)
           overwriteBaseFiles.commit()
         } else {
           val overwriteFiles = arctic.table().asUnkeyedTable().newOverwrite()

--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/execution/TruncateArcticTableExec.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/execution/TruncateArcticTableExec.scala
@@ -41,7 +41,7 @@ case class TruncateArcticTableExec(table: Table,
           val txId = arctic.table().asKeyedTable().beginTransaction(null);
           val overwriteBaseFiles: OverwriteBaseFiles = arctic.table().asKeyedTable().newOverwriteBaseFiles()
           overwriteBaseFiles.overwriteByRowFilter(Expressions.alwaysTrue())
-          overwriteBaseFiles.withTransactionIdForChangedPartition(txId)
+          overwriteBaseFiles.updateMaxTransactionIdDynamically(txId)
           overwriteBaseFiles.commit()
         } else {
           val overwriteFiles = arctic.table().asUnkeyedTable().newOverwrite()

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -488,7 +488,7 @@ public class SparkTestContext extends ExternalResource {
       KeyedTable keyedTable = table.asKeyedTable();
       OverwriteBaseFiles overwriteBaseFiles = keyedTable.newOverwriteBaseFiles();
       Arrays.stream(dataFiles).forEach(overwriteBaseFiles::addFile);
-      overwriteBaseFiles.withTransactionIdForChangedPartition(txId);
+      overwriteBaseFiles.updateMaxTransactionIdDynamically(txId);
       overwriteBaseFiles.commit();
     } else if (table.isUnkeyedTable()) {
       UnkeyedTable unkeyedTable = table.asUnkeyedTable();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->


Now, the transaction ids of each partition are stored in the base table's property, and the legacy transaction id is supposed to be read when the transaction id is not present, in order to be compatible with the legacy tables from 0.3.*.

However, when the transaction id is not present, we return `-1`, which is error-prone, and causes compatibility problem for MOR.

## Brief change log

  - return `null` instead of `-1` when transaction id is not present.
  - refactor `OverwriteBaseFiles` when handling transaction id
  - for data consistency, allow `KeyedPartitionRewrite` to set the transaction id to a smaller value 

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
