### PR TITLE
[Arctic-1066][Spark]:Fix ordered write error when using MixedHive unkeyedTable

### DIFF
--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -255,6 +255,20 @@
                                         <include>
                                             org.apache.spark.sql.execution.datasources.v2.SetWriteDistributionAndOrderingExec*
                                         </include>
+                                        <include>
+                                            org.apache.spark.sql.execution.datasources.v2.ArcticTableWriteExec*
+                                        </include>
+                                    </includes>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.spark.sql.execution.datasources</pattern>
+                                    <shadedPattern>
+                                        com.netease.arctic.shade.org.apache.spark.sql.execution.datasources
+                                    </shadedPattern>
+                                    <includes>
+                                        <include>
+                                            org.apache.spark.sql.execution.datasources.SparkExpressionConverter*
+                                        </include>
                                     </includes>
                                 </relocation>
                                 <relocation>
@@ -338,6 +352,9 @@
                                         </include>
                                         <include>
                                             org.apache.spark.sql.catalyst.plans.logical.SetWriteDistributionAndOrdering*
+                                        </include>
+                                        <include>
+                                            org.apache.spark.sql.catalyst.plans.logical.SortOrderParserUtil*
                                         </include>
                                     </includes>
                                 </relocation>

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
@@ -35,4 +35,7 @@ public class SparkSQLProperties {
   public static final String CHECK_SOURCE_DUPLICATES_ENABLE = "spark.sql.arctic.check-source-data-uniqueness.enabled";
 
   public static final String CHECK_SOURCE_DUPLICATES_ENABLE_DEFAULT = "false";
+
+  public static final String OPTIMIZE_WRITE_ENABLED = "spark.sql.arctic.optimize-write-enabled" ;
+  public static final String OPTIMIZE_WRITE_ENABLED_DEFAULT = "true" ;
 }

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/SparkSQLProperties.java
@@ -36,6 +36,6 @@ public class SparkSQLProperties {
 
   public static final String CHECK_SOURCE_DUPLICATES_ENABLE_DEFAULT = "false";
 
-  public static final String OPTIMIZE_WRITE_ENABLED = "spark.sql.arctic.optimize-write-enabled" ;
-  public static final String OPTIMIZE_WRITE_ENABLED_DEFAULT = "true" ;
+  public static final String OPTIMIZE_WRITE_ENABLED = "spark.sql.arctic.optimize-write-enabled";
+  public static final String OPTIMIZE_WRITE_ENABLED_DEFAULT = "true";
 }

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/util/DistributionAndOrderingUtil.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/util/DistributionAndOrderingUtil.java
@@ -102,7 +102,7 @@ public class DistributionAndOrderingUtil {
           TableProperties.CHANGE_FILE_INDEX_HASH_BUCKET,
           TableProperties.CHANGE_FILE_INDEX_HASH_BUCKET_DEFAULT);
     }
