### PR TITLE
[ARCTIC-1063] When the flink jobs reads the arctic table for a while, the flink job fails

### DIFF
--- a/flink/v1.12/flink/pom.xml
+++ b/flink/v1.12/flink/pom.xml
@@ -337,6 +337,19 @@
         </dependency>
 
         <dependency>
+            <groupId>com.netease.arctic</groupId>
+            <artifactId>arctic-ams-server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.parquet</groupId>
+                    <artifactId>parquet-hadoop</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-metrics-jmx_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>

--- a/flink/v1.12/flink/pom.xml
+++ b/flink/v1.12/flink/pom.xml
@@ -337,19 +337,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.netease.arctic</groupId>
-            <artifactId>arctic-ams-server</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.parquet</groupId>
-                    <artifactId>parquet-hadoop</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-metrics-jmx_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -63,6 +63,12 @@ public class ArcticEnumeratorOffset {
     this.snapshotTimestampMs = snapshotTimestamp;
   }
 
+  public boolean isEmpty() {
+    return (changeSnapshotId == null && snapshotTimestampMs == null) ||
+      (changeSnapshotId != null && changeSnapshotId == Long.MIN_VALUE &&
+        snapshotTimestampMs != null && snapshotTimestampMs == Long.MIN_VALUE);
+  }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  * The enumerator offset indicate the snapshot id of the change table, or the timestamp of snapshot.
  */
 public class ArcticEnumeratorOffset {
-  public static final ArcticEnumeratorOffset EMPTY = empty();
+  private static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
 
   /**
    * use Long.MIN_VALUE to indicate the earliest offset
@@ -44,7 +44,7 @@ public class ArcticEnumeratorOffset {
   }
 
   public static ArcticEnumeratorOffset empty() {
-    return new ArcticEnumeratorOffset(Long.MIN_VALUE, Long.MIN_VALUE);
+    return EMPTY;
   }
 
   public Long changeSnapshotId() {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  * The enumerator offset indicate the snapshot id of the change table, or the timestamp of snapshot.
  */
 public class ArcticEnumeratorOffset {
-  public static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
+  public static final ArcticEnumeratorOffset EMPTY = empty();
 
   /**
    * use Long.MIN_VALUE to indicate the earliest offset
@@ -39,12 +39,12 @@ public class ArcticEnumeratorOffset {
     this.snapshotTimestampMs = snapshotTimestampMs;
   }
 
-  public static ArcticEnumeratorOffset of(long changeSnapshotId, Long snapshotTimestampMs) {
+  public static ArcticEnumeratorOffset of(Long changeSnapshotId, Long snapshotTimestampMs) {
     return new ArcticEnumeratorOffset(changeSnapshotId, snapshotTimestampMs);
   }
 
   public static ArcticEnumeratorOffset empty() {
-    return new ArcticEnumeratorOffset(null, null);
+    return new ArcticEnumeratorOffset(Long.MIN_VALUE, Long.MIN_VALUE);
   }
 
   public Long changeSnapshotId() {
@@ -64,9 +64,7 @@ public class ArcticEnumeratorOffset {
   }
 
   public boolean isEmpty() {
-    return (changeSnapshotId == null && snapshotTimestampMs == null) ||
-      (changeSnapshotId != null && changeSnapshotId == Long.MIN_VALUE &&
-        snapshotTimestampMs != null && snapshotTimestampMs == Long.MIN_VALUE);
+    return (changeSnapshotId == null && snapshotTimestampMs == null) || equals(EMPTY);
   }
 
   @Override

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffsetSerializer.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffsetSerializer.java
@@ -82,10 +82,6 @@ class ArcticEnumeratorOffsetSerializer implements SimpleVersionedSerializer<Arct
       snapshotTimestampMs = in.readLong();
     }
 
-    if (snapshotId != null) {
-      return ArcticEnumeratorOffset.of(snapshotId, snapshotTimestampMs);
-    } else {
-      return ArcticEnumeratorOffset.empty();
-    }
+    return ArcticEnumeratorOffset.of(snapshotId, snapshotTimestampMs);
   }
 }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -176,13 +176,8 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
     }
     if (!enumerationResult.isEmpty()) {
       splitAssigner.onDiscoveredSplits(enumerationResult.splits());
-//      enumeratorPosition.set(enumerationResult.toOffset());
-//      LOG.info("=== enumerationResult is not Empty ===");
-//      LOG.info("enumerationResult.toOffset(): {}", enumerationResult.toOffset());
     }
     if (!enumerationResult.toOffset().isEmpty()) {
-      LOG.info("=== enumerationResult.toOffset() is not Empty ===");
-      LOG.info("enumerationResult.toOffset(): {}", enumerationResult.toOffset());
       enumeratorPosition.set(enumerationResult.toOffset());
     }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -176,8 +176,16 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
     }
     if (!enumerationResult.isEmpty()) {
       splitAssigner.onDiscoveredSplits(enumerationResult.splits());
+//      enumeratorPosition.set(enumerationResult.toOffset());
+//      LOG.info("=== enumerationResult is not Empty ===");
+//      LOG.info("enumerationResult.toOffset(): {}", enumerationResult.toOffset());
+    }
+    if (!enumerationResult.toOffset().isEmpty()) {
+      LOG.info("=== enumerationResult.toOffset() is not Empty ===");
+      LOG.info("enumerationResult.toOffset(): {}", enumerationResult.toOffset());
       enumeratorPosition.set(enumerationResult.toOffset());
     }
+
     LOG.info("handled result of splits, discover splits size {}, latest offset {}.",
         enumerationResult.splits().size(), enumeratorPosition.get());
     lock.set(false);

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousEnumerationResult.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousEnumerationResult.java
@@ -32,7 +32,7 @@ import java.util.Collections;
  */
 public class ContinuousEnumerationResult {
   public static final ContinuousEnumerationResult EMPTY =
-      new ContinuousEnumerationResult(Collections.emptyList(), null, ArcticEnumeratorOffset.EMPTY);
+      new ContinuousEnumerationResult(Collections.emptyList(), null, ArcticEnumeratorOffset.empty());
 
   private final Collection<ArcticSplit> splits;
   private final ArcticEnumeratorOffset fromOffset;

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -289,7 +289,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Test(timeout = 30000)
+  @Test(timeout = 60000)
   public void testArcticContinuousSourceWithEmptyChangeInInit() throws Exception {
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_empty_change");
     KeyedTable table = testCatalog

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -381,8 +381,6 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     JobClient jobClient = clientAndIterator.client;
 
     List<RowData> actualResult = collectRecordsFromUnboundedStream(clientAndIterator, changeData.size());
-
-    LOG.info("=== first Assert begin ===");
     Assert.assertEquals(new HashSet<>(changeData), new HashSet<>(actualResult));
 
     // expire changeTable snapshots

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -408,6 +408,76 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
   }
 
   @Test
+  public void testArcticSourceEnumeratorWithBaseExpired() throws Exception {
+    final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
+    TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_keyed_tb");
+    KeyedTable table = testCatalog
+      .newTableBuilder(tableId, TABLE_SCHEMA)
+      .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+      .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
+      .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+      .create().asKeyedTable();
+
+    TaskWriter<RowData> taskWriter = createTaskWriter(table, true);
+    List<RowData> baseData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+    }};
+    for (RowData record : baseData) {
+      taskWriter.write(record);
+    }
+
+    List<DataFile> baseDataFiles = new ArrayList<>();
+    WriteResult result = taskWriter.complete();
+    baseDataFiles.addAll(Arrays.asList(result.dataFiles()));
+    commit(table, result, true);
+
+    for (DataFile dataFile : baseDataFiles) {
+      Assert.assertTrue(table.io().exists(dataFile.path().toString()));
+    }
+
+    ArcticSource<RowData> arcticSource = initArcticSource(true, SCAN_STARTUP_MODE_EARLIEST, tableId);
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    // enable checkpoint
+    env.enableCheckpointing(1000);
+    ClientAndIterator<RowData> clientAndIterator = executeAndCollectWithClient(env, arcticSource);
+
+    JobClient jobClient = clientAndIterator.client;
+
+    List<RowData> actualResult = collectRecordsFromUnboundedStream(clientAndIterator, baseData.size());
+    Assert.assertEquals(new HashSet<>(baseData), new HashSet<>(actualResult));
+
+    // expire baseTable snapshots
+    DeleteFiles deleteFiles = table.baseTable().newDelete();
+    for (DataFile dataFile : baseDataFiles) {
+      Assert.assertTrue(table.io().exists(dataFile.path().toString()));
+      deleteFiles.deleteFile(dataFile);
+    }
+    deleteFiles.commit();
+
+    LOG.info("commit empty snapshot");
+    AppendFiles changeAppend = table.changeTable().newAppend();
+    changeAppend.commit();
+    Thread.sleep(ScanContext.MONITOR_INTERVAL.defaultValue().toMillis() * 2);
+
+    expireSnapshots(table.baseTable(), System.currentTimeMillis(), new HashSet<>());
+
+    writeUpdate(updateRecords(), table);
+    writeUpdate(updateRecords(), table);
+
+    actualResult = collectRecordsFromUnboundedStream(clientAndIterator, excepts2().length * 2);
+    jobClient.cancel();
+
+    Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+  }
+
+  @Test
   public void testLatestStartupMode() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSourceWithLatest();
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -603,7 +673,8 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final AtomicInteger deleteFiles = new AtomicInteger(0);
     Set<String> parentDirectory = new HashSet<>();
     arcticInternalTable.expireSnapshots()
-      .retainLast(1).expireOlderThan(olderThan)
+      .retainLast(1)
+      .expireOlderThan(olderThan)
       .deleteWith(file -> {
         try {
           if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
@@ -616,7 +687,9 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         } finally {
           toDeleteFiles.incrementAndGet();
         }
-      }).cleanExpiredFiles(true).commit();
+      })
+      .cleanExpiredFiles(true)
+      .commit();
     parentDirectory.forEach(parent -> TableFileUtils.deleteEmptyDirectory(arcticInternalTable.io(), parent, exclude));
     LOG.info("to delete {} files, success delete {} files", toDeleteFiles.get(), deleteFiles.get());
   }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -704,7 +704,6 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     return ArcticTableLoader.of(PK_TABLE_ID, catalogBuilder);
   }
 
