### PR TITLE
[ARCTIC-1107] Fix the problem that PartitionPropertiesUpdate can't remove key

### DIFF
--- a/core/src/main/java/com/netease/arctic/op/PartitionPropertiesUpdate.java
+++ b/core/src/main/java/com/netease/arctic/op/PartitionPropertiesUpdate.java
@@ -21,6 +21,7 @@ package com.netease.arctic.op;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.TablePropertyUtil;
+import org.apache.commons.compress.utils.Sets;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
@@ -75,13 +76,8 @@ public class PartitionPropertiesUpdate implements UpdatePartitionProperties {
     Preconditions.checkArgument(setPropertiesForPartition == null ||
             !setPropertiesForPartition.containsKey(key),
         "Cannot remove and update the same key: %s", key);
-    Set<String> properties = removeProperties.get(partitionData);
-    if (properties != null) {
-      properties.remove(key);
-      if (properties.isEmpty()) {
-        removeProperties.remove(partitionData);
-      }
-    }
+    Set<String> properties = removeProperties.computeIfAbsent(partitionData, k -> Sets.newHashSet());
+    properties.add(key);
     return this;
   }
 

--- a/core/src/main/java/com/netease/arctic/op/PartitionPropertiesUpdate.java
+++ b/core/src/main/java/com/netease/arctic/op/PartitionPropertiesUpdate.java
@@ -21,13 +21,13 @@ package com.netease.arctic.op;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.TablePropertyUtil;
-import org.apache.commons.compress.utils.Sets;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.StructLikeMap;
 
 import java.util.Map;

--- a/core/src/test/java/com/netease/arctic/op/UpdatePartitionPropertiesTest.java
+++ b/core/src/test/java/com/netease/arctic/op/UpdatePartitionPropertiesTest.java
@@ -60,4 +60,20 @@ public class UpdatePartitionPropertiesTest extends TableTestBase {
     Assert.assertEquals(1, partitionProperties.size());
     Assert.assertEquals("value", partitionProperties.get(p0).get("key"));
   }
+
+  @Test
+  public void testRemovePartitionProperties() {
+    StructLikeMap<Map<String, String>> partitionProperties = getArcticTable().asUnkeyedTable().partitionProperty();
+    Assert.assertEquals(0, partitionProperties.size());
+    StructLike p0 = TestHelpers.Row.of(1200);
+    getArcticTable().asUnkeyedTable().updatePartitionProperties(null).set(p0, "key", "value").commit();
+    partitionProperties = getArcticTable().asUnkeyedTable().partitionProperty();
+    Assert.assertEquals(1, partitionProperties.size());
+    Assert.assertEquals("value", partitionProperties.get(p0).get("key"));
+
+    getArcticTable().asUnkeyedTable().updatePartitionProperties(null).remove(p0, "key").commit();
+    partitionProperties = getArcticTable().asUnkeyedTable().partitionProperty();
+    Assert.assertEquals(1, partitionProperties.size());
+    Assert.assertEquals(null, partitionProperties.get(p0).get("key"));
+  }
 }

--- a/core/src/test/java/com/netease/arctic/op/UpdatePartitionPropertiesTest.java
+++ b/core/src/test/java/com/netease/arctic/op/UpdatePartitionPropertiesTest.java
@@ -74,6 +74,6 @@ public class UpdatePartitionPropertiesTest extends TableTestBase {
     getArcticTable().asUnkeyedTable().updatePartitionProperties(null).remove(p0, "key").commit();
     partitionProperties = getArcticTable().asUnkeyedTable().partitionProperty();
     Assert.assertEquals(1, partitionProperties.size());
-    Assert.assertEquals(null, partitionProperties.get(p0).get("key"));
+    Assert.assertNull(partitionProperties.get(p0).get("key"));
   }
 }

--- a/core/src/test/java/com/netease/arctic/op/UpdatePartitionPropertiesTest.java
+++ b/core/src/test/java/com/netease/arctic/op/UpdatePartitionPropertiesTest.java
@@ -68,12 +68,10 @@ public class UpdatePartitionPropertiesTest extends TableTestBase {
     StructLike p0 = TestHelpers.Row.of(1200);
     getArcticTable().asUnkeyedTable().updatePartitionProperties(null).set(p0, "key", "value").commit();
     partitionProperties = getArcticTable().asUnkeyedTable().partitionProperty();
-    Assert.assertEquals(1, partitionProperties.size());
-    Assert.assertEquals("value", partitionProperties.get(p0).get("key"));
+    Assert.assertEquals(1, partitionProperties.get(p0).size());
 
     getArcticTable().asUnkeyedTable().updatePartitionProperties(null).remove(p0, "key").commit();
     partitionProperties = getArcticTable().asUnkeyedTable().partitionProperty();
-    Assert.assertEquals(1, partitionProperties.size());
-    Assert.assertNull(partitionProperties.get(p0).get("key"));
+    Assert.assertEquals(0, partitionProperties.get(p0).size());
   }
 }


### PR DESCRIPTION
## Why are the changes needed?
fix #1107 

## Brief change log

  - *add remove the key to the removeProperties*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