-    return new FileIndexBucket(table.schema(), primaryKeySpec, numBucket);
+    return new FileIndexBucket(table.schema(), primaryKeySpec, numBucket - 1);
   }
 
   /**

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/writer/UnkeyedSparkBatchWrite.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/writer/UnkeyedSparkBatchWrite.java
@@ -79,7 +79,7 @@ public class UnkeyedSparkBatchWrite implements ArcticSparkWriteBuilder.ArcticWri
     this.table = table;
     this.dsSchema = info.schema();
     this.orderedWriter = Boolean.parseBoolean(info.options().getOrDefault(
-        "writer.distributed-and-ordered", "true"
+        "writer.distributed-and-ordered", "false"
     ));
     this.catalog = catalog;
   }

--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/optimize/OptimizeWriteRule.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/optimize/OptimizeWriteRule.scala
@@ -43,11 +43,6 @@ case class OptimizeWriteRule(spark: SparkSession) extends Rule[LogicalPlan] with
       val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
       a.copy(query = newQuery, writeOptions = options)
 
-    //    case rp @ ReplaceArcticData(r: DataSourceV2Relation, query, writeOptions) if isArcticRelation(r) =>
-    //      val newQuery = distributionQuery(query, r.table, rowLevelOperation = true, writeBase = false)
-    //      val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
-    //      rp.copy(query = newQuery, writeOptions = options)
-
     case o @ OverwriteArcticPartitionsDynamic(r: DataSourceV2Relation, query, _, writeOptions) if isArcticRelation(r) =>
       val newQuery = distributionQuery(query, r.table, rowLevelOperation = false)
       val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
@@ -57,6 +52,16 @@ case class OptimizeWriteRule(spark: SparkSession) extends Rule[LogicalPlan] with
       val newQuery = distributionQuery(query, r.table, rowLevelOperation = false)
       val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
       a.copy(query = newQuery, writeOptions = options)
+
+    case o @ OverwriteByExpression(r: DataSourceV2Relation, _, query, writeOptions, _) if isArcticRelation(r) =>
+      val newQuery = distributionQuery(query, r.table, rowLevelOperation = false)
+      val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
+      o.copy(query = newQuery, writeOptions = options)
+
+    case o @ OverwritePartitionsDynamic(r: DataSourceV2Relation, query, writeOptions, _) if isArcticRelation(r) =>
+      val newQuery = distributionQuery(query, r.table, rowLevelOperation = false)
+      val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
+      o.copy(query = newQuery, writeOptions = options)
 
     case a @ AppendData(r: DataSourceV2Relation, query, _, _) if isArcticIcebergRelation(r) =>
       val newQuery = distributionQuery(query, r.table, rowLevelOperation = false)

--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/optimize/OptimizeWriteRule.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/optimize/OptimizeWriteRule.scala
@@ -39,6 +39,9 @@ case class OptimizeWriteRule(spark: SparkSession) extends Rule[LogicalPlan] with
     }
   }
 
+  // do optimize write for insert overwrite. insert into.
+  // update will not enable optimize write for reason that we should
+  // write update_before and update_after in same time.
   def optimizeWritePlan(plan: LogicalPlan): LogicalPlan = plan transformDown {
     case o @ OverwritePartitionsDynamic(r: DataSourceV2Relation, query, writeOptions, _)
       if isArcticRelation(r) =>

--- a/spark/v3.1/spark/src/main/scala/org/apache/spark/sql/arctic/catalyst/ArcticSpark31CatalystHelper.scala
+++ b/spark/v3.1/spark/src/main/scala/org/apache/spark/sql/arctic/catalyst/ArcticSpark31CatalystHelper.scala
@@ -118,7 +118,7 @@ object ArcticSpark31CatalystHelper extends SQLConfHelper {
       internalRowToStruct.wrap(input)
       keyData.primaryKey(internalRowToStruct)
       val node = keyData.treeNode(numBuckets)
-      node.getId
+      node.getIndex
     }
 
     override def nullable: Boolean = true

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -28,9 +28,9 @@ import com.netease.arctic.catalog.ArcticCatalog;
 import com.netease.arctic.catalog.CatalogLoader;
 import com.netease.arctic.data.ChangeAction;
 import com.netease.arctic.data.DataTreeNode;
+import com.netease.arctic.data.file.FileNameGenerator;
 import com.netease.arctic.hive.HMSMockServer;
 import com.netease.arctic.hive.io.writer.AdaptHiveGenericTaskWriterBuilder;
-import com.netease.arctic.data.file.FileNameGenerator;
 import com.netease.arctic.io.writer.GenericTaskWriters;
 import com.netease.arctic.io.writer.SortedPosDeleteWriter;
 import com.netease.arctic.op.OverwriteBaseFiles;
@@ -192,7 +192,7 @@ public class SparkTestContext extends ExternalResource {
     sparkConfigs.put("spark.sql.extensions", ArcticSparkExtensions.class.getName());
     sparkConfigs.put("spark.testing.memory", "943718400");
     sparkConfigs.put("spark.sql.arctic.use-timestamp-without-timezone-in-new-tables", "false");
-    sparkConfigs.put("spark.sql.arctic.check-source-data-uniqueness.enabled", "true");
+    sparkConfigs.put("spark.sql.arctic.check-source-data-uniqueness.enabled", "false");
 
     sparkConfigs.putAll(configs);
     sparkConfigs.forEach(((k, v) -> System.out.println("--" + k + "=" + v)));

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -192,7 +192,7 @@ public class SparkTestContext extends ExternalResource {
     sparkConfigs.put("spark.sql.extensions", ArcticSparkExtensions.class.getName());
     sparkConfigs.put("spark.testing.memory", "943718400");
     sparkConfigs.put("spark.sql.arctic.use-timestamp-without-timezone-in-new-tables", "false");
-    sparkConfigs.put("spark.sql.arctic.check-source-data-uniqueness.enabled", "false");
+    sparkConfigs.put("spark.sql.arctic.check-source-data-uniqueness.enabled", "true");
 
     sparkConfigs.putAll(configs);
     sparkConfigs.forEach(((k, v) -> System.out.println("--" + k + "=" + v)));

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestOptimizeWrite.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestOptimizeWrite.java
@@ -18,13 +18,20 @@
 
 package com.netease.arctic.spark;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.netease.arctic.data.DataFileType;
+import com.netease.arctic.data.DataTreeNode;
+import com.netease.arctic.data.PrimaryKeyData;
+import com.netease.arctic.io.writer.TaskWriterKey;
 import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.PrimaryKeySpec;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.UnkeyedTable;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeMap;
@@ -33,12 +40,15 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.StructType;
+import org.glassfish.jersey.internal.guava.Sets;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class TestOptimizeWrite extends SparkTestBase {
 
@@ -47,24 +57,35 @@ public class TestOptimizeWrite extends SparkTestBase {
   private final String sourceTable = "source_table";
   private final TableIdentifier identifier = TableIdentifier.of(catalogNameArctic, database, sinkTable);
 
+  private List<GenericRecord> sources;
+  private Schema schema;
+
   @Before
   public void before() {
     sql("use " + catalogNameArctic);
     sql("create database if not exists {0}", database);
-    List<Row> rows = Lists.newArrayList(
-        RowFactory.create(1, "aaa", "aaa"),
-        RowFactory.create(2, "bbb", "aaa"),
-        RowFactory.create(3, "aaa", "bbb"),
-        RowFactory.create(4, "bbb", "bbb"),
-        RowFactory.create(5, "aaa", "ccc"),
-        RowFactory.create(6, "bbb", "ccc")
-    );
-    StructType schema = SparkSchemaUtil.convert(new Schema(
+
+    schema = new Schema(
         Types.NestedField.of(1, false, "id", Types.IntegerType.get()),
         Types.NestedField.of(2, false, "column1", Types.StringType.get()),
         Types.NestedField.of(3, false, "column2", Types.StringType.get())
-    ));
-    Dataset<Row> ds = spark.createDataFrame(rows, schema);
+    );
+
+    sources = Lists.newArrayList(
+        newRecord(schema,1, "aaa", "aaa"),
+        newRecord(schema,2, "bbb", "aaa"),
+        newRecord(schema,3, "aaa", "bbb"),
+        newRecord(schema,4, "bbb", "bbb"),
+        newRecord(schema,5, "aaa", "ccc"),
+        newRecord(schema,6, "bbb", "ccc")
+    );
+
+
+    StructType structType = SparkSchemaUtil.convert(schema);
+    Dataset<Row> ds = spark.createDataFrame(
+        sources.stream()
+            .map(TestOptimizeWrite::genericRecordToSparkRow)
+            .collect(Collectors.toList()), structType);
     ds = ds.repartition(new Column("column2"));
     ds.registerTempTable(sourceTable);
   }
@@ -98,9 +119,10 @@ public class TestOptimizeWrite extends SparkTestBase {
         database, sinkTable, sourceTable);
     rows = sql("select * from {0}.{1} order by id", database, sinkTable);
     Assert.assertEquals(6, rows.size());
+    int size = expectFileSize(2);
     Assert.assertEquals(
-        2,
-        Iterables.size(loadTable(identifier).asKeyedTable().baseTable().newScan().planFiles()));
+        size,
+        baseTableSize(identifier));
   }
 
   /**
@@ -123,7 +145,9 @@ public class TestOptimizeWrite extends SparkTestBase {
         database, sinkTable, sourceTable);
     rows = sql("select * from {0}.{1} order by id", database, sinkTable);
     Assert.assertEquals(6, rows.size());
-    Assert.assertEquals(4,
+    ArcticTable table = loadTable(identifier);
+    int size = expectFileSize(2);
+    Assert.assertEquals(size,
         baseTableSize(identifier));
   }
 
@@ -154,8 +178,55 @@ public class TestOptimizeWrite extends SparkTestBase {
 
     rows = sql("select * from {0}.{1} order by id", database, sinkTable);
     Assert.assertEquals(6, rows.size());
-    Assert.assertEquals(2,
+    int fileCount = expectFileSize(4);
+    Assert.assertEquals(fileCount,
         baseTableSize(identifier));
 
+  }
+
+  public int expectFileSize(int buckets) {
+    ArcticTable table = loadTable(identifier);
+    return expectFiles(
+        sources,
+        table.schema(),
+        table.spec(),
+        table.isKeyedTable() ? table.asKeyedTable().primaryKeySpec(): null,
+        buckets
+    );
+  }
+
+  public static int expectFiles(
+      List<GenericRecord> sources,
+      Schema schema,
+      PartitionSpec partitionSpec,
+      PrimaryKeySpec keySpec,
+      int buckets) {
+    PartitionKey partitionKey = new PartitionKey(partitionSpec, schema);
+    PrimaryKeyData primaryKey = keySpec == null ? null : new PrimaryKeyData(keySpec, schema);
+    int mask = buckets - 1 ;
+
+    Set<TaskWriterKey> writerKeys = Sets.newHashSet();
+    for (GenericRecord row: sources){
+      partitionKey.partition(row);
+      DataTreeNode node;
+      if (keySpec != null) {
+        primaryKey.primaryKey(row);
+        node = primaryKey.treeNode(mask);
+      } else {
+        node = DataTreeNode.ROOT;
+      }
+      writerKeys.add(
+          new TaskWriterKey(partitionKey.copy(), node, DataFileType.BASE_FILE)
+      );
+    }
+    return writerKeys.size();
+  }
+
+  public static Row genericRecordToSparkRow(GenericRecord record) {
+    Object[] values = new Object[record.size()];
+    for (int i = 0 ; i < values.length; i++ ) {
+      values[i] = record.get(i);
+    }
+    return RowFactory.create(values);
   }
 }

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestUnkeyedHiveInsertOverwriteDynamic.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/hive/TestUnkeyedHiveInsertOverwriteDynamic.java
@@ -18,8 +18,17 @@
 
 package com.netease.arctic.spark.hive;
 
+import com.google.common.collect.Lists;
 import com.netease.arctic.spark.SparkTestBase;
+import com.netease.arctic.table.ArcticTable;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.StructType;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
@@ -72,11 +81,18 @@ public class TestUnkeyedHiveInsertOverwriteDynamic extends SparkTestBase {
     sql("insert overwrite {0}.{1} values \n" +
         "(4, ''aaa'',  ''2021-1-1''), \n " +
         "(5, ''bbb'',  ''2021-1-2''), \n " +
-        "(6, ''ccc'',  ''2021-1-2'') \n ", database, table);
+        "(6, ''ccc'',  ''2021-1-2''), \n " +
+        "(7, ''ccc'',  ''2021-1-2''), \n " +
+        "(8, ''ccc'',  ''2021-1-2''), \n " +
+        "(9, ''ccc'',  ''2021-1-2''), \n " +
+        "(10, ''ccc'',  ''2021-1-2''), \n " +
+        "(11, ''ccc'',  ''2021-1-2''), \n " +
+        "(12, ''ccc'',  ''2021-1-2''), \n " +
+        "(13, ''ccc'',  ''2021-1-2'') \n " , database, table);
 
     rows = sql("select id, data, dt from {0}.{1} order by id", database, table);
-    Assert.assertEquals(4, rows.size());
-    assertContainIdSet(rows, 0, 4, 5, 6, 3);
+    Assert.assertEquals(11, rows.size());
+    assertContainIdSet(rows, 0, 3,4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
 
     List<Partition> partitions = hms.getClient().listPartitions(
         database,
@@ -85,8 +101,8 @@ public class TestUnkeyedHiveInsertOverwriteDynamic extends SparkTestBase {
     Assert.assertEquals(3, partitions.size());
     sql("use spark_catalog");
     rows = sql("select id, data, dt from {0}.{1} order by id", database, table);
-    Assert.assertEquals(4, rows.size());
-    assertContainIdSet(rows, 0, 4, 5, 6, 3);
+    Assert.assertEquals(11, rows.size());
+    assertContainIdSet(rows, 0, 3,4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
   }
 
   @Test
@@ -109,6 +125,36 @@ public class TestUnkeyedHiveInsertOverwriteDynamic extends SparkTestBase {
     rows = sql("select id, data, dt from {0}.{1} order by id", database, table);
     Assert.assertEquals(6, rows.size());
     assertContainIdSet(rows, 0, 1, 2, 3, 4, 5, 6);
+  }
+
+
+  @Test
+  public void testInsertOverwriteFromView() {
+    ArcticTable t = loadTable(catalogNameHive, database, table);
+    List<Row> sources = Lists.newArrayList(
+        RowFactory.create(4, "aaa", "2021-1-2"),
+        RowFactory.create(5, "aaa", "2021-1-3"),
+        RowFactory.create(6, "aaa", "2021-1-2"),
+        RowFactory.create(7, "aaa", "2021-1-3"),
+        RowFactory.create(8, "aaa", "2021-1-2"),
+        RowFactory.create(9, "aaa", "2021-1-3"),
+        RowFactory.create(10, "aaa", "2021-1-2"),
+        RowFactory.create(11, "aaa", "2021-1-3"),
+        RowFactory.create( 12, "aaa", "2021-1-2")
+    );
+    StructType schema = SparkSchemaUtil.convert(new Schema(
+        Types.NestedField.of(1, false, "id", Types.IntegerType.get()),
+        Types.NestedField.of(2, false, "data", Types.StringType.get()),
+        Types.NestedField.of(3, false, "dt", Types.StringType.get())
+    ));
+    Dataset<Row> row = spark.createDataFrame(sources, schema);
+    row = row.repartition(1);
+    row.registerTempTable("view");
+
+    sql("insert overwrite {0}.{1} select * from view", database, table);
+    rows = sql("select * from {0}.{1} order by id", database, table);
+    Assert.assertEquals(10, rows.size());
+
   }
 
 }


### PR DESCRIPTION

## Why are the changes needed?

fix: #1066 


## Brief change log

- Set default value of write options `writer.distributed-and-ordered` to false for the unkeyed table.
- Set the right value of FileIndexBucketMask
- Do optimize write for Batch Insert 

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