-
   private static class WatermarkAwareFailWrapper {
 
     private static WatermarkFailoverTestOperator op;

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -405,6 +405,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
 
     Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+    testCatalog.dropTable(tableId, true);
   }
 
   @Test
@@ -475,6 +476,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
 
     Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+    testCatalog.dropTable(tableId, true);
   }
 
   @Test

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -597,6 +597,32 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     return rowData;
   }
 
+  private static void expireSnapshots(UnkeyedTable arcticInternalTable,
+                                      long olderThan,
+                                      Set<String> exclude) {
+    LOG.debug("start expire snapshots, the exclude is {}", exclude);
+    final AtomicInteger toDeleteFiles = new AtomicInteger(0);
+    final AtomicInteger deleteFiles = new AtomicInteger(0);
+    Set<String> parentDirectory = new HashSet<>();
+    arcticInternalTable.expireSnapshots()
+      .retainLast(1).expireOlderThan(olderThan)
+      .deleteWith(file -> {
+        try {
+          if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
+            arcticInternalTable.io().deleteFile(file);
+          }
+          parentDirectory.add(new Path(file).getParent().toString());
+          deleteFiles.incrementAndGet();
+        } catch (Throwable t) {
+          LOG.warn("failed to delete file " + file, t);
+        } finally {
+          toDeleteFiles.incrementAndGet();
+        }
+      }).cleanExpiredFiles(true).commit();
+    parentDirectory.forEach(parent -> TableFileUtils.deleteEmptyDirectory(arcticInternalTable.io(), parent, exclude));
+    LOG.info("to delete {} files, success delete {} files", toDeleteFiles.get(), deleteFiles.get());
+  }
+
   private ArcticSource<RowData> initArcticSource(boolean isStreaming) {
     return initArcticSource(isStreaming, SCAN_STARTUP_MODE_EARLIEST);
   }
