### PR TITLE
[ARCTIC-1152]Fix the smooth cancellation issue of Optimizer jobs during runtime in Flink environment

### DIFF
--- a/optimizer/src/main/java/com/netease/arctic/optimizer/flink/FlinkConsumer.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/flink/FlinkConsumer.java
@@ -31,6 +31,8 @@ public class FlinkConsumer extends RichParallelSourceFunction<TaskWrapper> {
 
   private final BaseTaskConsumer taskConsumer;
 
+  private volatile boolean running = true;
+
   public FlinkConsumer(OptimizerConfig config) {
     this.taskConsumer = new BaseTaskConsumer(config);
   }
@@ -47,7 +49,7 @@ public class FlinkConsumer extends RichParallelSourceFunction<TaskWrapper> {
   @Override
   public void run(SourceContext<TaskWrapper> sourceContext) throws Exception {
     int retry = 0;
-    while (true) {
+    while (running) {
       try {
         TaskWrapper task = taskConsumer.pollTask();
         if (task != null) {
@@ -73,6 +75,6 @@ public class FlinkConsumer extends RichParallelSourceFunction<TaskWrapper> {
 
   @Override
   public void cancel() {
-
+    running = false;
   }
 }


### PR DESCRIPTION
Resolve #1152

## Why are the changes needed?
When the Optimizer job under Flink environment is canceled during runtime, it cannot exit smoothly.

Use variables to optimize the while loop logic in the run method of the FlinkConsumer class in the arctic-optimizer module. When the user cancels the job, control the loop variable to be false to allow the while loop to exit in a timely manner.

## Brief change log

  - Modified the FlinkConsumer class in the optimizer module, adding a loop variable in the run method.

## How was this patch tested?
- Local testing has been conducted.
