### PR TITLE
[ARCTIC-1153][Optimize] Put task back into the queue if polling tasks failed

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
@@ -570,10 +570,17 @@ public class OptimizeQueueService extends IJDBCService {
               tableTaskHistory = task.onExecuting(jobId, attemptId);
             } catch (Exception e) {
               task.clearFiles();
-              LOG.error("{} failed to load files from sysdb, try put task back into queue", task.getTaskId(), e);
+              LOG.error("{} handle sysdb failed, try put task back into queue", task.getTaskId(), e);
               if (!tasks.offer(task)) {
                 LOG.error("{} failed to put task back into queue", task.getTaskId());
                 task.onFailed(new ErrorMessage(System.currentTimeMillis(), "failed to put task back into queue"), 0);
+              }
+
+              // sleep 1s, avoid poll task failed use too much cpu
+              try {
+                Thread.sleep(1000);
+              } catch (InterruptedException ex) {
+                LOG.error("poll task {} failed,sleep thread was interrupted", task.getTaskId(), ex);
               }
               continue;
             }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
@@ -580,7 +580,7 @@ public class OptimizeQueueService extends IJDBCService {
               try {
                 Thread.sleep(1000);
               } catch (InterruptedException ex) {
-                LOG.error("poll task {} failed,sleep thread was interrupted", task.getTaskId(), ex);
+                LOG.error("poll task {} failed, sleep thread was interrupted", task.getTaskId(), ex);
               }
               continue;
             }


### PR DESCRIPTION
## Why are the changes needed?
fix #1153 

## Brief change log

  - *Put task back into the queue if polling tasks failed*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
