### PR TITLE
[ARCTIC-1134][Core] Fix kerberos authenticate failure

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
+++ b/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
@@ -283,7 +283,7 @@ public class TableMetaStore implements Serializable {
                 }
               }
 
-              if (oldSystemPrincipal != null && oldSystemPrincipal.equals(krbPrincipal)) {
+              if (oldSystemPrincipal != null && !oldSystemPrincipal.equals(krbPrincipal)) {
                 System.setProperty("sun.security.krb5.principal", krbPrincipal);
                 systemPrincipalChanged = true;
               }

--- a/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
+++ b/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
@@ -280,6 +280,7 @@ public class TableMetaStore implements Serializable {
                   LOG.warn("Fail to reflect UserGroupInformation", e);
                 }
               }
+              System.setProperty("sun.security.krb5.principal", krbPrincipal);
               ugi.checkTGTAndReloginFromKeytab();
             } catch (Exception e) {
               throw new RuntimeException("Re-login from keytab failed", e);

--- a/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
+++ b/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
@@ -283,7 +283,7 @@ public class TableMetaStore implements Serializable {
                 }
               }
 
-              if (!krbPrincipal.equals(oldSystemPrincipal)) {
+              if (oldSystemPrincipal != null && oldSystemPrincipal.equals(krbPrincipal)) {
                 System.setProperty("sun.security.krb5.principal", krbPrincipal);
                 systemPrincipalChanged = true;
               }


### PR DESCRIPTION
## Why are the changes needed?

resolve #1134 

## Brief change log

Reset `sun.security.krb5.principal` before `ugi.checkTGTAndReloginFromKeytab()`.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
