### PR TITLE
[ARCTIC-1171][FLINK] When reading partial fields from Logstore, the number of fields does not match

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -257,7 +257,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
           arcticTable, schema);
     }
     return new LogDynamicSource(
-        valueProjection,
         properties,
         schema,
         tableOptions,

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -142,7 +142,9 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
 
     if (projectedFields != null) {
       List<NestedField> projectedSchemaColumns = projectedSchema.columns();
-      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(projectedSchemaColumns::get).collect(Collectors.toList()));
+      projectedSchema = new Schema(Arrays.stream(projectedFields)
+        .mapToObj(projectedSchemaColumns::get)
+        .collect(Collectors.toList()));
     }
     LOG.info("Schema used for create KafkaSource is :{}", projectedSchema);
 
@@ -162,7 +164,9 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
 
     if (projectedFields != null) {
       List<NestedField> projectedSchemaColumns = projectedSchema.columns();
-      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(projectedSchemaColumns::get).collect(Collectors.toList()));
+      projectedSchema = new Schema(Arrays.stream(projectedFields)
+        .mapToObj(projectedSchemaColumns::get)
+        .collect(Collectors.toList()));
     }
     LOG.info("Schema used for create PulsarSource is :{}", projectedSchema);
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -146,7 +146,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
         .mapToObj(projectedSchemaColumns::get)
         .collect(Collectors.toList()));
     }
-    LOG.info("Schema used for create KafkaSource is :{}", projectedSchema);
+    LOG.info("Schema used for create KafkaSource is: {}", projectedSchema);
 
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
     kafkaSourceBuilder.setProperties(properties);
@@ -168,7 +168,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
         .mapToObj(projectedSchemaColumns::get)
         .collect(Collectors.toList()));
     }
-    LOG.info("Schema used for create PulsarSource is :{}", projectedSchema);
+    LOG.info("Schema used for create PulsarSource is: {}", projectedSchema);
 
     LogPulsarSourceBuilder pulsarSourceBuilder = LogPulsarSource.builder(projectedSchema, arcticTable.properties());
     pulsarSourceBuilder.setProperties(properties);

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -34,11 +34,14 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +65,7 @@ import static org.apache.flink.table.connector.ChangelogMode.insertOnly;
 /**
  * This is a log source table api, create log queue consumer e.g. {@link LogKafkaSource}
  */