@@ -679,33 +705,6 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
   private ArcticTableLoader initLoader() {
     return ArcticTableLoader.of(PK_TABLE_ID, catalogBuilder);
   }
-
-  private static void expireSnapshots(UnkeyedTable arcticInternalTable,
-                                      long olderThan,
-                                      Set<String> exclude) {
-    LOG.debug("start expire snapshots, the exclude is {}", exclude);
-    final AtomicInteger toDeleteFiles = new AtomicInteger(0);
-    final AtomicInteger deleteFiles = new AtomicInteger(0);
-    Set<String> parentDirectory = new HashSet<>();
-    arcticInternalTable.expireSnapshots()
-      .retainLast(1).expireOlderThan(olderThan)
-      .deleteWith(file -> {
-        try {
-          if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
-            arcticInternalTable.io().deleteFile(file);
-          }
-          parentDirectory.add(new Path(file).getParent().toString());
-          deleteFiles.incrementAndGet();
-        } catch (Throwable t) {
-          LOG.warn("failed to delete file " + file, t);
-        } finally {
-          toDeleteFiles.incrementAndGet();
-        }
-      }).cleanExpiredFiles(true).commit();
-    parentDirectory.forEach(parent -> TableFileUtils.deleteEmptyDirectory(arcticInternalTable.io(), parent, exclude));
-    LOG.info("to delete {} files, success delete {} files", toDeleteFiles.get(), deleteFiles.get());
-  }
-  
 
   private static class WatermarkAwareFailWrapper {
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -706,6 +706,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     return ArcticTableLoader.of(PK_TABLE_ID, catalogBuilder);
   }
 
