### PR TITLE
[ARCTIC-1095][AMS] Add the sequence number for the native iceberg table when the major optimizing commit

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergOptimizeCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergOptimizeCommit.java
@@ -225,7 +225,7 @@ public class IcebergOptimizeCommit extends BasicOptimizeCommit {
       rewriteDataFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
       rewriteDataFiles.commit();
 
-      // remove DeleteFiles additional, because DeleteFiles maybe not existed
+      // remove DeleteFiles additional
       if (CollectionUtils.isNotEmpty(deleteDeleteFiles)) {
         RewriteFiles rewriteDeleteFiles = baseArcticTable.newRewrite();
         rewriteDeleteFiles.set(SnapshotSummary.SNAPSHOT_PRODUCER, CommitMetaProducer.OPTIMIZE.name());
@@ -234,6 +234,8 @@ public class IcebergOptimizeCommit extends BasicOptimizeCommit {
         try {
           rewriteDeleteFiles.commit();
         } catch (ValidationException e) {
+          // Iceberg will drop DeleteFiles that are older than the min Data sequence number. So some DeleteFiles
+          // maybe already dropped in the last commit, the exception can be ignored.
           LOG.warn("Iceberg RewriteFiles commit failed, but ignore", e);
         }
       }

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizeCommit.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizeCommit.java
@@ -46,10 +46,8 @@ public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
     try (CloseableIterable<FileScanTask> filesIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
         .planFiles()) {
       filesIterable.forEach(fileScanTask -> {
-        if (fileScanTask.file().fileSizeInBytes() <= 1000) {
-          oldDataFilesPath.add((String) fileScanTask.file().path());
-          fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
-        }
+        oldDataFilesPath.add((String) fileScanTask.file().path());
+        fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
       });
     }
 
@@ -108,6 +106,7 @@ public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
         .set(TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
             TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
         .set(TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
+        .set(org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")
         .commit();
     List<DataFile> dataFiles = insertDataFiles(icebergPartitionTable.asUnkeyedTable(), 10);
     insertEqDeleteFiles(icebergPartitionTable.asUnkeyedTable(), 5);
@@ -116,10 +115,8 @@ public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
     Set<String> oldDeleteFilesPath = new HashSet<>();
     try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan().planFiles()) {
       filesIterable.forEach(fileScanTask -> {
-        if (fileScanTask.file().fileSizeInBytes() <= 1000) {
-          oldDataFilesPath.add((String) fileScanTask.file().path());
-          fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
-        }
+        oldDataFilesPath.add((String) fileScanTask.file().path());
+        fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
       });
     }
 

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergMinorOptimizeCommit.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergMinorOptimizeCommit.java
@@ -96,7 +96,18 @@ public class TestIcebergMinorOptimizeCommit extends TestIcebergBase {
     optimizeCommit.commit(icebergNoPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
+    Set<String> newDeleteFilesPath = new HashSet<>();
+    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan()
+        .planFiles()) {
+      filesIterable.forEach(fileScanTask -> {
+        if (fileScanTask.file().fileSizeInBytes() <= 1000) {
+          newDataFilesPath.add((String) fileScanTask.file().path());
+          fileScanTask.deletes().forEach(deleteFile -> newDeleteFilesPath.add((String) deleteFile.path()));
+        }
+      });
+    }
     Assert.assertNotEquals(oldDataFilesPath, newDataFilesPath);
+    Assert.assertNotEquals(oldDeleteFilesPath, newDeleteFilesPath);
   }
 
   @Test
@@ -113,10 +124,8 @@ public class TestIcebergMinorOptimizeCommit extends TestIcebergBase {
     try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan()
         .planFiles()) {
       filesIterable.forEach(fileScanTask -> {
-        if (fileScanTask.file().fileSizeInBytes() <= 1000) {
-          oldDataFilesPath.add((String) fileScanTask.file().path());
-          fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
-        }
+        oldDataFilesPath.add((String) fileScanTask.file().path());
+        fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
       });
     }
 
@@ -160,6 +169,17 @@ public class TestIcebergMinorOptimizeCommit extends TestIcebergBase {
     optimizeCommit.commit(icebergPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
+    Set<String> newDeleteFilesPath = new HashSet<>();
+    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan()
+        .planFiles()) {
+      filesIterable.forEach(fileScanTask -> {
+        if (fileScanTask.file().fileSizeInBytes() <= 1000) {
+          newDataFilesPath.add((String) fileScanTask.file().path());
+          fileScanTask.deletes().forEach(deleteFile -> newDeleteFilesPath.add((String) deleteFile.path()));
+        }
+      });
+    }
     Assert.assertNotEquals(oldDataFilesPath, newDataFilesPath);
+    Assert.assertNotEquals(oldDeleteFilesPath, newDeleteFilesPath);
   }
 }


### PR DESCRIPTION
## Why are the changes needed?
fix #1095 

## Brief change log
  - *Add the sequence number for the native iceberg table when the major optimizing commit*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
