### PR TITLE
[ARCTIC-1062][AMS]Terminal support config spark properties in the local model

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/config/ArcticMetaStoreConf.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/config/ArcticMetaStoreConf.java
@@ -188,7 +188,7 @@ public class ArcticMetaStoreConf {
    * config key prefix of terminal
    */
   public static final String TERMINAL_PREFIX = "arctic.ams.terminal.";
-  public static final String SPARK_CONF = "spark.sql";
+  public static final String SPARK_CONF = "spark.";
   public static final ConfigOption<String> TERMINAL_BACKEND =
       ConfigOptions.key("arctic.ams.terminal.backend")
           .stringType()

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/config/ArcticMetaStoreConf.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/config/ArcticMetaStoreConf.java
@@ -188,6 +188,7 @@ public class ArcticMetaStoreConf {
    * config key prefix of terminal
    */
   public static final String TERMINAL_PREFIX = "arctic.ams.terminal.";
+  public static final String SPARK_CONF = "spark.sql";
   public static final ConfigOption<String> TERMINAL_BACKEND =
       ConfigOptions.key("arctic.ams.terminal.backend")
           .stringType()

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/local/LocalSessionFactory.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/local/LocalSessionFactory.java
@@ -18,6 +18,9 @@
 
 package com.netease.arctic.ams.server.terminal.local;
 
+import java.util.HashMap;
+import com.netease.arctic.ams.server.config.ArcticMetaStoreConf;
+import com.netease.arctic.ams.server.config.ConfigOptions;
 import com.netease.arctic.ams.server.config.Configuration;
 import com.netease.arctic.ams.server.terminal.SparkContextUtil;
 import com.netease.arctic.ams.server.terminal.TerminalSession;
@@ -47,14 +50,16 @@ public class LocalSessionFactory implements TerminalSessionFactory {
 
   SparkSession context = null;
 
+  Configuration conf = null;
+
   @Override
   public void initialize(Configuration properties) {
-
+    conf = properties;
   }
 
   @Override
   public TerminalSession create(TableMetaStore metaStore, Configuration configuration) {
-    SparkSession context = lazyInitContext();
+    SparkSession context = lazyInitContext(conf);
     SparkSession session = context.cloneSession();
     List<String> catalogs = configuration.get(SessionConfigOptions.CATALOGS);
     List<String> initializeLogs = Lists.newArrayList();
@@ -79,7 +84,7 @@ public class LocalSessionFactory implements TerminalSessionFactory {
     logs.add(key + "  " + value);
   }
 
-  protected synchronized SparkSession lazyInitContext() {
+  protected synchronized SparkSession lazyInitContext(Configuration conf) {
     if (context == null) {
       SparkConf sparkconf = new SparkConf()
           .setAppName("spark-local-context")
@@ -89,6 +94,13 @@ public class LocalSessionFactory implements TerminalSessionFactory {
       sparkconf.set("spark.network.timeout", "200s");
       sparkconf.set("spark.sql.extensions", ArcticSparkExtensions.class.getName() +
           "," + IcebergSparkSessionExtensions.class.getName());
+      for (String key : conf.keySet()) {
+        if (!key.startsWith(ArcticMetaStoreConf.SPARK_CONF)) {
+          continue;
+        }
+        String value = conf.getValue(ConfigOptions.key(key).stringType().noDefaultValue());
+        sparkconf.set(key, value);
+      }
       context = SparkSession
           .builder()
           .config(sparkconf)

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/local/LocalSessionFactory.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/local/LocalSessionFactory.java
@@ -18,7 +18,6 @@
 
 package com.netease.arctic.ams.server.terminal.local;
 
-import java.util.HashMap;
 import com.netease.arctic.ams.server.config.ArcticMetaStoreConf;
 import com.netease.arctic.ams.server.config.ConfigOptions;
 import com.netease.arctic.ams.server.config.Configuration;

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsTestBase.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsTestBase.java
@@ -101,29 +101,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(Suite.class)
 @Suite.SuiteClasses({
-    CatalogControllerTest.class,
-    OptimizerControllerTest.class,
-    TableControllerTest.class,
-    TerminalControllerTest.class,
-    TestDDLTracerService.class,
-    LoginControllerTest.class,
-    TestExpiredFileClean.class,
-    TestMajorOptimizeCommit.class,
-    TestMajorOptimizePlan.class,
-    TestMinorOptimizeCommit.class,
-    TestMinorOptimizePlan.class,
-    TestIcebergFullOptimizePlan.class,
-    TestIcebergMinorOptimizePlan.class,
-    TestIcebergFullOptimizeCommit.class,
-    TestIcebergMinorOptimizeCommit.class,
-    TestExpireFileCleanSupportIceberg.class,
-    TestOrphanFileCleanSupportIceberg.class,
-    TestOrphanFileClean.class,
-    TestFileInfoCacheService.class,
-    TestTableBlockerService.class,
-    SupportHiveTestGroup.class,
-    TestArcticTransactionService.class,
-    TestOptimizerService.class
+    TerminalControllerTest.class
 })
 @PrepareForTest({
     JDBCSqlSessionFactoryProvider.class,
@@ -194,6 +172,7 @@ public class AmsTestBase {
     com.netease.arctic.ams.server.config.Configuration configuration =
         new com.netease.arctic.ams.server.config.Configuration();
     configuration.setString(ArcticMetaStoreConf.DB_TYPE, "derby");
+    configuration.setString("arctic.ams.terminal.local.spark.sql.session.timeZone", "UTC");
     ArcticMetaStore.conf = configuration;
 
     //mock service

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsTestBase.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsTestBase.java
@@ -101,7 +101,29 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(Suite.class)
 @Suite.SuiteClasses({
-    TerminalControllerTest.class
+    CatalogControllerTest.class,
+    OptimizerControllerTest.class,
+    TableControllerTest.class,
+    TerminalControllerTest.class,
+    TestDDLTracerService.class,
+    LoginControllerTest.class,
+    TestExpiredFileClean.class,
+    TestMajorOptimizeCommit.class,
+    TestMajorOptimizePlan.class,
+    TestMinorOptimizeCommit.class,
+    TestMinorOptimizePlan.class,
+    TestIcebergFullOptimizePlan.class,
+    TestIcebergMinorOptimizePlan.class,
+    TestIcebergFullOptimizeCommit.class,
+    TestIcebergMinorOptimizeCommit.class,
+    TestExpireFileCleanSupportIceberg.class,
+    TestOrphanFileCleanSupportIceberg.class,
+    TestOrphanFileClean.class,
+    TestFileInfoCacheService.class,
+    TestTableBlockerService.class,
+    SupportHiveTestGroup.class,
+    TestArcticTransactionService.class,
+    TestOptimizerService.class
 })
 @PrepareForTest({
     JDBCSqlSessionFactoryProvider.class,

--- a/site/docs/ch/guides/deployment.md
+++ b/site/docs/ch/guides/deployment.md
@@ -209,7 +209,7 @@ optimize_group:
 ```
 
 ### 配置 Terminal 
-Terminal 在 AMS 中的内存中执行的情况下，可以配置 Spark 相关参数
+Terminal 在 local 模式执行的情况下，可以配置 Spark 相关参数
 ```shell
 arctic.ams.terminal.backend: local
 arctic.ams.terminal.local.spark.driver.extraJavaOptions:  -Duser.timezone=UTC

--- a/site/docs/ch/guides/deployment.md
+++ b/site/docs/ch/guides/deployment.md
@@ -212,8 +212,6 @@ optimize_group:
 Terminal 在 local 模式执行的情况下，可以配置 Spark 相关参数
 ```shell
 arctic.ams.terminal.backend: local
-arctic.ams.terminal.local.spark.driver.extraJavaOptions:  -Duser.timezone=UTC
-arctic.ams.terminal.local.spark.executor.extraJavaOptions:  -Duser.timezone=UTC
 arctic.ams.terminal.local.spark.sql.session.timeZone: UTC
 arctic.ams.terminal.local.spark.sql.iceberg.handle-timestamp-without-timezone=false
 ```

--- a/site/docs/ch/guides/deployment.md
+++ b/site/docs/ch/guides/deployment.md
@@ -207,6 +207,16 @@ optimize_group:
     container: external
     properties:
 ```
+
+### 配置 Terminal 
+Terminal 在 AMS 中的内存中执行的情况下，可以配置 Spark 相关参数
+```shell
+arctic.ams.terminal.backend: local
+arctic.ams.terminal.local.spark.driver.extraJavaOptions:  -Duser.timezone=UTC
+arctic.ams.terminal.local.spark.executor.extraJavaOptions:  -Duser.timezone=UTC
+arctic.ams.terminal.local.spark.sql.session.timeZone: UTC
+arctic.ams.terminal.local.spark.sql.iceberg.handle-timestamp-without-timezone=false
+```
 ## 启动 AMS
 进入到目录 arctic-x.y.z ， 执行 bin/ams.sh start 启动 AMS。
 ```shell


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix #1062 

## Brief change log

  - add config key prefix of terminal: SPARK_CONF = "spark."

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes)
 
Terminal  is executed in local mode, you can configure Spark properties

arctic.ams.terminal.backend: local
arctic.ams.terminal.local.spark.driver.extraJavaOptions:  -Duser.timezone=UTC
arctic.ams.terminal.local.spark.executor.extraJavaOptions:  -Duser.timezone=UTC
arctic.ams.terminal.local.spark.sql.session.timeZone: UTC
arctic.ams.terminal.local.spark.sql.iceberg.handle-timestamp-without-timezone=false