+
   private static class WatermarkAwareFailWrapper {
 
     private static WatermarkFailoverTestOperator op;

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImplTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImplTest.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read.hybrid.enumerator;
 
 import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.table.KeyedTable;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -102,5 +103,9 @@ public class ContinuousSplitPlannerImplTest extends FlinkTestBase {
 
   protected TaskWriter<RowData> createTaskWriter(boolean base) {
     return createKeyedTaskWriter(testKeyedTable, ROW_TYPE, base);
+  }
+
+  protected TaskWriter<RowData> createTaskWriter(KeyedTable keyedTable, boolean base) {
+    return createKeyedTaskWriter(keyedTable, ROW_TYPE, base);
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -63,6 +63,12 @@ public class ArcticEnumeratorOffset {
     this.snapshotTimestampMs = snapshotTimestamp;
   }
 
+  public boolean isEmpty() {
+    return (changeSnapshotId == null && snapshotTimestampMs == null) ||
+      (changeSnapshotId != null && changeSnapshotId == Long.MIN_VALUE &&
+        snapshotTimestampMs != null && snapshotTimestampMs == Long.MIN_VALUE);
+  }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  * The enumerator offset indicate the snapshot id of the change table, or the timestamp of snapshot.
  */
 public class ArcticEnumeratorOffset {
-  public static final ArcticEnumeratorOffset EMPTY = empty();
+  private static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
 
   /**
    * use Long.MIN_VALUE to indicate the earliest offset
@@ -44,7 +44,7 @@ public class ArcticEnumeratorOffset {
   }
 
   public static ArcticEnumeratorOffset empty() {
-    return new ArcticEnumeratorOffset(Long.MIN_VALUE, Long.MIN_VALUE);
+    return EMPTY;
   }
 
   public Long changeSnapshotId() {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  * The enumerator offset indicate the snapshot id of the change table, or the timestamp of snapshot.
  */
 public class ArcticEnumeratorOffset {
-  public static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
+  public static final ArcticEnumeratorOffset EMPTY = empty();
 
   /**
    * use Long.MIN_VALUE to indicate the earliest offset
@@ -39,12 +39,12 @@ public class ArcticEnumeratorOffset {
     this.snapshotTimestampMs = snapshotTimestampMs;
   }
 
-  public static ArcticEnumeratorOffset of(long changeSnapshotId, Long snapshotTimestampMs) {
+  public static ArcticEnumeratorOffset of(Long changeSnapshotId, Long snapshotTimestampMs) {
     return new ArcticEnumeratorOffset(changeSnapshotId, snapshotTimestampMs);
   }
 
   public static ArcticEnumeratorOffset empty() {
-    return new ArcticEnumeratorOffset(null, null);
+    return new ArcticEnumeratorOffset(Long.MIN_VALUE, Long.MIN_VALUE);
   }
 
   public Long changeSnapshotId() {
@@ -64,9 +64,7 @@ public class ArcticEnumeratorOffset {
   }
 
   public boolean isEmpty() {
-    return (changeSnapshotId == null && snapshotTimestampMs == null) ||
-      (changeSnapshotId != null && changeSnapshotId == Long.MIN_VALUE &&
-        snapshotTimestampMs != null && snapshotTimestampMs == Long.MIN_VALUE);
+    return (changeSnapshotId == null && snapshotTimestampMs == null) || equals(EMPTY);
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffsetSerializer.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffsetSerializer.java
@@ -83,10 +83,6 @@ class ArcticEnumeratorOffsetSerializer implements SimpleVersionedSerializer<Arct
       snapshotTimestampMs = in.readLong();
     }
 
-    if (snapshotId != null) {
-      return ArcticEnumeratorOffset.of(snapshotId, snapshotTimestampMs);
-    } else {
-      return ArcticEnumeratorOffset.empty();
-    }
+    return ArcticEnumeratorOffset.of(snapshotId, snapshotTimestampMs);
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -176,6 +176,8 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
     }
     if (!enumerationResult.isEmpty()) {
       splitAssigner.onDiscoveredSplits(enumerationResult.splits());
+    }
+    if (!enumerationResult.toOffset().isEmpty()) {
       enumeratorPosition.set(enumerationResult.toOffset());
     }
     LOG.info("handled result of splits, discover splits size {}, latest offset {}.",

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousEnumerationResult.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousEnumerationResult.java
@@ -33,7 +33,7 @@ import java.util.Collections;
  */
 public class ContinuousEnumerationResult {
   public static final ContinuousEnumerationResult EMPTY =
-      new ContinuousEnumerationResult(Collections.emptyList(), null, ArcticEnumeratorOffset.EMPTY);
+      new ContinuousEnumerationResult(Collections.emptyList(), null, ArcticEnumeratorOffset.empty());
 
   private final Collection<ArcticSplit> splits;
   private final ArcticEnumeratorOffset fromOffset;

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -289,7 +289,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Test(timeout = 30000)
+  @Test(timeout = 60000)
   public void testArcticContinuousSourceWithEmptyChangeInInit() throws Exception {
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_empty_change");
     KeyedTable table = testCatalog

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -381,8 +381,6 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     JobClient jobClient = clientAndIterator.client;
 
     List<RowData> actualResult = collectRecordsFromUnboundedStream(clientAndIterator, changeData.size());
-
-    LOG.info("=== first Assert begin ===");
     Assert.assertEquals(new HashSet<>(changeData), new HashSet<>(actualResult));
 
     // expire changeTable snapshots

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -405,6 +405,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
 
     Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+    testCatalog.dropTable(tableId, true);
   }
 
   @Test
@@ -475,6 +476,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
 
     Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+    testCatalog.dropTable(tableId, true);
   }
 
   @Test

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -32,6 +32,8 @@ import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.table.UnkeyedTable;
+import com.netease.arctic.utils.TableFileUtils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -61,9 +63,15 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
@@ -83,6 +91,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -329,6 +338,78 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
   }
 
   @Test
+  public void testArcticSourceEnumeratorWithChangeExpired() throws Exception {
+    final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
+    TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_keyed_tb");
+    KeyedTable table = testCatalog
+      .newTableBuilder(tableId, TABLE_SCHEMA)
+      .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+      .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
+      .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+      .create().asKeyedTable();
+
+    TaskWriter<RowData> taskWriter = createTaskWriter(table, false);
+    List<RowData> changeData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+    }};
+    for (RowData record : changeData) {
+      taskWriter.write(record);
+    }
+
+    List<DataFile> changeDataFiles = new ArrayList<>();
+    WriteResult result = taskWriter.complete();
+    changeDataFiles.addAll(Arrays.asList(result.dataFiles()));
+    commit(table, result, false);
+
+    for (DataFile dataFile : changeDataFiles) {
+      Assert.assertTrue(table.io().exists(dataFile.path().toString()));
+    }
+
+    ArcticSource<RowData> arcticSource = initArcticSource(true, SCAN_STARTUP_MODE_EARLIEST, tableId);
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    // enable checkpoint
+    env.enableCheckpointing(1000);
+    ClientAndIterator<RowData> clientAndIterator = executeAndCollectWithClient(env, arcticSource);
+
+    JobClient jobClient = clientAndIterator.client;
+
+    List<RowData> actualResult = collectRecordsFromUnboundedStream(clientAndIterator, changeData.size());
+
+    LOG.info("=== first Assert begin ===");
+    Assert.assertEquals(new HashSet<>(changeData), new HashSet<>(actualResult));
+
+    // expire changeTable snapshots
+    DeleteFiles deleteFiles = table.changeTable().newDelete();
+    for (DataFile dataFile : changeDataFiles) {
+      Assert.assertTrue(table.io().exists(dataFile.path().toString()));
+      deleteFiles.deleteFile(dataFile);
+    }
+    deleteFiles.commit();
+
+    LOG.info("commit empty snapshot");
+    AppendFiles changeAppend = table.changeTable().newAppend();
+    changeAppend.commit();
+    Thread.sleep(ScanContext.MONITOR_INTERVAL.defaultValue().toMillis() * 2);
+
+    expireSnapshots(table.changeTable(), System.currentTimeMillis(), new HashSet<>());
+
+    writeUpdate(updateRecords(), table);
+    writeUpdate(updateRecords(), table);
+
+    actualResult = collectRecordsFromUnboundedStream(clientAndIterator, excepts2().length * 2);
+    jobClient.cancel();
+
+    Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+  }
+
+  @Test
   public void testLatestStartupMode() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSourceWithLatest();
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -556,6 +637,32 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     rowData.setField(1, row.getString(1));
     rowData.setField(2, row.getTimestamp(2, 6));
     return rowData;
+  }
+
+  private static void expireSnapshots(UnkeyedTable arcticInternalTable,
+                                      long olderThan,
+                                      Set<String> exclude) {
+    LOG.debug("start expire snapshots, the exclude is {}", exclude);
+    final AtomicInteger toDeleteFiles = new AtomicInteger(0);
+    final AtomicInteger deleteFiles = new AtomicInteger(0);
+    Set<String> parentDirectory = new HashSet<>();
+    arcticInternalTable.expireSnapshots()
+      .retainLast(1).expireOlderThan(olderThan)
+      .deleteWith(file -> {
+        try {
+          if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
+            arcticInternalTable.io().deleteFile(file);
+          }
+          parentDirectory.add(new Path(file).getParent().toString());
+          deleteFiles.incrementAndGet();
+        } catch (Throwable t) {
+          LOG.warn("failed to delete file " + file, t);
+        } finally {
+          toDeleteFiles.incrementAndGet();
+        }
+      }).cleanExpiredFiles(true).commit();
+    parentDirectory.forEach(parent -> TableFileUtils.deleteEmptyDirectory(arcticInternalTable.io(), parent, exclude));
+    LOG.info("to delete {} files, success delete {} files", toDeleteFiles.get(), deleteFiles.get());
   }
 
   private ArcticSource<RowData> initArcticSource(boolean isStreaming) {

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImplTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImplTest.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read.hybrid.enumerator;
 
 import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.table.KeyedTable;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -102,5 +103,9 @@ public class ContinuousSplitPlannerImplTest extends FlinkTestBase {
 
   protected TaskWriter<RowData> createTaskWriter(boolean base) {
     return createKeyedTaskWriter(testKeyedTable, ROW_TYPE, base);
+  }
+
+  protected TaskWriter<RowData> createTaskWriter(KeyedTable keyedTable, boolean base) {
+    return createKeyedTaskWriter(keyedTable, ROW_TYPE, base);
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -63,6 +63,12 @@ public class ArcticEnumeratorOffset {
     this.snapshotTimestampMs = snapshotTimestamp;
   }
 
+  public boolean isEmpty() {
+    return (changeSnapshotId == null && snapshotTimestampMs == null) ||
+      (changeSnapshotId != null && changeSnapshotId == Long.MIN_VALUE &&
+        snapshotTimestampMs != null && snapshotTimestampMs == Long.MIN_VALUE);
+  }
+
   @Override
   public int hashCode() {
     return Objects.hashCode(

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  * The enumerator offset indicate the snapshot id of the change table, or the timestamp of snapshot.
  */
 public class ArcticEnumeratorOffset {
-  public static final ArcticEnumeratorOffset EMPTY = empty();
+  private static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
 
   /**
    * use Long.MIN_VALUE to indicate the earliest offset
@@ -44,7 +44,7 @@ public class ArcticEnumeratorOffset {
   }
 
   public static ArcticEnumeratorOffset empty() {
-    return new ArcticEnumeratorOffset(Long.MIN_VALUE, Long.MIN_VALUE);
+    return EMPTY;
   }
 
   public Long changeSnapshotId() {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffset.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Objects;
  * The enumerator offset indicate the snapshot id of the change table, or the timestamp of snapshot.
  */
 public class ArcticEnumeratorOffset {
-  public static final ArcticEnumeratorOffset EMPTY = of(Long.MIN_VALUE, Long.MIN_VALUE);
+  public static final ArcticEnumeratorOffset EMPTY = empty();
 
   /**
    * use Long.MIN_VALUE to indicate the earliest offset
@@ -39,12 +39,12 @@ public class ArcticEnumeratorOffset {
     this.snapshotTimestampMs = snapshotTimestampMs;
   }
 
-  public static ArcticEnumeratorOffset of(long changeSnapshotId, Long snapshotTimestampMs) {
+  public static ArcticEnumeratorOffset of(Long changeSnapshotId, Long snapshotTimestampMs) {
     return new ArcticEnumeratorOffset(changeSnapshotId, snapshotTimestampMs);
   }
 
   public static ArcticEnumeratorOffset empty() {
-    return new ArcticEnumeratorOffset(null, null);
+    return new ArcticEnumeratorOffset(Long.MIN_VALUE, Long.MIN_VALUE);
   }
 
   public Long changeSnapshotId() {
@@ -64,9 +64,7 @@ public class ArcticEnumeratorOffset {
   }
 
   public boolean isEmpty() {
-    return (changeSnapshotId == null && snapshotTimestampMs == null) ||
-      (changeSnapshotId != null && changeSnapshotId == Long.MIN_VALUE &&
-        snapshotTimestampMs != null && snapshotTimestampMs == Long.MIN_VALUE);
+    return (changeSnapshotId == null && snapshotTimestampMs == null) || equals(EMPTY);
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffsetSerializer.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticEnumeratorOffsetSerializer.java
@@ -83,10 +83,6 @@ class ArcticEnumeratorOffsetSerializer implements SimpleVersionedSerializer<Arct
       snapshotTimestampMs = in.readLong();
     }
 
-    if (snapshotId != null) {
-      return ArcticEnumeratorOffset.of(snapshotId, snapshotTimestampMs);
-    } else {
-      return ArcticEnumeratorOffset.empty();
-    }
+    return ArcticEnumeratorOffset.of(snapshotId, snapshotTimestampMs);
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ArcticSourceEnumerator.java
@@ -176,6 +176,8 @@ public class ArcticSourceEnumerator extends AbstractArcticEnumerator {
     }
     if (!enumerationResult.isEmpty()) {
       splitAssigner.onDiscoveredSplits(enumerationResult.splits());
+    }
+    if (!enumerationResult.toOffset().isEmpty()) {
       enumeratorPosition.set(enumerationResult.toOffset());
     }
     LOG.info("handled result of splits, discover splits size {}, latest offset {}.",

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousEnumerationResult.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousEnumerationResult.java
@@ -33,7 +33,7 @@ import java.util.Collections;
  */
 public class ContinuousEnumerationResult {
   public static final ContinuousEnumerationResult EMPTY =
-      new ContinuousEnumerationResult(Collections.emptyList(), null, ArcticEnumeratorOffset.EMPTY);
+      new ContinuousEnumerationResult(Collections.emptyList(), null, ArcticEnumeratorOffset.empty());
 
   private final Collection<ArcticSplit> splits;
   private final ArcticEnumeratorOffset fromOffset;

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -289,7 +289,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
   }
 
-  @Test(timeout = 30000)
+  @Test(timeout = 60000)
   public void testArcticContinuousSourceWithEmptyChangeInInit() throws Exception {
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_empty_change");
     KeyedTable table = testCatalog

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -405,6 +405,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
 
     Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+    testCatalog.dropTable(tableId, true);
   }
 
   @Test
@@ -475,6 +476,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     jobClient.cancel();
 
     Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+    testCatalog.dropTable(tableId, true);
   }
 
   @Test

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -64,9 +64,14 @@ import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
@@ -323,6 +328,76 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     Assert.assertEquals(new HashSet<>(baseData), new HashSet<>(actualResult));
 
     LOG.info("begin write update_before update_after data and commit new snapshot to change table.");
+    writeUpdate(updateRecords(), table);
+    writeUpdate(updateRecords(), table);
+
+    actualResult = collectRecordsFromUnboundedStream(clientAndIterator, excepts2().length * 2);
+    jobClient.cancel();
+
+    Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+  }
+
+  @Test
+  public void testArcticSourceEnumeratorWithChangeExpired() throws Exception {
+    final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
+    TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_keyed_tb");
+    KeyedTable table = testCatalog
+      .newTableBuilder(tableId, TABLE_SCHEMA)
+      .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+      .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
+      .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+      .create().asKeyedTable();
+
+    TaskWriter<RowData> taskWriter = createTaskWriter(table, false);
+    List<RowData> changeData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+    }};
+    for (RowData record : changeData) {
+      taskWriter.write(record);
+    }
+
+    List<DataFile> changeDataFiles = new ArrayList<>();
+    WriteResult result = taskWriter.complete();
+    changeDataFiles.addAll(Arrays.asList(result.dataFiles()));
+    commit(table, result, false);
+
+    for (DataFile dataFile : changeDataFiles) {
+      Assert.assertTrue(table.io().exists(dataFile.path().toString()));
+    }
+
+    ArcticSource<RowData> arcticSource = initArcticSource(true, SCAN_STARTUP_MODE_EARLIEST, tableId);
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    // enable checkpoint
+    env.enableCheckpointing(1000);
+    ClientAndIterator<RowData> clientAndIterator = executeAndCollectWithClient(env, arcticSource);
+
+    JobClient jobClient = clientAndIterator.client;
+
+    List<RowData> actualResult = collectRecordsFromUnboundedStream(clientAndIterator, changeData.size());
+    Assert.assertEquals(new HashSet<>(changeData), new HashSet<>(actualResult));
+
+    // expire changeTable snapshots
+    DeleteFiles deleteFiles = table.changeTable().newDelete();
+    for (DataFile dataFile : changeDataFiles) {
+      Assert.assertTrue(table.io().exists(dataFile.path().toString()));
+      deleteFiles.deleteFile(dataFile);
+    }
+    deleteFiles.commit();
+
+    LOG.info("commit empty snapshot");
+    AppendFiles changeAppend = table.changeTable().newAppend();
+    changeAppend.commit();
+    Thread.sleep(ScanContext.MONITOR_INTERVAL.defaultValue().toMillis() * 2);
+
+    expireSnapshots(table.changeTable(), System.currentTimeMillis(), new HashSet<>());
+
     writeUpdate(updateRecords(), table);
     writeUpdate(updateRecords(), table);
 

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -408,6 +408,76 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
   }
 
   @Test
+  public void testArcticSourceEnumeratorWithBaseExpired() throws Exception {
+    final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
+    TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_keyed_tb");
+    KeyedTable table = testCatalog
+      .newTableBuilder(tableId, TABLE_SCHEMA)
+      .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+      .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
+      .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+      .create().asKeyedTable();
+
+    TaskWriter<RowData> taskWriter = createTaskWriter(table, true);
+    List<RowData> baseData = new ArrayList<RowData>() {{
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+      add(GenericRowData.ofKind(
+        RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+    }};
+    for (RowData record : baseData) {
+      taskWriter.write(record);
+    }
+
+    List<DataFile> baseDataFiles = new ArrayList<>();
+    WriteResult result = taskWriter.complete();
+    baseDataFiles.addAll(Arrays.asList(result.dataFiles()));
+    commit(table, result, true);
+
+    for (DataFile dataFile : baseDataFiles) {
+      Assert.assertTrue(table.io().exists(dataFile.path().toString()));
+    }
+
+    ArcticSource<RowData> arcticSource = initArcticSource(true, SCAN_STARTUP_MODE_EARLIEST, tableId);
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    // enable checkpoint
+    env.enableCheckpointing(1000);
+    ClientAndIterator<RowData> clientAndIterator = executeAndCollectWithClient(env, arcticSource);
+
+    JobClient jobClient = clientAndIterator.client;
+
+    List<RowData> actualResult = collectRecordsFromUnboundedStream(clientAndIterator, baseData.size());
+    Assert.assertEquals(new HashSet<>(baseData), new HashSet<>(actualResult));
+
+    // expire baseTable snapshots
+    DeleteFiles deleteFiles = table.baseTable().newDelete();
+    for (DataFile dataFile : baseDataFiles) {
+      Assert.assertTrue(table.io().exists(dataFile.path().toString()));
+      deleteFiles.deleteFile(dataFile);
+    }
+    deleteFiles.commit();
+
+    LOG.info("commit empty snapshot");
+    AppendFiles changeAppend = table.changeTable().newAppend();
+    changeAppend.commit();
+    Thread.sleep(ScanContext.MONITOR_INTERVAL.defaultValue().toMillis() * 2);
+
+    expireSnapshots(table.baseTable(), System.currentTimeMillis(), new HashSet<>());
+
+    writeUpdate(updateRecords(), table);
+    writeUpdate(updateRecords(), table);
+
+    actualResult = collectRecordsFromUnboundedStream(clientAndIterator, excepts2().length * 2);
+    jobClient.cancel();
+
+    Assert.assertEquals(new HashSet<>(updateRecords()), new HashSet<>(actualResult));
+  }
+
+  @Test
   public void testLatestStartupMode() throws Exception {
     ArcticSource<RowData> arcticSource = initArcticSourceWithLatest();
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -645,7 +715,8 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final AtomicInteger deleteFiles = new AtomicInteger(0);
     Set<String> parentDirectory = new HashSet<>();
     arcticInternalTable.expireSnapshots()
-      .retainLast(1).expireOlderThan(olderThan)
+      .retainLast(1)
+      .expireOlderThan(olderThan)
       .deleteWith(file -> {
         try {
           if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
@@ -658,7 +729,9 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         } finally {
           toDeleteFiles.incrementAndGet();
         }
-      }).cleanExpiredFiles(true).commit();
+      })
+      .cleanExpiredFiles(true)
+      .commit();
     parentDirectory.forEach(parent -> TableFileUtils.deleteEmptyDirectory(arcticInternalTable.io(), parent, exclude));
     LOG.info("to delete {} files, success delete {} files", toDeleteFiles.get(), deleteFiles.get());
   }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImplTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hybrid/enumerator/ContinuousSplitPlannerImplTest.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read.hybrid.enumerator;
 
 import com.netease.arctic.flink.FlinkTestBase;
+import com.netease.arctic.table.KeyedTable;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -102,5 +103,9 @@ public class ContinuousSplitPlannerImplTest extends FlinkTestBase {
 
   protected TaskWriter<RowData> createTaskWriter(boolean base) {
     return createKeyedTaskWriter(testKeyedTable, ROW_TYPE, base);
+  }
+
+  protected TaskWriter<RowData> createTaskWriter(KeyedTable keyedTable, boolean base) {
+    return createKeyedTaskWriter(keyedTable, ROW_TYPE, base);
   }
 }


### PR DESCRIPTION
## Why are the changes needed?

fix #1063 
The ArcticSourceEnumerator enumeratorPosition does not advance with empty snapshots commit, which would cause this problem #1063 when empty snapshots are committed and the snapshot marked by the enumeratorPosition expires, so we need to change the movement rules for the enumeratorPosition

## Brief change log

  - *Change the movement rules for the enumeratorPosition of ArcticSourceEnumerator*
  
## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
