### PR TITLE
[ARCTIC-1175][AMS] Improve the return of the UnKeyedTableUtil#getAllContentFilePath method

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
@@ -66,13 +66,9 @@ public class UnKeyedTableUtil {
             MetadataTableType.ALL_ENTRIES);
     try (CloseableIterable<Record> entries = IcebergGenerics.read(manifestTable).build()) {
       for (Record entry : entries) {
-        ManifestEntryFields.Status status =
-            ManifestEntryFields.Status.of((int) entry.get(ManifestEntryFields.STATUS.fieldId()));
-        if (status == ManifestEntryFields.Status.ADDED || status == ManifestEntryFields.Status.EXISTING) {
-          GenericRecord dataFile = (GenericRecord) entry.get(ManifestEntryFields.DATA_FILE_ID);
-          String filePath = (String) dataFile.getField(DataFile.FILE_PATH.name());
-          validFilesPath.add(TableFileUtils.getUriPath(filePath));
-        }
+        GenericRecord dataFile = (GenericRecord) entry.get(ManifestEntryFields.DATA_FILE_ID);
+        String filePath = (String) dataFile.getField(DataFile.FILE_PATH.name());
+        validFilesPath.add(TableFileUtils.getUriPath(filePath));
       }
     } catch (IOException e) {
       LOG.error("close manifest file error", e);

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtilTest.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtilTest.java
@@ -133,7 +133,6 @@ public class UnKeyedTableUtilTest extends TableTestBase {
     getArcticTable().asKeyedTable().baseTable().expireSnapshots()
         .retainLast(1).expireOlderThan(System.currentTimeMillis()).cleanExpiredFiles(true).commit();
 
-    s1FilePath.remove(TableFileUtils.getUriPath(result.dataFiles()[0].path().toString()));
     Assert.assertEquals(s1FilePath, UnKeyedTableUtil.getAllContentFilePath(getArcticTable().asKeyedTable().baseTable()));
   }
 


### PR DESCRIPTION
## Why are the changes needed?
resolve #1175 

## Brief change log

  - *Remove the check of the file's status in the UnKeyedTableUtil#getAllContentFilePath method*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
