### PR TITLE
[ARCTIC-985] avoid NoSuchObjectException when renew blocker

### DIFF
--- a/ams/ams-api/src/test/java/com/netease/arctic/ams/api/MockArcticMetastoreServer.java
+++ b/ams/ams-api/src/test/java/com/netease/arctic/ams/api/MockArcticMetastoreServer.java
@@ -188,7 +188,8 @@ public class MockArcticMetastoreServer implements Runnable {
     }
   }
 
-  public class AmsHandler implements ArcticTableMetastore.Iface {
+  public static class AmsHandler implements ArcticTableMetastore.Iface {
+    private static final long DEFAULT_BLOCKER_TIMEOUT = 60_000;
     private final ConcurrentLinkedQueue<CatalogMeta> catalogs = new ConcurrentLinkedQueue<>();
     private final ConcurrentLinkedQueue<TableMeta> tables = new ConcurrentLinkedQueue<>();
     private final ConcurrentHashMap<String, List<String>> databases = new ConcurrentHashMap<>();
@@ -321,8 +322,8 @@ public class MockArcticMetastoreServer implements Runnable {
       Map<String, Blocker> blockers = this.tableBlockers.computeIfAbsent(tableIdentifier, t -> new HashMap<>());
       long now = System.currentTimeMillis();
       properties.put("create.time", now + "");
-      properties.put("expiration.time", (now + 60000) + "");
-      properties.put("blocker.timeout", 60000 + "");
+      properties.put("expiration.time", (now + DEFAULT_BLOCKER_TIMEOUT) + "");
+      properties.put("blocker.timeout", DEFAULT_BLOCKER_TIMEOUT + "");
       Blocker blocker = new Blocker(this.blockerId.getAndIncrement() + "", operations, properties);
       blockers.put(blocker.getBlockerId(), blocker);
       return blocker;
@@ -338,7 +339,17 @@ public class MockArcticMetastoreServer implements Runnable {
 
     @Override
     public long renewBlocker(TableIdentifier tableIdentifier, String blockerId) throws TException {
-      return 0;
+      Map<String, Blocker> blockers = this.tableBlockers.get(tableIdentifier);
+      if (blockers == null) {
+        throw new NoSuchObjectException("illegal blockerId " + blockerId + ", it may be released or expired");
+      }
+      Blocker blocker = blockers.get(blockerId);
+      if (blocker == null) {
+        throw new NoSuchObjectException("illegal blockerId " + blockerId + ", it may be released or expired");
+      }
+      long expirationTime = System.currentTimeMillis() + DEFAULT_BLOCKER_TIMEOUT;
+      blocker.getProperties().put("expiration.time", expirationTime + "");
+      return expirationTime;
     }
 
     @Override

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/TableBlockerService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/TableBlockerService.java
@@ -146,13 +146,13 @@ public class TableBlockerService extends IJDBCService {
       long now = System.currentTimeMillis();
       TableBlocker tableBlocker = mapper.selectBlocker(Long.parseLong(blockerId), now);
       if (tableBlocker == null) {
-        throw new NoSuchObjectException("illegal blockerId " + blockerId + ", it may be released or expired");
+        throw new NoSuchObjectException(
+            tableIdentifier + " illegal blockerId " + blockerId + ", it may be released or expired");
       }
       long expirationTime = now + blockerTimeout;
       mapper.updateBlockerExpirationTime(Long.parseLong(blockerId), expirationTime);
       return expirationTime;
     } catch (NoSuchObjectException e1) {
-      LOG.error("failed to renew blocker {} for {}", blockerId, tableIdentifier, e1);
       throw e1;
     } catch (Exception e) {
       LOG.error("failed to renew blocker {} for {}", blockerId, tableIdentifier, e);

--- a/core/src/main/java/com/netease/arctic/table/blocker/RenewableBlocker.java
+++ b/core/src/main/java/com/netease/arctic/table/blocker/RenewableBlocker.java
@@ -28,12 +28,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Renewable {@link Blocker} implementation.
@@ -95,13 +93,6 @@ public class RenewableBlocker implements Blocker {
 
   private void doRenew() {
     try {
-      Set<String> validBlockers = amsClient.getBlockers(tableIdentifier.buildTableIdentifier())
-          .stream()
-          .map(com.netease.arctic.ams.api.Blocker::getBlockerId)
-          .collect(Collectors.toSet());
-      if (!validBlockers.contains(blockerId())) {
-        cancelRenew();
-      }
       this.expirationTime = amsClient.renewBlocker(tableIdentifier.buildTableIdentifier(), blockerId());
       LOG.info("renew blocker {} success of {}", blockerId(), tableIdentifier);
     } catch (NoSuchObjectException e) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->


## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

avoid NoSuchObjectException when renew blocker, like 
![image](https://user-images.githubusercontent.com/103108928/217514155-8cb7c85c-1e58-49a2-a7af-5c10a142b542.png)


## Brief change log

  - check blocker exist before renewing blocker
  - MockArcticMetastoreServer support renewBlocker

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
