### PR TITLE
[ARCTIC-985] unit test improment MockArcticMetastoreServer support renewBlocker

### DIFF
--- a/ams/ams-api/src/test/java/com/netease/arctic/ams/api/MockArcticMetastoreServer.java
+++ b/ams/ams-api/src/test/java/com/netease/arctic/ams/api/MockArcticMetastoreServer.java
@@ -188,7 +188,8 @@ public class MockArcticMetastoreServer implements Runnable {
     }
   }
 
-  public class AmsHandler implements ArcticTableMetastore.Iface {
+  public static class AmsHandler implements ArcticTableMetastore.Iface {
+    private static final long DEFAULT_BLOCKER_TIMEOUT = 60_000;
     private final ConcurrentLinkedQueue<CatalogMeta> catalogs = new ConcurrentLinkedQueue<>();
     private final ConcurrentLinkedQueue<TableMeta> tables = new ConcurrentLinkedQueue<>();
     private final ConcurrentHashMap<String, List<String>> databases = new ConcurrentHashMap<>();
@@ -321,8 +322,8 @@ public class MockArcticMetastoreServer implements Runnable {
       Map<String, Blocker> blockers = this.tableBlockers.computeIfAbsent(tableIdentifier, t -> new HashMap<>());
       long now = System.currentTimeMillis();
       properties.put("create.time", now + "");
-      properties.put("expiration.time", (now + 60000) + "");
-      properties.put("blocker.timeout", 60000 + "");
+      properties.put("expiration.time", (now + DEFAULT_BLOCKER_TIMEOUT) + "");
+      properties.put("blocker.timeout", DEFAULT_BLOCKER_TIMEOUT + "");
       Blocker blocker = new Blocker(this.blockerId.getAndIncrement() + "", operations, properties);
       blockers.put(blocker.getBlockerId(), blocker);
       return blocker;
@@ -338,7 +339,17 @@ public class MockArcticMetastoreServer implements Runnable {
 
     @Override
     public long renewBlocker(TableIdentifier tableIdentifier, String blockerId) throws TException {
-      return 0;
+      Map<String, Blocker> blockers = this.tableBlockers.get(tableIdentifier);
+      if (blockers == null) {
+        throw new NoSuchObjectException("illegal blockerId " + blockerId + ", it may be released or expired");
+      }
+      Blocker blocker = blockers.get(blockerId);
+      if (blocker == null) {
+        throw new NoSuchObjectException("illegal blockerId " + blockerId + ", it may be released or expired");
+      }
+      long expirationTime = System.currentTimeMillis() + DEFAULT_BLOCKER_TIMEOUT;
+      blocker.getProperties().put("expiration.time", expirationTime + "");
+      return expirationTime;
     }
 
     @Override


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

MockArcticMetastoreServer supports renewBlocker to avoid keeping renew in unit test.

## Brief change log

  - MockArcticMetastoreServer supports renewBlocer to avoid keeping renew in unit test

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
