### PR TITLE
[ARCTIC-994] fix listTableMetas from sysdb not return the currentTxId

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/TableMetadataMapper.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/mapper/TableMetadataMapper.java
@@ -37,7 +37,7 @@ public interface TableMetadataMapper {
 
   @Select("select table_name, db_name, catalog_name, primary_key, " +
       "table_location, base_location, delta_location, meta_store_site, hdfs_site, core_site, " +
-      "auth_method, hadoop_username, krb_keytab, krb_conf, krb_principal, properties from " + TABLE_NAME)
+      "auth_method, hadoop_username, krb_keytab, krb_conf, krb_principal, properties, current_tx_id from " + TABLE_NAME)
   @Results({
       @Result(property = "tableIdentifier.tableName", column = "table_name"),
       @Result(property = "tableIdentifier.database", column = "db_name"),
@@ -55,7 +55,8 @@ public interface TableMetadataMapper {
       @Result(property = "krbConf", column = "krb_conf"),
       @Result(property = "krbPrincipal", column = "krb_principal"),
       @Result(property = "properties", column = "properties",
-          typeHandler = Map2StringConverter.class)
+          typeHandler = Map2StringConverter.class),
+      @Result(property = "currentTxId", column = "current_tx_id")
   })
   List<TableMetadata> listTableMetas();
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableMetadata.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableMetadata.java
@@ -160,7 +160,7 @@ public class TableMetadata implements Serializable {
 
   private Map<String, String> properties;
 
-  private Long currentTxId;
+  private long currentTxId;
 
   private volatile TableMetaStore metaStore;
 
@@ -300,11 +300,11 @@ public class TableMetadata implements Serializable {
     this.krbPrincipal = krbPrincipal;
   }
 
-  public Long getCurrentTxId() {
+  public long getCurrentTxId() {
     return currentTxId;
   }
 
-  public void setCurrentTxId(Long currentTxId) {
+  public void setCurrentTxId(long currentTxId) {
     this.currentTxId = currentTxId;
   }
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UpdateTool.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UpdateTool.java
@@ -51,7 +51,7 @@ public class UpdateTool extends IJDBCService {
             ServiceContainer.getArcticTransactionService().validTable(tableIdentifier.buildTableIdentifier());
           }
         } catch (Throwable t) {
-          LOG.error("failed to update transactionId of {}, ignore and continue", tableIdentifier);
+          LOG.error("failed to update transactionId of {}, ignore and continue", tableIdentifier, t);
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When listing all tables' metadata from sysdb, the `currentTxId` is not returned, and it will influence the `UpdateTool` update legacy table from 0.3* to 0.4.1.

## Brief change log

- load `current_tx_id` from sysdb when `listTableMetas`
- change `currentTxId` from `Long` to `long`, since null value is not used

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
