### PR TITLE
[ARCTIC-1111] Address the deserializing exception of the array<string> type in the logstore

### DIFF
--- a/core/src/main/java/com/netease/arctic/log/JsonToLogDataConverters.java
+++ b/core/src/main/java/com/netease/arctic/log/JsonToLogDataConverters.java
@@ -189,12 +189,15 @@ public class JsonToLogDataConverters<T> implements Serializable {
         final JsonNode innerNode = node.get(i);
         Object value = elementConverter.convert(innerNode, context);
         Object flinkValue = convertSecondTimeIfNecessary(elementType, value);
-        if (array == null) {
-          Class<?> flinkValueClass = flinkValue.getClass();
-          array = (Object[]) Array.newInstance(flinkValueClass, node.size());
+        if (flinkValue != null) {
+          if (array == null) {
+            Class<?> flinkValueClass = flinkValue.getClass();
+            array = (Object[]) Array.newInstance(flinkValueClass, node.size());
+          }
+          array[i] = flinkValue;
         }
-        array[i] = flinkValue;
       }
+      array = array == null ? new Object[node.size()] : array;
       return arrayFactory.create(array);
     };
   }

--- a/core/src/main/java/com/netease/arctic/log/JsonToLogDataConverters.java
+++ b/core/src/main/java/com/netease/arctic/log/JsonToLogDataConverters.java
@@ -181,20 +181,19 @@ public class JsonToLogDataConverters<T> implements Serializable {
     Types.NestedField elementField = list.field(list.elementId());
     JsonToLogDataConverter<T> elementConverter = createConverter(elementField.type());
     Type elementType = elementField.type();
-    final Class<?> elementClass;
-    if (elementType.typeId() == Type.TypeID.STRUCT) {
-      elementClass = factory.getActualValueClass();
-    } else {
-      elementClass = elementField.type().typeId().javaClass();
-    }
 
     return (jsonNode, context) -> {
       final ArrayNode node = (ArrayNode) jsonNode;
-      final Object[] array = (Object[]) Array.newInstance(elementClass, node.size());
+      Object[] array = null;
       for (int i = 0; i < node.size(); i++) {
         final JsonNode innerNode = node.get(i);
         Object value = elementConverter.convert(innerNode, context);
-        array[i] = convertSecondTimeIfNecessary(elementType, value);
+        Object flinkValue = convertSecondTimeIfNecessary(elementType, value);
+        if (array == null) {
+          Class<?> flinkValueClass = flinkValue.getClass();
+          array = (Object[]) Array.newInstance(flinkValueClass, node.size());
+        }
+        array[i] = flinkValue;
       }
       return arrayFactory.create(array);
     };

--- a/flink/v1.12/flink-format/src/main/java/com/netease/arctic/flink/shuffle/LogRecordV1.java
+++ b/flink/v1.12/flink-format/src/main/java/com/netease/arctic/flink/shuffle/LogRecordV1.java
@@ -353,20 +353,16 @@ public class LogRecordV1 implements LogData<RowData>, Serializable {
       for (int i = 0; i < objects.length; i++) {
         Object obj = objects[i];
         Type type = fieldTypes[i];
-        obj = wrapIntoNullableConvert(type, obj);
+        obj = convertIfNecessary(type, obj);
         row.setField(i, obj);
       }
       return row;
     }
 
-    public Object wrapIntoNullableConvert(Type primitiveType, Object object) {
-      if (object == null) {
+    public Object convertIfNecessary(Type primitiveType, Object obj) {
+      if (obj == null) {
         return null;
       }
-      return convertIfNecessary(primitiveType, object);
-    }
-
-    public Object convertIfNecessary(Type primitiveType, Object obj) {
       switch (primitiveType.typeId()) {
         case STRING:
           obj = StringData.fromString(obj.toString());

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/shuffle/LogRecordV1Test.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/shuffle/LogRecordV1Test.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.shuffle;
+
+import com.netease.arctic.data.ChangeAction;
+import com.netease.arctic.log.BaseFormatTest;
+import com.netease.arctic.log.Bytes;
+import com.netease.arctic.log.FormatVersion;
+import com.netease.arctic.log.LogData;
+import com.netease.arctic.log.LogDataJsonDeserialization;
+import com.netease.arctic.log.LogDataJsonSerialization;
+import com.netease.arctic.utils.IdGenerator;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This is a {@link LogRecordV1} log data test, include all data types.
+ */
+public class LogRecordV1Test extends BaseFormatTest {
+
+  public final Schema userSchema = new Schema(
+      new ArrayList<Types.NestedField>() {
+        {
+          add(Types.NestedField.optional(0, "f_boolean", Types.BooleanType.get()));
+          add(Types.NestedField.optional(1, "f_int", Types.IntegerType.get()));
+          add(Types.NestedField.optional(2, "f_long", Types.LongType.get()));
+          add(Types.NestedField.optional(3, "f_list_string", Types.ListType.ofOptional(
+              4, Types.StringType.get()
+          )));
+        }
+      });
+
+  @Test
+  public void testLogDataSerialize() throws IOException {
+
+    LogDataJsonSerialization<RowData> logDataJsonSerialization =
+        new LogDataJsonSerialization<>(userSchema, LogRecordV1.fieldGetterFactory);
+    GenericRowData rowData = new GenericRowData(4);
+    rowData.setField(0, true);
+    rowData.setField(1, 1);
+    rowData.setField(2, 123456789L);
+    rowData.setField(3,
+        new GenericArrayData(
+            new StringData[] {
+                StringData.fromString("a"),
+                StringData.fromString("b"),
+                StringData.fromString("c"),
+                StringData.fromString("d")}));
+    LogData<RowData> logData = new LogRecordV1(
+        FormatVersion.FORMAT_VERSION_V1,
+        IdGenerator.generateUpstreamId(),
+        123455L,
+        false,
+        ChangeAction.INSERT,
+        rowData
+    );
+
+    byte[] bytes = logDataJsonSerialization.serialize(logData);
+
+    Assert.assertNotNull(bytes);
+    String actualJson = new String(Bytes.subByte(bytes, 18, bytes.length - 18));
+    String expected =
+        "{\"f_boolean\":true,\"f_int\":1,\"f_long\":123456789,\"f_list_string\":[\"a\",\"b\",\"c\",\"d\"]}";
+    assertEquals(expected, actualJson);
+
+    LogDataJsonDeserialization<RowData> logDataJsonDeserialization =
+        new LogDataJsonDeserialization<>(
+            userSchema,
+            LogRecordV1.factory,
+            LogRecordV1.arrayFactory,
+            LogRecordV1.mapFactory);
+    LogData<RowData> result = logDataJsonDeserialization.deserialize(bytes);
+    Assert.assertNotNull(result);
+    check(logData, result);
+  }
+
+  private void check(LogData<RowData> expected, LogData<RowData> actual) {
+    assertArrayEquals(expected.getVersionBytes(), actual.getVersionBytes());
+    assertArrayEquals(expected.getUpstreamIdBytes(), actual.getUpstreamIdBytes());
+    assertEquals(expected.getEpicNo(), actual.getEpicNo());
+    assertEquals(expected.getFlip(), actual.getFlip());
+    assertEquals(expected.getChangeActionByte(), actual.getChangeActionByte());
+    assertEquals(expected.getActualValue().toString(), actual.getActualValue().toString());
+  }
+}

--- a/flink/v1.14/flink-format/src/main/java/com/netease/arctic/flink/shuffle/LogRecordV1.java
+++ b/flink/v1.14/flink-format/src/main/java/com/netease/arctic/flink/shuffle/LogRecordV1.java
@@ -353,20 +353,16 @@ public class LogRecordV1 implements LogData<RowData>, Serializable {
       for (int i = 0; i < objects.length; i++) {
         Object obj = objects[i];
         Type type = fieldTypes[i];
-        obj = wrapIntoNullableConvert(type, obj);
+        obj = convertIfNecessary(type, obj);
         row.setField(i, obj);
       }
       return row;
     }
 
-    public Object wrapIntoNullableConvert(Type primitiveType, Object object) {
-      if (object == null) {
+    public Object convertIfNecessary(Type primitiveType, Object obj) {
+      if (obj == null) {
         return null;
       }
-      return convertIfNecessary(primitiveType, object);
-    }
-
-    public Object convertIfNecessary(Type primitiveType, Object obj) {
       switch (primitiveType.typeId()) {
         case STRING:
           obj = StringData.fromString(obj.toString());

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/shuffle/LogRecordV1Test.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/shuffle/LogRecordV1Test.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.shuffle;
+
+import com.netease.arctic.data.ChangeAction;
+import com.netease.arctic.log.BaseFormatTest;
+import com.netease.arctic.log.Bytes;
+import com.netease.arctic.log.FormatVersion;
+import com.netease.arctic.log.LogData;
+import com.netease.arctic.log.LogDataJsonDeserialization;
+import com.netease.arctic.log.LogDataJsonSerialization;
+import com.netease.arctic.utils.IdGenerator;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This is a {@link LogRecordV1} log data test, include all data types.
+ */
+public class LogRecordV1Test extends BaseFormatTest {
+
+  public final Schema userSchema = new Schema(
+      new ArrayList<Types.NestedField>() {
+        {
+          add(Types.NestedField.optional(0, "f_boolean", Types.BooleanType.get()));
+          add(Types.NestedField.optional(1, "f_int", Types.IntegerType.get()));
+          add(Types.NestedField.optional(2, "f_long", Types.LongType.get()));
+          add(Types.NestedField.optional(3, "f_list_string", Types.ListType.ofOptional(
+              4, Types.StringType.get()
+          )));
+        }
+      });
+
+  @Test
+  public void testLogDataSerialize() throws IOException {
+
+    LogDataJsonSerialization<RowData> logDataJsonSerialization =
+        new LogDataJsonSerialization<>(userSchema, LogRecordV1.fieldGetterFactory);
+    GenericRowData rowData = new GenericRowData(4);
+    rowData.setField(0, true);
+    rowData.setField(1, 1);
+    rowData.setField(2, 123456789L);
+    rowData.setField(3,
+        new GenericArrayData(
+            new StringData[] {
+                StringData.fromString("a"),
+                StringData.fromString("b"),
+                StringData.fromString("c"),
+                StringData.fromString("d")}));
+    LogData<RowData> logData = new LogRecordV1(
+        FormatVersion.FORMAT_VERSION_V1,
+        IdGenerator.generateUpstreamId(),
+        123455L,
+        false,
+        ChangeAction.INSERT,
+        rowData
+    );
+
+    byte[] bytes = logDataJsonSerialization.serialize(logData);
+
+    Assert.assertNotNull(bytes);
+    String actualJson = new String(Bytes.subByte(bytes, 18, bytes.length - 18));
+    String expected =
+        "{\"f_boolean\":true,\"f_int\":1,\"f_long\":123456789,\"f_list_string\":[\"a\",\"b\",\"c\",\"d\"]}";
+    assertEquals(expected, actualJson);
+
+    LogDataJsonDeserialization<RowData> logDataJsonDeserialization =
+        new LogDataJsonDeserialization<>(
+            userSchema,
+            LogRecordV1.factory,
+            LogRecordV1.arrayFactory,
+            LogRecordV1.mapFactory);
+    LogData<RowData> result = logDataJsonDeserialization.deserialize(bytes);
+    Assert.assertNotNull(result);
+    check(logData, result);
+  }
+
+  private void check(LogData<RowData> expected, LogData<RowData> actual) {
+    assertArrayEquals(expected.getVersionBytes(), actual.getVersionBytes());
+    assertArrayEquals(expected.getUpstreamIdBytes(), actual.getUpstreamIdBytes());
+    assertEquals(expected.getEpicNo(), actual.getEpicNo());
+    assertEquals(expected.getFlip(), actual.getFlip());
+    assertEquals(expected.getChangeActionByte(), actual.getChangeActionByte());
+    assertEquals(expected.getActualValue().toString(), actual.getActualValue().toString());
+  }
+}

--- a/flink/v1.15/flink-format/src/main/java/com/netease/arctic/flink/shuffle/LogRecordV1.java
+++ b/flink/v1.15/flink-format/src/main/java/com/netease/arctic/flink/shuffle/LogRecordV1.java
@@ -353,20 +353,16 @@ public class LogRecordV1 implements LogData<RowData>, Serializable {
       for (int i = 0; i < objects.length; i++) {
         Object obj = objects[i];
         Type type = fieldTypes[i];
-        obj = wrapIntoNullableConvert(type, obj);
+        obj = convertIfNecessary(type, obj);
         row.setField(i, obj);
       }
       return row;
     }
 
-    public Object wrapIntoNullableConvert(Type primitiveType, Object object) {
-      if (object == null) {
+    public Object convertIfNecessary(Type primitiveType, Object obj) {
+      if (obj == null) {
         return null;
       }
-      return convertIfNecessary(primitiveType, object);
-    }
-
-    public Object convertIfNecessary(Type primitiveType, Object obj) {
       switch (primitiveType.typeId()) {
         case STRING:
           obj = StringData.fromString(obj.toString());

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/shuffle/LogRecordV1Test.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/shuffle/LogRecordV1Test.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.shuffle;
+
+import com.netease.arctic.data.ChangeAction;
+import com.netease.arctic.log.BaseFormatTest;
+import com.netease.arctic.log.Bytes;
+import com.netease.arctic.log.FormatVersion;
+import com.netease.arctic.log.LogData;
+import com.netease.arctic.log.LogDataJsonDeserialization;
+import com.netease.arctic.log.LogDataJsonSerialization;
+import com.netease.arctic.utils.IdGenerator;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This is a {@link LogRecordV1} log data test, include all data types.
+ */
+public class LogRecordV1Test extends BaseFormatTest {
+
+  public final Schema userSchema = new Schema(
+      new ArrayList<Types.NestedField>() {
+        {
+          add(Types.NestedField.optional(0, "f_boolean", Types.BooleanType.get()));
+          add(Types.NestedField.optional(1, "f_int", Types.IntegerType.get()));
+          add(Types.NestedField.optional(2, "f_long", Types.LongType.get()));
+          add(Types.NestedField.optional(3, "f_list_string", Types.ListType.ofOptional(
+              4, Types.StringType.get()
+          )));
+        }
+      });
+
+  @Test
+  public void testLogDataSerialize() throws IOException {
+
+    LogDataJsonSerialization<RowData> logDataJsonSerialization =
+        new LogDataJsonSerialization<>(userSchema, LogRecordV1.fieldGetterFactory);
+    GenericRowData rowData = new GenericRowData(4);
+    rowData.setField(0, true);
+    rowData.setField(1, 1);
+    rowData.setField(2, 123456789L);
+    rowData.setField(3,
+        new GenericArrayData(
+            new StringData[] {
+                StringData.fromString("a"),
+                StringData.fromString("b"),
+                StringData.fromString("c"),
+                StringData.fromString("d")}));
+    LogData<RowData> logData = new LogRecordV1(
+        FormatVersion.FORMAT_VERSION_V1,
+        IdGenerator.generateUpstreamId(),
+        123455L,
+        false,
+        ChangeAction.INSERT,
+        rowData
+    );
+
+    byte[] bytes = logDataJsonSerialization.serialize(logData);
+
+    Assert.assertNotNull(bytes);
+    String actualJson = new String(Bytes.subByte(bytes, 18, bytes.length - 18));
+    String expected =
+        "{\"f_boolean\":true,\"f_int\":1,\"f_long\":123456789,\"f_list_string\":[\"a\",\"b\",\"c\",\"d\"]}";
+    assertEquals(expected, actualJson);
+
+    LogDataJsonDeserialization<RowData> logDataJsonDeserialization =
+        new LogDataJsonDeserialization<>(
+            userSchema,
+            LogRecordV1.factory,
+            LogRecordV1.arrayFactory,
+            LogRecordV1.mapFactory);
+    LogData<RowData> result = logDataJsonDeserialization.deserialize(bytes);
+    Assert.assertNotNull(result);
+    check(logData, result);
+  }
+
+  private void check(LogData<RowData> expected, LogData<RowData> actual) {
+    assertArrayEquals(expected.getVersionBytes(), actual.getVersionBytes());
+    assertArrayEquals(expected.getUpstreamIdBytes(), actual.getUpstreamIdBytes());
+    assertEquals(expected.getEpicNo(), actual.getEpicNo());
+    assertEquals(expected.getFlip(), actual.getFlip());
+    assertEquals(expected.getChangeActionByte(), actual.getChangeActionByte());
+    assertEquals(expected.getActualValue().toString(), actual.getActualValue().toString());
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Address the deserializing exception of the array<string> type in the logstore

Fix: #1111 
## Brief change log

*(For example:)*
  - *Add LogRecordV1Test*
  - *The flink 1.12, 1.14, and 1.15 versions are affected.*
  - *Update the JsonToLogDataConverters class*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no) no 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not