-public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown {
+public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown, SupportsProjectionPushDown {
 
   private static final Logger LOG = LoggerFactory.getLogger(LogDynamicSource.class);
 
@@ -71,6 +74,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   private final ReadableConfig tableOptions;
   private final Optional<String> consumerChangelogMode;
   private final boolean logRetractionEnable;
+  private int[] projectedFields;
 
   /**
    * Watermark strategy that is used to generate per-partition watermark.
@@ -136,6 +140,12 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       projectedSchema = new Schema(Arrays.stream(valueProjection).mapToObj(columns::get).collect(Collectors.toList()));
     }
 
+    if (projectedFields != null) {
+      List<NestedField> projectedSchemaColumns = projectedSchema.columns();
+      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(projectedSchemaColumns::get).collect(Collectors.toList()));
+    }
+    LOG.info("Schema used for create KafkaSource is :{}", projectedSchema);
+
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
     kafkaSourceBuilder.setProperties(properties);
 
@@ -149,6 +159,12 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       final List<Types.NestedField> columns = schema.columns();
       projectedSchema = new Schema(Arrays.stream(valueProjection).mapToObj(columns::get).collect(Collectors.toList()));
     }
+
+    if (projectedFields != null) {
+      List<NestedField> projectedSchemaColumns = projectedSchema.columns();
+      projectedSchema = new Schema(Arrays.stream(projectedFields).mapToObj(projectedSchemaColumns::get).collect(Collectors.toList()));
+    }
+    LOG.info("Schema used for create PulsarSource is :{}", projectedSchema);
 
     LogPulsarSourceBuilder pulsarSourceBuilder = LogPulsarSource.builder(projectedSchema, arcticTable.properties());
     pulsarSourceBuilder.setProperties(properties);
@@ -240,4 +256,18 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.watermarkStrategy = watermarkStrategy;
   }
 
+  @Override
+  public boolean supportsNestedProjection() {
+    return false;
+  }
+
+  @Override
+  public void applyProjection(int[][] projectFields) {
+    this.projectedFields = new int[projectFields.length];
+    for (int i = 0; i < projectFields.length; i++) {
+      Preconditions.checkArgument(projectFields[i].length == 1,
+          "Don't support nested projection now.");
+      this.projectedFields[i] = projectFields[i][0];
+    }
+  }
 }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -292,6 +292,68 @@ public class TestKeyed extends FlinkTestBase {
   }
 
   @Test
+  public void testUnpartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        Row row = iterator.next();
+        actual.add(row);
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
   public void testUnPartitionDoubleSink() throws Exception {
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a"});
@@ -535,6 +597,68 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
+  public void testPartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+      ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        Row row = iterator.next();
+        actual.add(row);
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
     result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -317,7 +317,7 @@ public class TestKeyed extends FlinkTestBase {
 
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
+      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
       "'arctic.emit.mode'='log'" +

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -374,6 +374,67 @@ public class TestUnkeyed extends FlinkTestBase {
   }
 
   @Test
+  public void testUnpartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        actual.add(iterator.next());
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
   public void testUnPartitionDoubleSink() throws Exception {
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a"});
@@ -591,6 +652,67 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
+
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
+  public void testPartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        actual.add(iterator.next());
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
 
     result.getJobClient().ifPresent(TestUtil::cancelJob);
   }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -398,7 +398,7 @@ public class TestUnkeyed extends FlinkTestBase {
 
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING) WITH %s", toWithClause(tableProperties));
+      " id INT, name STRING, op_time TIMESTAMP) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
       "'arctic.emit.mode'='log'" +
@@ -681,7 +681,7 @@ public class TestUnkeyed extends FlinkTestBase {
 
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING, dt STRING) PARTITIONED BY (dt) WITH %s", toWithClause(tableProperties));
+      " id INT, name STRING, op_time TIMESTAMP) PARTITIONED BY (op_time) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
       "'arctic.emit.mode'='log'" +

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -257,7 +257,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
           arcticTable, schema);
     }
     return new LogDynamicSource(
-        valueProjection,
         properties,
         schema,
         tableOptions,

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -138,7 +138,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
         .mapToObj(projectedSchemaColumns::get)
         .collect(Collectors.toList()));
     }
-    LOG.info("Schema used for create KafkaSource is :{}", projectedSchema);
+    LOG.info("Schema used for create KafkaSource is: {}", projectedSchema);
 
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
     kafkaSourceBuilder.setProperties(properties);

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -31,11 +31,16 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -53,13 +58,15 @@ import static org.apache.flink.table.connector.ChangelogMode.insertOnly;
 /**
  * This is a log source table api, create log queue consumer e.g. {@link LogKafkaSource}
  */
-public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown {
+public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushDown, SupportsProjectionPushDown {
+  private static final Logger LOG = LoggerFactory.getLogger(LogDynamicSource.class);
 
   private final ArcticTable arcticTable;
   private final Schema schema;
   private final ReadableConfig tableOptions;
   private final Optional<String> consumerChangelogMode;
   private final boolean logRetractionEnable;
+  private int[] projectedFields;
 
   /**
    * Watermark strategy that is used to generate per-partition watermark.
@@ -125,9 +132,18 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       projectedSchema = new Schema(Arrays.stream(valueProjection).mapToObj(columns::get).collect(Collectors.toList()));
     }
 
+    if (projectedFields != null) {
+      List<NestedField> projectedSchemaColumns = projectedSchema.columns();
+      projectedSchema = new Schema(Arrays.stream(projectedFields)
+        .mapToObj(projectedSchemaColumns::get)
+        .collect(Collectors.toList()));
+    }
+    LOG.info("Schema used for create KafkaSource is :{}", projectedSchema);
+
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
     kafkaSourceBuilder.setProperties(properties);
 
+    LOG.info("build log kafka source");
     return kafkaSourceBuilder.build();
   }
 
@@ -199,5 +215,20 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   @Override
   public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
     this.watermarkStrategy = watermarkStrategy;
+  }
+
+  @Override
+  public boolean supportsNestedProjection() {
+    return false;
+  }
+
+  @Override
+  public void applyProjection(int[][] projectFields) {
+    this.projectedFields = new int[projectFields.length];
+    for (int i = 0; i < projectFields.length; i++) {
+      Preconditions.checkArgument(projectFields[i].length == 1,
+          "Don't support nested projection now.");
+      this.projectedFields[i] = projectFields[i][0];
+    }
   }
 }

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -270,6 +270,68 @@ public class TestKeyed extends FlinkTestBase {
   }
 
   @Test
+  public void testUnpartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        Row row = iterator.next();
+        actual.add(row);
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
   public void testUnPartitionDoubleSink() throws Exception {
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a"});
@@ -513,6 +575,68 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
+  public void testPartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+      ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        Row row = iterator.next();
+        actual.add(row);
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
     result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -335,6 +335,71 @@ public class TestUnkeyed extends FlinkTestBase {
   }
 
   @Test
+  public void testUnpartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(ENABLE_LOG_STORE, "true");
+    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
+    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        actual.add(iterator.next());
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
   public void testUnPartitionDoubleSink() throws Exception {
     String topic = this.topic + "testUnPartitionDoubleSink";
     kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
@@ -566,6 +631,75 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
+
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
+  public void testPartitionLogSinkSourceWithSelectedFields() throws Exception {
+    String topic = this.topic + "testPartitionLogSinkSourceWithSelectedFields";
+    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
+
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(ENABLE_LOG_STORE, "true");
+    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
+    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP) PARTITIONED BY (op_time) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        actual.add(iterator.next());
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
 
     result.getJobClient().ifPresent(TestUtil::cancelJob);
   }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/DynamicTableFactory.java
@@ -257,7 +257,6 @@ public class DynamicTableFactory implements DynamicTableSourceFactory, DynamicTa
           arcticTable, schema);
     }
     return new LogDynamicSource(
-        valueProjection,
         properties,
         schema,
         tableOptions,

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -139,7 +139,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
         .mapToObj(projectedSchemaColumns::get)
         .collect(Collectors.toList()));
     }
-    LOG.info("Schema used for create KafkaSource is :{}", projectedSchema);
+    LOG.info("Schema used for create KafkaSource is: {}", projectedSchema);
 
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
     kafkaSourceBuilder.setProperties(properties);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/LogDynamicSource.java
@@ -37,7 +37,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +66,6 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   private final ReadableConfig tableOptions;
   private final Optional<String> consumerChangelogMode;
   private final boolean logRetractionEnable;
-  private int[] projectedFields;
 
   /**
    * Watermark strategy that is used to generate per-partition watermark.
@@ -79,7 +77,7 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   /**
    * Indices that determine the value fields and the target position in the produced row.
    */
-  protected final int[] valueProjection;
+  protected int[] projectedFields;
 
   /**
    * Properties for the logStore consumer.
@@ -94,7 +92,6 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
       .build();
 
   public LogDynamicSource(
-      int[] valueProjection,
       Properties properties,
       Schema schema,
       ReadableConfig tableOptions,
@@ -105,12 +102,10 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.logRetractionEnable = CompatibleFlinkPropertyUtil.propertyAsBoolean(arcticTable.properties(),
         ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.key(), ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.defaultValue());
     this.arcticTable = arcticTable;
-    this.valueProjection = valueProjection;
     this.properties = properties;
   }
 
   public LogDynamicSource(
-      int[] valueProjection,
       Properties properties,
       Schema schema,
       ReadableConfig tableOptions,
@@ -122,23 +117,11 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
     this.consumerChangelogMode = consumerChangelogMode;
     this.logRetractionEnable = logRetractionEnable;
     this.arcticTable = arcticTable;
-    this.valueProjection = valueProjection;
     this.properties = properties;
   }
 
   protected LogKafkaSource createKafkaSource() {
-    Schema projectedSchema = schema;
-    if (valueProjection != null) {
-      final List<Types.NestedField> columns = schema.columns();
-      projectedSchema = new Schema(Arrays.stream(valueProjection).mapToObj(columns::get).collect(Collectors.toList()));
-    }
-
-    if (projectedFields != null) {
-      List<NestedField> projectedSchemaColumns = projectedSchema.columns();
-      projectedSchema = new Schema(Arrays.stream(projectedFields)
-        .mapToObj(projectedSchemaColumns::get)
-        .collect(Collectors.toList()));
-    }
+    Schema projectedSchema = getProjectSchema(schema);
     LOG.info("Schema used for create KafkaSource is: {}", projectedSchema);
 
     LogKafkaSourceBuilder kafkaSourceBuilder = LogKafkaSource.builder(projectedSchema, arcticTable.properties());
@@ -199,7 +182,6 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
   @Override
   public DynamicTableSource copy() {
     return new LogDynamicSource(
-        this.valueProjection,
         this.properties,
         this.schema,
         this.tableOptions,
@@ -231,5 +213,15 @@ public class LogDynamicSource implements ScanTableSource, SupportsWatermarkPushD
           "Don't support nested projection now.");
       this.projectedFields[i] = projectFields[i][0];
     }
+  }
+
+  private Schema getProjectSchema(Schema projectedSchema) {
+    if (projectedFields != null) {
+      List<NestedField> projectedSchemaColumns = projectedSchema.columns();
+      projectedSchema = new Schema(Arrays.stream(projectedFields)
+        .mapToObj(projectedSchemaColumns::get)
+        .collect(Collectors.toList()));
+    }
+    return projectedSchema;
   }
 }

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -270,6 +270,68 @@ public class TestKeyed extends FlinkTestBase {
   }
 
   @Test
+  public void testUnpartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        Row row = iterator.next();
+        actual.add(row);
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
   public void testUnPartitionDoubleSink() throws Exception {
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a"});
@@ -513,6 +575,68 @@ public class TestKeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
+  public void testPartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+      ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        Row row = iterator.next();
+        actual.add(row);
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
     result.getJobClient().ifPresent(TestUtil::cancelJob);
   }
 

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -335,6 +335,71 @@ public class TestUnkeyed extends FlinkTestBase {
   }
 
   @Test
+  public void testUnpartitionLogSinkSourceWithSelectedFields() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(ENABLE_LOG_STORE, "true");
+    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
+    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        actual.add(iterator.next());
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
+
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
   public void testUnPartitionDoubleSink() throws Exception {
     String topic = this.topic + "testUnPartitionDoubleSink";
     kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
@@ -566,6 +631,75 @@ public class TestUnkeyed extends FlinkTestBase {
       }
     }
     Assert.assertEquals(DataUtil.toRowSet(data), actual);
+
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
+  public void testPartitionLogSinkSourceWithSelectedFields() throws Exception {
+    String topic = this.topic + "testPartitionLogSinkSourceWithSelectedFields";
+    kafkaTestBase.createTopics(KAFKA_PARTITION_NUMS, topic);
+
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000015, "d", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(ENABLE_LOG_STORE, "true");
+    tableProperties.put(LOG_STORE_ADDRESS, kafkaTestBase.brokerConnectionStrings);
+    tableProperties.put(LOG_STORE_MESSAGE_TOPIC, topic);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, op_time TIMESTAMP) PARTITIONED BY (op_time) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+      "'arctic.emit.mode'='log'" +
+      ", 'log.version'='v1'" +
+      ") */" +
+      " select * from input");
+
+    TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='log'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        actual.add(iterator.next());
+      }
+    }
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{1000004, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000011, LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{1000014, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000015, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    expected.add(new Object[]{1000007, LocalDateTime.parse("2022-06-18T10:10:11.0")});
+
+    Assert.assertEquals(DataUtil.toRowSet(expected), actual);
 
     result.getJobClient().ifPresent(TestUtil::cancelJob);
   }


### PR DESCRIPTION
## Why are the changes needed?
fix #1171 

## Brief change log

  - *LogDynamicSource support ProjectionPushDown feature*
  - *The flink 1.12, 1.14 and 1.15 versions are affected.*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
