### PR TITLE
[ARCTIC-1091] Browser tab does not display Arctic's icon

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/AmsRestServer.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/AmsRestServer.java
@@ -36,6 +36,7 @@ import com.netease.arctic.ams.server.service.impl.ApiTokenService;
 import com.netease.arctic.ams.server.utils.ParamSignatureCalculator;
 import com.netease.arctic.ams.server.utils.Utils;
 import io.javalin.Javalin;
+import io.javalin.http.ContentType;
 import io.javalin.http.HttpCode;
 import io.javalin.http.staticfiles.Location;
 import org.apache.commons.lang3.StringUtils;
@@ -130,10 +131,17 @@ public class AmsRestServer {
     app.routes(() -> {
       /*backend routers*/
       path("", () -> {
-        //  /docs/latest can't be locationed to the index.html, so we add rule to redict to it.
+        // /docs/latest can't be located to the index.html, so we add rule to redirect to it.
         get("/docs/latest", ctx -> ctx.redirect("/docs/latest/index.html"));
         // unify all addSinglePageRoot(like /tables, /optimizers etc) configure here
-        get("/{page}", ctx -> ctx.html(getFileContent()));
+        get("/{page}", ctx -> {
+          if ("favicon.ico".equals(ctx.pathParam("page"))) {
+            ctx.contentType(ContentType.IMAGE_ICO);
+            ctx.result(AmsRestServer.class.getClassLoader().getResourceAsStream("static/favicon.ico"));
+          } else {
+            ctx.html(getFileContent());
+          }
+        });
         get("/hive-tables/upgrade", ctx -> ctx.html(getFileContent()));
       });
       path("/ams/v1", () -> {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1091 

## Brief change log

  - *Manually load the static resource favicon.ico
  - *Fix some grammar errors

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
