### PR TITLE
[ARCTIC-1148] Confirm the file cache is latest when optimize plan for the unKeyed table support hive

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BaseOptimizePlan.java
@@ -38,7 +38,6 @@ import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.SerializationUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.Snapshot;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -282,13 +281,11 @@ public abstract class BaseOptimizePlan {
   }
 
   private boolean baseTableCacheAll() {
-    if (arcticTable.isKeyedTable()) {
-      if (currentBaseSnapshotId != TableOptimizeRuntime.INVALID_SNAPSHOT_ID &&
-          !snapshotIsCached.test(currentBaseSnapshotId)) {
-        LOG.debug("File cache don't have cache snapshotId:{}," +
-            "wait file cache sync latest file info", currentBaseSnapshotId);
-        return false;
-      }
+    if (currentBaseSnapshotId != TableOptimizeRuntime.INVALID_SNAPSHOT_ID &&
+        !snapshotIsCached.test(currentBaseSnapshotId)) {
+      LOG.debug("File cache don't have cache snapshotId:{}," +
+          "wait file cache sync latest file info", currentBaseSnapshotId);
+      return false;
     }
 
     return true;


### PR DESCRIPTION
## Why are the changes needed?
fix #1148 

## Brief change log

  - *Confirm the file cache is latest when optimize plan for the unKeyed table support hive*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
