### PR TITLE
[ARCTIC-1025][FLINK] Fix data duplication even if there is a primary key table with upsert enabled

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/PartitionPrimaryKeyHelper.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/PartitionPrimaryKeyHelper.java
@@ -148,6 +148,9 @@ public class PartitionPrimaryKeyHelper implements Serializable {
   }
 
   public PrimaryKeyData key(RowData rowData) {
+    if (primaryKeyData == null) {
+      return null;
+    }
     primaryKeyData.primaryKey(rowDataWrapper.wrap(rowData));
     return primaryKeyData.copy();
   }

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/ReadShuffleRulePolicy.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/ReadShuffleRulePolicy.java
@@ -37,15 +37,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class ReadShuffleRulePolicy implements ShuffleRulePolicy<RowData, ShuffleKey> {
   private static final Logger LOG = LoggerFactory.getLogger(ReadShuffleRulePolicy.class);
 
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
 
   private final DistributionHashMode distributionHashMode;
 
-  public ReadShuffleRulePolicy(ShuffleHelper helper) {
+  public ReadShuffleRulePolicy(PartitionPrimaryKeyHelper helper) {
     this(helper, DistributionHashMode.autoSelect(helper.isPrimaryKeyExist(), helper.isPartitionKeyExist()));
   }
 
-  public ReadShuffleRulePolicy(ShuffleHelper helper,
+  public ReadShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                DistributionHashMode distributionHashMode) {
     this.helper = helper;
     this.distributionHashMode = distributionHashMode;
@@ -81,11 +81,11 @@ public class ReadShuffleRulePolicy implements ShuffleRulePolicy<RowData, Shuffle
    * Circular polling feed a streamRecord into a special factor node
    */
   static class RoundRobinPartitioner implements Partitioner<ShuffleKey> {
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private final DistributionHashMode distributionHashMode;
     private Random random = null;
 
-    RoundRobinPartitioner(DistributionHashMode distributionHashMode, ShuffleHelper helper) {
+    RoundRobinPartitioner(DistributionHashMode distributionHashMode, PartitionPrimaryKeyHelper helper) {
       this.distributionHashMode = distributionHashMode;
       this.helper = helper;
       if (!distributionHashMode.isSupportPartition() && !distributionHashMode.isSupportPrimaryKey()) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicy.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicy.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, ShuffleKey> {
   private static final Logger LOG = LoggerFactory.getLogger(RoundRobinShuffleRulePolicy.class);
 
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
 
   private final int downStreamOperatorParallelism;
 
@@ -64,14 +64,14 @@ public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, S
     this(null, downStreamOperatorParallelism, fileSplit);
   }
 
-  public RoundRobinShuffleRulePolicy(ShuffleHelper helper,
+  public RoundRobinShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                      int downStreamOperatorParallelism,
                                      int fileSplit) {
     this(helper, downStreamOperatorParallelism, fileSplit,
         DistributionHashMode.autoSelect(helper.isPrimaryKeyExist(), helper.isPartitionKeyExist()));
   }
 
-  public RoundRobinShuffleRulePolicy(ShuffleHelper helper,
+  public RoundRobinShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                      int downStreamOperatorParallelism,
                                      int fileSplit, DistributionHashMode distributionHashMode) {
     this.helper = helper;
@@ -176,11 +176,11 @@ public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, S
   static class RoundRobinPartitioner implements Partitioner<ShuffleKey> {
     private final int downStreamOperatorParallelism;
     private final int factor;
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private final DistributionHashMode distributionHashMode;
 
     RoundRobinPartitioner(int downStreamOperatorParallelism, int factor,
-                          DistributionHashMode distributionHashMode, ShuffleHelper helper) {
+                          DistributionHashMode distributionHashMode, PartitionPrimaryKeyHelper helper) {
       this.downStreamOperatorParallelism = downStreamOperatorParallelism;
       this.factor = factor;
       this.distributionHashMode = distributionHashMode;

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -20,7 +20,7 @@ package com.netease.arctic.flink.util;
 
 import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.write.ArcticLogWriter;
@@ -145,7 +145,7 @@ public class ArcticUtils {
                                                      @Nullable String topic,
                                                      TableSchema tableSchema,
                                                      String arcticEmitMode,
-                                                     ShuffleHelper helper,
+                                                     PartitionPrimaryKeyHelper helper,
                                                      ArcticTableLoader tableLoader,
                                                      Duration watermarkWriteGap) {
     if (!arcticWALWriterEnable(properties, arcticEmitMode)) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -79,7 +79,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    */
   private transient ArcticTable table;
   /**
-   * Track whether there is update_before before update_after or not neglecting primary key.
+   * Track whether there is update_before before update_after or not neglecting primary key if upsert enabled.
    */
   private transient boolean hasUpdateBefore = false;
 
@@ -219,7 +219,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   /**
    * If upsert is enabled, turn update_after to insert if there isn't update_after followed by update_before.
-   * It may lead to some unnecessary delete data if there are some data interspersed with other primary key data.
+   * But it may lead to some unnecessary delete data if there are some data interspersed with other primary key data.
    * e.g. K1-UB, K2-UB, K1-UA, K2-UB
    */
   private void processMultiUpdateAfter(RowData row) {

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -19,6 +19,8 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.data.DataTreeNode;
+import com.netease.arctic.data.PrimaryKeyData;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.shuffle.ShuffleKey;
 import com.netease.arctic.flink.shuffle.ShuffleRulePolicy;
 import com.netease.arctic.flink.table.ArcticTableLoader;
@@ -45,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -65,6 +68,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private final ArcticTableLoader tableLoader;
   private final boolean upsert;
   private final boolean submitEmptySnapshot;
+  private final PartitionPrimaryKeyHelper primaryKeyHelper;
 
   private transient org.apache.iceberg.io.TaskWriter<RowData> writer;
   private transient int subTaskId;
@@ -79,9 +83,9 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    */
   private transient ArcticTable table;
   /**
-   * Track whether there is update_before before update_after or not neglecting primary key if upsert enabled.
+   * Track whether there is update_before before update_after or not if upsert enabled.
    */
-  private transient boolean hasUpdateBefore = false;
+  private Set<PrimaryKeyData> hasUpdateBeforeKeys = new HashSet<>();
 
   public ArcticFileWriter(
       ShuffleRulePolicy<RowData, ShuffleKey> shuffleRule,
@@ -89,7 +93,8 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
       int minFileSplitCount,
       ArcticTableLoader tableLoader,
       boolean upsert,
-      boolean submitEmptySnapshot) {
+      boolean submitEmptySnapshot,
+      PartitionPrimaryKeyHelper primaryKeyHelper) {
     this.shuffleRule = shuffleRule;
     this.taskWriterFactory = taskWriterFactory;
     this.minFileSplitCount = minFileSplitCount;
@@ -98,6 +103,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     this.submitEmptySnapshot = submitEmptySnapshot;
     LOG.info("ArcticFileWriter is created with minFileSplitCount: {}, upsert: {}, submitEmptySnapshot: {}",
         minFileSplitCount, upsert, submitEmptySnapshot);
+    this.primaryKeyHelper = primaryKeyHelper;
   }
 
   @Override
@@ -110,6 +116,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     initTaskWriterFactory(mask);
 
     this.writer = table.io().doAs(taskWriterFactory::create);
+    primaryKeyHelper.open();
   }
 
   @Override
@@ -123,7 +130,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
                 new ListStateDescriptor<>(
                     subTaskId + "-task-file-writer-state",
                     LongSerializer.INSTANCE));
-    
+
     if (context.isRestored()) {
       // get last success ckp num from state when failover continuously
       checkpointId = checkpointState.get().iterator().next();
@@ -139,7 +146,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     checkpointState.clear();
     checkpointState.add(context.getCheckpointId());
   }
-  
+
   private void initTaskWriterFactory(long mask) {
     if (taskWriterFactory instanceof ArcticRowDataTaskWriterFactory) {
       ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setMask(mask);
@@ -218,19 +225,19 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   }
 
   /**
-   * If upsert is enabled, turn update_after to insert if there isn't update_after followed by update_before.
-   * But it may lead to some unnecessary delete data if there are some data interspersed with other primary key data.
-   * e.g. K1-UB, K2-UB, K1-UA, K2-UB
+   * Turn update_after to insert if there isn't update_after followed by update_before.
    */
   private void processMultiUpdateAfter(RowData row) {
-    if (!upsert) {
-      return;
-    }
+    PrimaryKeyData key = primaryKeyHelper.key(row);
 
-    if (!hasUpdateBefore && RowKind.UPDATE_AFTER.equals(row.getRowKind())) {
+    if (RowKind.UPDATE_AFTER.equals(row.getRowKind()) && !hasUpdateBeforeKeys.contains(key)) {
       row.setRowKind(RowKind.INSERT);
     }
-    hasUpdateBefore = RowKind.UPDATE_BEFORE.equals(row.getRowKind());
+    if (RowKind.UPDATE_BEFORE.equals(row.getRowKind())) {
+      hasUpdateBeforeKeys.add(key);
+    } else {
+      hasUpdateBeforeKeys.remove(key);
+    }
   }
 
   @Override
@@ -257,7 +264,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    *
    * @param writeResult the WriteResult to emit
    * @return true if the WriteResult should be emitted, or the WriteResult isn't empty,
-   *         false only if the WriteResult is empty and the submitEmptySnapshot is false.
+   * false only if the WriteResult is empty and the submitEmptySnapshot is false.
    */
   private boolean shouldEmit(WriteResult writeResult) {
     return submitEmptySnapshot || (writeResult != null &&

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -78,6 +78,10 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    * if Arctic's table is KERBEROS enabled. It will cause ugi relevant exception when deploy to yarn cluster.
    */
   private transient ArcticTable table;
+  /**
+   * Track whether there is update_before before update_after or not neglecting primary key.
+   */
+  private transient boolean hasUpdateBefore = false;
 
   public ArcticFileWriter(
       ShuffleRulePolicy<RowData, ShuffleKey> shuffleRule,
@@ -201,7 +205,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
       if (writer == null) {
         this.writer = taskWriterFactory.create();
       }
-
+      processMultiUpdateAfter(row);
       if (upsert && RowKind.INSERT.equals(row.getRowKind())) {
         row.setRowKind(RowKind.DELETE);
         writer.write(row);
@@ -211,6 +215,22 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
       writer.write(row);
       return null;
     });
+  }
+
+  /**
+   * If upsert is enabled, turn update_after to insert if there isn't update_after followed by update_before.
+   * It may lead to some unnecessary delete data if there are some data interspersed with other primary key data.
+   * e.g. K1-UB, K2-UB, K1-UA, K2-UB
+   */
+  private void processMultiUpdateAfter(RowData row) {
+    if (!upsert) {
+      return;
+    }
+
+    if (!hasUpdateBefore && RowKind.UPDATE_AFTER.equals(row.getRowKind())) {
+      row.setRowKind(RowKind.INSERT);
+    }
+    hasUpdateBefore = RowKind.UPDATE_BEFORE.equals(row.getRowKind());
   }
 
   @Override

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.write.hidden.HiddenLogWriter;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
@@ -52,7 +52,7 @@ public class AutomaticLogWriter extends ArcticLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper,
+      PartitionPrimaryKeyHelper helper,
       ArcticTableLoader tableLoader,
       Duration writeLogstoreWatermarkGap) {
     this.arcticLogWriter =

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -19,8 +19,8 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.metric.MetricsGenerator;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.shuffle.RoundRobinShuffleRulePolicy;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.shuffle.ShuffleKey;
 import com.netease.arctic.flink.shuffle.ShuffleRulePolicy;
 import com.netease.arctic.flink.table.ArcticTableLoader;
@@ -177,7 +177,7 @@ public class FlinkSink {
 
       DistributionHashMode distributionMode = getDistributionHashMode();
       LOG.info("take effect distribute mode: {}", distributionMode);
-      ShuffleHelper helper = ShuffleHelper.build(table, writeSchema, flinkSchemaRowType);
+      PartitionPrimaryKeyHelper helper = PartitionPrimaryKeyHelper.build(table, writeSchema, flinkSchemaRowType);
 
       ShuffleRulePolicy<RowData, ShuffleKey>
           shufflePolicy = buildShuffleRulePolicy(helper, writeOperatorParallelism, distributionMode, overwrite, table);
@@ -196,7 +196,7 @@ public class FlinkSink {
       final Duration watermarkWriteGap = config.get(AUTO_EMIT_LOGSTORE_WATERMARK_GAP);
 
       ArcticFileWriter fileWriter = createFileWriter(table, shufflePolicy, overwrite, flinkSchemaRowType,
-          arcticEmitMode, tableLoader);
+          arcticEmitMode, tableLoader, writeSchema);
 
       ArcticLogWriter logWriter = ArcticUtils.buildArcticLogWriter(table.properties(),
           producerConfig, topic, flinkSchema, arcticEmitMode, helper, tableLoader, watermarkWriteGap);
@@ -256,7 +256,7 @@ public class FlinkSink {
 
     @Nullable
     public static ShuffleRulePolicy<RowData, ShuffleKey> buildShuffleRulePolicy(
-        ShuffleHelper helper,
+        PartitionPrimaryKeyHelper helper,
         int writeOperatorParallelism,
         DistributionHashMode distributionHashMode,
         boolean overwrite,
@@ -298,8 +298,10 @@ public class FlinkSink {
                                                   boolean overwrite,
                                                   RowType flinkSchema,
                                                   ArcticTableLoader tableLoader) {
+    Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(FlinkSchemaUtil.toSchema(flinkSchema)),
+        arcticTable.schema());
     return createFileWriter(arcticTable, shufflePolicy, overwrite, flinkSchema, ARCTIC_EMIT_FILE,
-        tableLoader);
+        tableLoader, writeSchema);
   }
 
   public static ArcticFileWriter createFileWriter(ArcticTable arcticTable,
@@ -307,7 +309,8 @@ public class FlinkSink {
                                                   boolean overwrite,
                                                   RowType flinkSchema,
                                                   String emitMode,
-                                                  ArcticTableLoader tableLoader) {
+                                                  ArcticTableLoader tableLoader,
+                                                  Schema writeSchema) {
     if (!ArcticUtils.arcticFileWriterEnable(emitMode)) {
       return null;
     }
@@ -331,7 +334,8 @@ public class FlinkSink {
         minFileSplitCount,
         tableLoader,
         upsert,
-        submitEmptySnapshot);
+        submitEmptySnapshot,
+        PartitionPrimaryKeyHelper.build(arcticTable, writeSchema, flinkSchema));
   }
 
   private static TaskWriterFactory<RowData> createTaskWriterFactory(ArcticTable arcticTable,

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -20,7 +20,7 @@ package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.data.ChangeAction;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.write.ArcticLogWriter;
 import com.netease.arctic.log.FormatVersion;
 import com.netease.arctic.log.LogData;
@@ -65,7 +65,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
   private final Schema schema;
   private final Properties producerConfig;
   private final String topic;
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
   protected final LogMsgFactory<RowData> factory;
   protected LogMsgFactory.Producer<RowData> producer;
 
@@ -90,7 +90,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     this.schema = schema;
     this.producerConfig = checkNotNull(producerConfig);
     this.topic = checkNotNull(topic);

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/ArcticLogPartitioner.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/ArcticLogPartitioner.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.flink.table.data.RowData;
@@ -37,9 +37,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class ArcticLogPartitioner<T> implements Serializable {
   private static final long serialVersionUID = 9184708069203854226L;
   private final AtomicInteger counter = new AtomicInteger(0);
-  private ShuffleHelper helper;
+  private PartitionPrimaryKeyHelper helper;
 
-  public ArcticLogPartitioner(ShuffleHelper shuffleHelper) {
+  public ArcticLogPartitioner(PartitionPrimaryKeyHelper shuffleHelper) {
     this.helper = shuffleHelper;
   }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
 import org.apache.flink.api.common.functions.AggregateFunction;
@@ -83,7 +83,7 @@ public class GlobalFlipCommitter {
     private final LogMsgFactory<RowData> factory;
     private final Properties producerConfig;
     private final String topic;
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private transient LogMsgFactory.Producer<RowData> producer;
 
     public FlipCommitFunction(
@@ -93,7 +93,7 @@ public class GlobalFlipCommitter {
         LogMsgFactory<RowData> factory,
         Properties producerConfig,
         String topic,
-        ShuffleHelper helper) {
+        PartitionPrimaryKeyHelper helper) {
       this.numberOfTasks = numberOfTasks;
       this.factory = checkNotNull(factory);
       this.logDataJsonSerialization = new LogDataJsonSerialization<>(

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
@@ -19,7 +19,7 @@
 package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
@@ -42,7 +42,7 @@ public class HiddenLogWriter extends AbstractHiddenLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
   }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
 import org.apache.flink.configuration.Configuration;
@@ -38,7 +38,7 @@ public interface LogMsgFactory<T> extends Serializable {
       Properties producerConfig,
       String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
-      ShuffleHelper helper);
+      PartitionPrimaryKeyHelper helper);
 
   Consumer<T> createConsumer();
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden.kafka;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.write.hidden.ArcticLogPartitioner;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
 import com.netease.arctic.log.LogDataJsonSerialization;
@@ -38,7 +38,7 @@ public class HiddenKafkaFactory<T> implements LogMsgFactory<T> {
       Properties producerConfig,
       String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     checkNotNull(topic);
     return new HiddenKafkaProducer<>(
         producerConfig,

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/pulsar/HiddenPulsarFactory.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/pulsar/HiddenPulsarFactory.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden.pulsar;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.write.hidden.ArcticLogPartitioner;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
 import com.netease.arctic.log.LogDataJsonSerialization;
@@ -43,7 +43,7 @@ public class HiddenPulsarFactory<T> implements LogMsgFactory<T> {
       Properties producerConfig,
       String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     checkNotNull(topic);
     SinkConfiguration conf = toSinkConf(producerConfig);
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicyTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicyTest.java
@@ -34,7 +34,7 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPrimaryKeyPartitionedTable() throws Exception {
-    ShuffleHelper helper = ShuffleHelper.build(testKeyedTable, testKeyedTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper = PartitionPrimaryKeyHelper.build(testKeyedTable, testKeyedTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();
@@ -65,8 +65,8 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPrimaryKeyTableWithoutPartition() throws Exception {
-    ShuffleHelper helper =
-        ShuffleHelper.build(testKeyedNoPartitionTable, testKeyedNoPartitionTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper =
+        PartitionPrimaryKeyHelper.build(testKeyedNoPartitionTable, testKeyedNoPartitionTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();
@@ -102,8 +102,8 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPartitionedTableWithoutPrimaryKey() throws Exception {
-    ShuffleHelper helper =
-        ShuffleHelper.build(testPartitionTable, testPartitionTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper =
+        PartitionPrimaryKeyHelper.build(testPartitionTable, testPartitionTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -441,11 +441,13 @@ public class TestKeyed extends FlinkTestBase {
   @Test
   public void testFileUpsert() throws IOException {
     Assume.assumeFalse(kafkaLegacyEnable);
+    Assume.assumeFalse(LOG_STORE_STORAGE_TYPE_PULSAR.equals(logType));
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.DELETE, 1000015, "b", LocalDateTime.parse("2022-06-17T10:08:11.0")});
     data.add(new Object[]{RowKind.DELETE, 1000011, "c", LocalDateTime.parse("2022-06-18T10:10:11.0")});
     data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
@@ -477,6 +479,8 @@ public class TestKeyed extends FlinkTestBase {
     expected.add(new Object[]{RowKind.DELETE, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     Assert.assertEquals(DataUtil.toRowSet(expected),
@@ -488,6 +492,7 @@ public class TestKeyed extends FlinkTestBase {
   @Test
   public void testFileUpsertWithSamePrimaryKey() throws Exception {
     Assume.assumeFalse(kafkaLegacyEnable);
+    Assume.assumeFalse(LOG_STORE_STORAGE_TYPE_PULSAR.equals(logType));
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000004, "b", LocalDateTime.parse("2022-06-17T10:10:11.0")});

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -439,7 +439,7 @@ public class TestKeyed extends FlinkTestBase {
   }
 
   @Test
-  public void testFileUpsert() throws IOException {
+  public void testFileUpsert() {
     Assume.assumeFalse(kafkaLegacyEnable);
     Assume.assumeFalse(LOG_STORE_STORAGE_TYPE_PULSAR.equals(logType));
     List<Object[]> data = new LinkedList<>();
@@ -502,7 +502,7 @@ public class TestKeyed extends FlinkTestBase {
   }
 
   @Test
-  public void testFileCDC() throws IOException {
+  public void testFileCDC() {
     Assume.assumeFalse(kafkaLegacyEnable);
     Assume.assumeFalse(LOG_STORE_STORAGE_TYPE_PULSAR.equals(logType));
     List<Object[]> data = new LinkedList<>();

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
@@ -21,7 +21,7 @@ package com.netease.arctic.flink.write;
 import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
@@ -301,7 +301,7 @@ public class AutomaticLogWriterTest extends FlinkTestBase {
             new HiddenKafkaFactory<>(),
             LogRecordV1.fieldGetterFactory,
             jobId,
-            ShuffleHelper.EMPTY,
+            PartitionPrimaryKeyHelper.EMPTY,
             tableLoader,
             writeLogstoreWatermarkGap);
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/HiddenLogOperatorsTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/hidden/HiddenLogOperatorsTest.java
@@ -22,7 +22,7 @@ import com.netease.arctic.flink.read.hidden.pulsar.LogPulsarSourceTest;
 import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.read.source.log.pulsar.LogPulsarSource;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.flink.util.TestGlobalAggregateManager;
 import com.netease.arctic.flink.util.TestUtil;
@@ -575,7 +575,7 @@ public class HiddenLogOperatorsTest {
             logMsgFactory,
             LogRecordV1.fieldGetterFactory,
             jobId,
-            ShuffleHelper.EMPTY
+            PartitionPrimaryKeyHelper.EMPTY
         );
 
     OneInputStreamOperatorInternTest<RowData, RowData> harness =

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/PartitionPrimaryKeyHelper.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/PartitionPrimaryKeyHelper.java
@@ -36,7 +36,7 @@ import static org.apache.iceberg.IcebergSchemaUtil.projectPartition;
 /**
  * This helper operates to one arctic table and the data of the table.
  */
-public class ShuffleHelper implements Serializable {
+public class PartitionPrimaryKeyHelper implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private boolean primaryKeyExist = false;
@@ -46,9 +46,9 @@ public class ShuffleHelper implements Serializable {
   private Types.StructType struct;
   private transient RowDataWrapper rowDataWrapper;
 
-  public static ShuffleHelper EMPTY = new ShuffleHelper();
+  public static PartitionPrimaryKeyHelper EMPTY = new PartitionPrimaryKeyHelper();
 
-  public static ShuffleHelper build(ArcticTable table, Schema schema, RowType rowType) {
+  public static PartitionPrimaryKeyHelper build(ArcticTable table, Schema schema, RowType rowType) {
     PartitionKey partitionKey = null;
 
     if (table.spec() != null && !CollectionUtil.isNullOrEmpty(table.spec().fields())) {
@@ -57,12 +57,12 @@ public class ShuffleHelper implements Serializable {
     schema = addFieldsNotInArctic(schema, rowType);
 
     if (table.isUnkeyedTable()) {
-      return new ShuffleHelper(rowType, schema.asStruct(), partitionKey);
+      return new PartitionPrimaryKeyHelper(rowType, schema.asStruct(), partitionKey);
     }
 
     KeyedTable keyedTable = table.asKeyedTable();
     PrimaryKeyData primaryKeyData = new PrimaryKeyData(keyedTable.primaryKeySpec(), schema);
-    return new ShuffleHelper(keyedTable.primaryKeySpec().primaryKeyExisted(),
+    return new PartitionPrimaryKeyHelper(keyedTable.primaryKeySpec().primaryKeyExisted(),
         primaryKeyData, partitionKey, rowType, schema.asStruct());
   }
 
@@ -101,21 +101,25 @@ public class ShuffleHelper implements Serializable {
     }
   }
 
-  public ShuffleHelper() {
+  public PartitionPrimaryKeyHelper() {
   }
 
-  public ShuffleHelper(RowType rowType, Types.StructType structType,
-                       PartitionKey partitionKey) {
+  public PartitionPrimaryKeyHelper(RowType rowType, Types.StructType structType,
+                                   PartitionKey partitionKey) {
     this(false, null, partitionKey, rowType, structType);
   }
 
-  public ShuffleHelper(boolean primaryKeyExist, PrimaryKeyData primaryKeyData,
-                       PartitionKey partitionKey, RowType rowType, Types.StructType structType) {
+  public PartitionPrimaryKeyHelper(boolean primaryKeyExist, PrimaryKeyData primaryKeyData,
+                                   PartitionKey partitionKey, RowType rowType, Types.StructType structType) {
     this(primaryKeyExist, primaryKeyData, null, partitionKey, rowType, structType);
   }
 
-  public ShuffleHelper(boolean primaryKeyExist, PrimaryKeyData primaryKeyData, RowDataWrapper rowDataWrapper,
-                       PartitionKey partitionKey, RowType rowType, Types.StructType structType) {
+  public PartitionPrimaryKeyHelper(boolean primaryKeyExist,
+                                   PrimaryKeyData primaryKeyData,
+                                   RowDataWrapper rowDataWrapper,
+                                   PartitionKey partitionKey,
+                                   RowType rowType,
+                                   Types.StructType structType) {
     this.primaryKeyExist = primaryKeyExist;
     this.primaryKeyData = primaryKeyData;
     this.rowDataWrapper = rowDataWrapper;
@@ -141,5 +145,13 @@ public class ShuffleHelper implements Serializable {
   public int hashKeyValue(RowData rowData) {
     primaryKeyData.primaryKey(rowDataWrapper.wrap(rowData));
     return primaryKeyData.hashCode();
+  }
+
+  public PrimaryKeyData key(RowData rowData) {
+    if (primaryKeyData == null) {
+      return null;
+    }
+    primaryKeyData.primaryKey(rowDataWrapper.wrap(rowData));
+    return primaryKeyData.copy();
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ReadShuffleRulePolicy.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/ReadShuffleRulePolicy.java
@@ -37,15 +37,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class ReadShuffleRulePolicy implements ShuffleRulePolicy<RowData, ShuffleKey> {
   private static final Logger LOG = LoggerFactory.getLogger(ReadShuffleRulePolicy.class);
 
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
 
   private final DistributionHashMode distributionHashMode;
 
-  public ReadShuffleRulePolicy(ShuffleHelper helper) {
+  public ReadShuffleRulePolicy(PartitionPrimaryKeyHelper helper) {
     this(helper, DistributionHashMode.autoSelect(helper.isPrimaryKeyExist(), helper.isPartitionKeyExist()));
   }
 
-  public ReadShuffleRulePolicy(ShuffleHelper helper,
+  public ReadShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                DistributionHashMode distributionHashMode) {
     this.helper = helper;
     this.distributionHashMode = distributionHashMode;
@@ -81,11 +81,11 @@ public class ReadShuffleRulePolicy implements ShuffleRulePolicy<RowData, Shuffle
    * Circular polling feed a streamRecord into a special factor node
    */
   static class RoundRobinPartitioner implements Partitioner<ShuffleKey> {
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private final DistributionHashMode distributionHashMode;
     private Random random = null;
 
-    RoundRobinPartitioner(DistributionHashMode distributionHashMode, ShuffleHelper helper) {
+    RoundRobinPartitioner(DistributionHashMode distributionHashMode, PartitionPrimaryKeyHelper helper) {
       this.distributionHashMode = distributionHashMode;
       this.helper = helper;
       if (!distributionHashMode.isSupportPartition() && !distributionHashMode.isSupportPrimaryKey()) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicy.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicy.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, ShuffleKey> {
   private static final Logger LOG = LoggerFactory.getLogger(RoundRobinShuffleRulePolicy.class);
 
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
 
   private final int downStreamOperatorParallelism;
 
@@ -64,14 +64,14 @@ public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, S
     this(null, downStreamOperatorParallelism, fileSplit);
   }
 
-  public RoundRobinShuffleRulePolicy(ShuffleHelper helper,
+  public RoundRobinShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                      int downStreamOperatorParallelism,
                                      int fileSplit) {
     this(helper, downStreamOperatorParallelism, fileSplit,
         DistributionHashMode.autoSelect(helper.isPrimaryKeyExist(), helper.isPartitionKeyExist()));
   }
 
-  public RoundRobinShuffleRulePolicy(ShuffleHelper helper,
+  public RoundRobinShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                      int downStreamOperatorParallelism,
                                      int fileSplit, DistributionHashMode distributionHashMode) {
     this.helper = helper;
@@ -176,11 +176,11 @@ public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, S
   static class RoundRobinPartitioner implements Partitioner<ShuffleKey> {
     private final int downStreamOperatorParallelism;
     private final int factor;
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private final DistributionHashMode distributionHashMode;
 
     RoundRobinPartitioner(int downStreamOperatorParallelism, int factor,
-                          DistributionHashMode distributionHashMode, ShuffleHelper helper) {
+                          DistributionHashMode distributionHashMode, PartitionPrimaryKeyHelper helper) {
       this.downStreamOperatorParallelism = downStreamOperatorParallelism;
       this.factor = factor;
       this.distributionHashMode = distributionHashMode;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -20,7 +20,7 @@ package com.netease.arctic.flink.util;
 
 import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.write.ArcticLogWriter;
@@ -144,7 +144,7 @@ public class ArcticUtils {
                                                      @Nullable String topic,
                                                      TableSchema tableSchema,
                                                      String arcticEmitMode,
-                                                     ShuffleHelper helper,
+                                                     PartitionPrimaryKeyHelper helper,
                                                      ArcticTableLoader tableLoader,
                                                      Duration watermarkWriteGap) {
     if (!arcticWALWriterEnable(properties, arcticEmitMode)) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -78,6 +78,10 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    * if Arctic's table is KERBEROS enabled. It will cause ugi relevant exception when deploy to yarn cluster.
    */
   private transient ArcticTable table;
+  /**
+   * Track whether there is update_before before update_after or not neglecting primary key if upsert enabled.
+   */
+  private transient boolean hasUpdateBefore = false;
 
   public ArcticFileWriter(
       ShuffleRulePolicy<RowData, ShuffleKey> shuffleRule,
@@ -202,7 +206,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
       if (writer == null) {
         this.writer = taskWriterFactory.create();
       }
-
+      processMultiUpdateAfter(row);
       if (upsert && RowKind.INSERT.equals(row.getRowKind())) {
         row.setRowKind(RowKind.DELETE);
         writer.write(row);
@@ -212,6 +216,22 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
       writer.write(row);
       return null;
     });
+  }
+
+  /**
+   * If upsert is enabled, turn update_after to insert if there isn't update_after followed by update_before.
+   * But it may lead to some unnecessary delete data if there are some data interspersed with other primary key data.
+   * e.g. K1-UB, K2-UB, K1-UA, K2-UB
+   */
+  private void processMultiUpdateAfter(RowData row) {
+    if (!upsert) {
+      return;
+    }
+
+    if (!hasUpdateBefore && RowKind.UPDATE_AFTER.equals(row.getRowKind())) {
+      row.setRowKind(RowKind.INSERT);
+    }
+    hasUpdateBefore = RowKind.UPDATE_BEFORE.equals(row.getRowKind());
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.write.hidden.HiddenLogWriter;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
@@ -52,7 +52,7 @@ public class AutomaticLogWriter extends ArcticLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper,
+      PartitionPrimaryKeyHelper helper,
       ArcticTableLoader tableLoader,
       Duration writeLogstoreWatermarkGap) {
     this.arcticLogWriter =

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -19,8 +19,8 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.flink.metric.MetricsGenerator;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.shuffle.RoundRobinShuffleRulePolicy;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
 import com.netease.arctic.flink.shuffle.ShuffleKey;
 import com.netease.arctic.flink.shuffle.ShuffleRulePolicy;
 import com.netease.arctic.flink.table.ArcticTableLoader;
@@ -177,7 +177,7 @@ public class FlinkSink {
 
       DistributionHashMode distributionMode = getDistributionHashMode();
       LOG.info("take effect distribute mode: {}", distributionMode);
-      ShuffleHelper helper = ShuffleHelper.build(table, writeSchema, flinkSchemaRowType);
+      PartitionPrimaryKeyHelper helper = PartitionPrimaryKeyHelper.build(table, writeSchema, flinkSchemaRowType);
 
       ShuffleRulePolicy<RowData, ShuffleKey>
           shufflePolicy = buildShuffleRulePolicy(helper, writeOperatorParallelism, distributionMode, overwrite, table);
@@ -196,7 +196,7 @@ public class FlinkSink {
       final Duration watermarkWriteGap = config.get(AUTO_EMIT_LOGSTORE_WATERMARK_GAP);
 
       ArcticFileWriter fileWriter = createFileWriter(table, shufflePolicy, overwrite, flinkSchemaRowType,
-          arcticEmitMode, tableLoader);
+          arcticEmitMode, tableLoader, writeSchema);
 
       ArcticLogWriter logWriter = ArcticUtils.buildArcticLogWriter(table.properties(),
           producerConfig, topic, flinkSchema, arcticEmitMode, helper, tableLoader, watermarkWriteGap);
@@ -258,7 +258,7 @@ public class FlinkSink {
 
     @Nullable
     public static ShuffleRulePolicy<RowData, ShuffleKey> buildShuffleRulePolicy(
-        ShuffleHelper helper,
+        PartitionPrimaryKeyHelper helper,
         int writeOperatorParallelism,
         DistributionHashMode distributionHashMode,
         boolean overwrite,
@@ -303,8 +303,10 @@ public class FlinkSink {
       boolean overwrite,
       RowType flinkSchema,
       ArcticTableLoader tableLoader) {
+    Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(FlinkSchemaUtil.toSchema(flinkSchema)),
+        arcticTable.schema());
     return createFileWriter(arcticTable, shufflePolicy, overwrite, flinkSchema, ARCTIC_EMIT_FILE,
-        tableLoader);
+        tableLoader, writeSchema);
   }
 
   public static ArcticFileWriter createFileWriter(
@@ -313,7 +315,8 @@ public class FlinkSink {
       boolean overwrite,
       RowType flinkSchema,
       String emitMode,
-      ArcticTableLoader tableLoader) {
+      ArcticTableLoader tableLoader,
+      Schema writeSchema) {
     if (!ArcticUtils.arcticFileWriterEnable(emitMode)) {
       return null;
     }
@@ -339,7 +342,8 @@ public class FlinkSink {
         minFileSplitCount,
         tableLoader,
         upsert,
-        submitEmptySnapshot);
+        submitEmptySnapshot,
+        PartitionPrimaryKeyHelper.build(arcticTable, writeSchema, flinkSchema));
   }
 
   private static TaskWriterFactory<RowData> createTaskWriterFactory(

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -20,7 +20,7 @@ package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.data.ChangeAction;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.write.ArcticLogWriter;
 import com.netease.arctic.log.FormatVersion;
 import com.netease.arctic.log.LogData;
@@ -63,7 +63,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
   private final Schema schema;
   private final Properties producerConfig;
   private final String topic;
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
   protected final LogMsgFactory<RowData> factory;
   protected LogMsgFactory.Producer<RowData> producer;
 
@@ -88,7 +88,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     this.schema = schema;
     this.producerConfig = checkNotNull(producerConfig);
     this.topic = checkNotNull(topic);

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/ArcticLogPartitioner.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/ArcticLogPartitioner.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.table.data.RowData;
@@ -36,9 +36,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class ArcticLogPartitioner<T> implements Serializable {
   private static final long serialVersionUID = 9184708069203854226L;
   private final AtomicInteger counter = new AtomicInteger(0);
-  private ShuffleHelper helper;
+  private PartitionPrimaryKeyHelper helper;
 
-  public ArcticLogPartitioner(ShuffleHelper shuffleHelper) {
+  public ArcticLogPartitioner(PartitionPrimaryKeyHelper shuffleHelper) {
     this.helper = shuffleHelper;
   }
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
 import org.apache.flink.api.common.functions.AggregateFunction;
@@ -83,7 +83,7 @@ public class GlobalFlipCommitter {
     private final LogMsgFactory<RowData> factory;
     private final Properties producerConfig;
     private final String topic;
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private transient LogMsgFactory.Producer<RowData> producer;
 
     public FlipCommitFunction(
@@ -93,7 +93,7 @@ public class GlobalFlipCommitter {
         LogMsgFactory<RowData> factory,
         Properties producerConfig,
         String topic,
-        ShuffleHelper helper) {
+        PartitionPrimaryKeyHelper helper) {
       this.numberOfTasks = numberOfTasks;
       this.factory = checkNotNull(factory);
       this.logDataJsonSerialization = new LogDataJsonSerialization<>(

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
@@ -19,7 +19,7 @@
 package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
@@ -42,7 +42,7 @@ public class HiddenLogWriter extends AbstractHiddenLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
   }
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
 import org.apache.flink.configuration.Configuration;
@@ -36,7 +36,7 @@ public interface LogMsgFactory<T> extends Serializable {
       Properties producerConfig,
       String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
-      ShuffleHelper helper);
+      PartitionPrimaryKeyHelper helper);
 
   Consumer<T> createConsumer();
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden.kafka;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.write.hidden.ArcticLogPartitioner;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
 import com.netease.arctic.log.LogDataJsonSerialization;
@@ -38,7 +38,7 @@ public class HiddenKafkaFactory<T> implements LogMsgFactory<T> {
       Properties producerConfig,
       String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     checkNotNull(topic);
     return new HiddenKafkaProducer<>(
         producerConfig,

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicyTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicyTest.java
@@ -34,7 +34,7 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPrimaryKeyPartitionedTable() throws Exception {
-    ShuffleHelper helper = ShuffleHelper.build(testKeyedTable, testKeyedTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper = PartitionPrimaryKeyHelper.build(testKeyedTable, testKeyedTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();
@@ -65,8 +65,8 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPrimaryKeyTableWithoutPartition() throws Exception {
-    ShuffleHelper helper =
-        ShuffleHelper.build(testKeyedNoPartitionTable, testKeyedNoPartitionTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper =
+        PartitionPrimaryKeyHelper.build(testKeyedNoPartitionTable, testKeyedNoPartitionTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();
@@ -102,8 +102,8 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPartitionedTableWithoutPrimaryKey() throws Exception {
-    ShuffleHelper helper =
-        ShuffleHelper.build(testPartitionTable, testPartitionTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper =
+        PartitionPrimaryKeyHelper.build(testPartitionTable, testPartitionTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -67,7 +67,6 @@ import static com.netease.arctic.table.TableProperties.LOCATION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
-import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_PULSAR;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
 import static org.apache.flink.table.api.Expressions.$;
 
@@ -284,11 +283,11 @@ public class TestKeyed extends FlinkTestBase {
     List<ApiExpression> rows = DataUtil.toRows(data);
 
     Table input = getTableEnv().fromValues(DataTypes.ROW(
-        DataTypes.FIELD("id", DataTypes.INT()),
-        DataTypes.FIELD("name", DataTypes.STRING()),
-        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
-      ),
-      rows
+            DataTypes.FIELD("id", DataTypes.INT()),
+            DataTypes.FIELD("name", DataTypes.STRING()),
+            DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+        ),
+        rows
     );
     getTableEnv().createTemporaryView("input", input);
 
@@ -296,20 +295,20 @@ public class TestKeyed extends FlinkTestBase {
 
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
-      "'arctic.emit.mode'='log'" +
-      ", 'log.version'='v1'" +
-      ") */" +
-      " select * from input");
+        "'arctic.emit.mode'='log'" +
+        ", 'log.version'='v1'" +
+        ") */" +
+        " select * from input");
 
     TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
-      "/*+ OPTIONS(" +
-      "'arctic.read.mode'='log'" +
-      ", 'scan.startup.mode'='earliest'" +
-      ")*/" +
-      "");
+        "/*+ OPTIONS(" +
+        "'arctic.read.mode'='log'" +
+        ", 'scan.startup.mode'='earliest'" +
+        ")*/" +
+        "");
 
     Set<Row> actual = new HashSet<>();
     try (CloseableIterator<Row> iterator = result.collect()) {
@@ -418,7 +417,7 @@ public class TestKeyed extends FlinkTestBase {
   }
 
   @Test
-  public void testFileUpsert() throws IOException {
+  public void testFileUpsert() {
     Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
@@ -428,6 +427,11 @@ public class TestKeyed extends FlinkTestBase {
     data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "d", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
         InternalTypeInfo.ofFields(
             DataTypes.INT().getLogicalType(),
@@ -461,6 +465,69 @@ public class TestKeyed extends FlinkTestBase {
     expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "d", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    Assert.assertEquals(DataUtil.toRowSet(expected),
+        new HashSet<>(sql("select * from arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+            "'streaming'='false'" +
+            ") */")));
+  }
+
+  @Test
+  public void testFileCDC() {
+    Assume.assumeFalse(kafkaLegacyEnable);
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.DELETE, 1000015, "b", LocalDateTime.parse("2022-06-17T10:08:11.0")});
+    data.add(new Object[]{RowKind.DELETE, 1000011, "c", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "d", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
+        InternalTypeInfo.ofFields(
+            DataTypes.INT().getLogicalType(),
+            DataTypes.VARCHAR(100).getLogicalType(),
+            DataTypes.TIMESTAMP().getLogicalType()
+        ));
+
+    Table input = getTableEnv().fromDataStream(source, $("id"), $("name"), $("op_time"));
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+        ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE +
+        "/*+ OPTIONS(" +
+        "'arctic.emit.mode'='file'" +
+        ")*/" + " select * from input");
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "d", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     Assert.assertEquals(DataUtil.toRowSet(expected),
         new HashSet<>(sql("select * from arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
             "'streaming'='false'" +
@@ -596,11 +663,11 @@ public class TestKeyed extends FlinkTestBase {
     List<ApiExpression> rows = DataUtil.toRows(data);
 
     Table input = getTableEnv().fromValues(DataTypes.ROW(
-        DataTypes.FIELD("id", DataTypes.INT()),
-        DataTypes.FIELD("name", DataTypes.STRING()),
-        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
-      ),
-      rows
+            DataTypes.FIELD("id", DataTypes.INT()),
+            DataTypes.FIELD("name", DataTypes.STRING()),
+            DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+        ),
+        rows
     );
     getTableEnv().createTemporaryView("input", input);
 
@@ -608,21 +675,21 @@ public class TestKeyed extends FlinkTestBase {
 
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
-      ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+        ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
-      "'arctic.emit.mode'='log'" +
-      ", 'log.version'='v1'" +
-      ") */" +
-      " select * from input");
+        "'arctic.emit.mode'='log'" +
+        ", 'log.version'='v1'" +
+        ") */" +
+        " select * from input");
 
     TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
-      "/*+ OPTIONS(" +
-      "'arctic.read.mode'='log'" +
-      ", 'scan.startup.mode'='earliest'" +
-      ")*/" +
-      "");
+        "/*+ OPTIONS(" +
+        "'arctic.read.mode'='log'" +
+        ", 'scan.startup.mode'='earliest'" +
+        ")*/" +
+        "");
     Set<Row> actual = new HashSet<>();
     try (CloseableIterator<Row> iterator = result.collect()) {
       for (Object[] datum : data) {

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -67,6 +67,7 @@ import static com.netease.arctic.table.TableProperties.LOCATION;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_ADDRESS;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_MESSAGE_TOPIC;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_KAFKA;
+import static com.netease.arctic.table.TableProperties.LOG_STORE_STORAGE_TYPE_PULSAR;
 import static com.netease.arctic.table.TableProperties.LOG_STORE_TYPE;
 import static org.apache.flink.table.api.Expressions.$;
 
@@ -425,6 +426,7 @@ public class TestKeyed extends FlinkTestBase {
     data.add(new Object[]{RowKind.DELETE, 1000011, "c", LocalDateTime.parse("2022-06-18T10:10:11.0")});
     data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
         InternalTypeInfo.ofFields(
@@ -455,6 +457,8 @@ public class TestKeyed extends FlinkTestBase {
     expected.add(new Object[]{RowKind.DELETE, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     Assert.assertEquals(DataUtil.toRowSet(expected),

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
@@ -22,7 +22,7 @@ import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.kafka.testutils.KafkaTestBase;
 import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
@@ -301,7 +301,7 @@ public class AutomaticLogWriterTest extends FlinkTestBase {
             new HiddenKafkaFactory<>(),
             LogRecordV1.fieldGetterFactory,
             jobId,
-            ShuffleHelper.EMPTY,
+            PartitionPrimaryKeyHelper.EMPTY,
             tableLoader,
             writeLogstoreWatermarkGap);
 

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
@@ -20,7 +20,7 @@ package com.netease.arctic.flink.write.hidden.kafka;
 
 import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.flink.util.TestGlobalAggregateManager;
 import com.netease.arctic.flink.write.hidden.HiddenLogWriter;
@@ -458,7 +458,7 @@ public class HiddenLogOperatorsTest {
             new HiddenKafkaFactory<>(),
             LogRecordV1.fieldGetterFactory,
             jobId,
-            ShuffleHelper.EMPTY
+            PartitionPrimaryKeyHelper.EMPTY
         );
 
     OneInputStreamOperatorInternTest<RowData, RowData> harness =

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/PartitionPrimaryKeyHelper.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/PartitionPrimaryKeyHelper.java
@@ -36,7 +36,7 @@ import static org.apache.iceberg.IcebergSchemaUtil.projectPartition;
 /**
  * This helper operates to one arctic table and the data of the table.
  */
-public class ShuffleHelper implements Serializable {
+public class PartitionPrimaryKeyHelper implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private boolean primaryKeyExist = false;
@@ -46,9 +46,9 @@ public class ShuffleHelper implements Serializable {
   private Types.StructType struct;
   private transient RowDataWrapper rowDataWrapper;
 
-  public static ShuffleHelper EMPTY = new ShuffleHelper();
+  public static PartitionPrimaryKeyHelper EMPTY = new PartitionPrimaryKeyHelper();
 
-  public static ShuffleHelper build(ArcticTable table, Schema schema, RowType rowType) {
+  public static PartitionPrimaryKeyHelper build(ArcticTable table, Schema schema, RowType rowType) {
     PartitionKey partitionKey = null;
 
     if (table.spec() != null && !CollectionUtil.isNullOrEmpty(table.spec().fields())) {
@@ -57,12 +57,12 @@ public class ShuffleHelper implements Serializable {
     schema = addFieldsNotInArctic(schema, rowType);
 
     if (table.isUnkeyedTable()) {
-      return new ShuffleHelper(rowType, schema.asStruct(), partitionKey);
+      return new PartitionPrimaryKeyHelper(rowType, schema.asStruct(), partitionKey);
     }
 
     KeyedTable keyedTable = table.asKeyedTable();
     PrimaryKeyData primaryKeyData = new PrimaryKeyData(keyedTable.primaryKeySpec(), schema);
-    return new ShuffleHelper(keyedTable.primaryKeySpec().primaryKeyExisted(),
+    return new PartitionPrimaryKeyHelper(keyedTable.primaryKeySpec().primaryKeyExisted(),
         primaryKeyData, partitionKey, rowType, schema.asStruct());
   }
 
@@ -101,21 +101,25 @@ public class ShuffleHelper implements Serializable {
     }
   }
 
-  public ShuffleHelper() {
+  public PartitionPrimaryKeyHelper() {
   }
 
-  public ShuffleHelper(RowType rowType, Types.StructType structType,
-                       PartitionKey partitionKey) {
+  public PartitionPrimaryKeyHelper(RowType rowType, Types.StructType structType,
+                                   PartitionKey partitionKey) {
     this(false, null, partitionKey, rowType, structType);
   }
 
-  public ShuffleHelper(boolean primaryKeyExist, PrimaryKeyData primaryKeyData,
-                       PartitionKey partitionKey, RowType rowType, Types.StructType structType) {
+  public PartitionPrimaryKeyHelper(boolean primaryKeyExist, PrimaryKeyData primaryKeyData,
+                                   PartitionKey partitionKey, RowType rowType, Types.StructType structType) {
     this(primaryKeyExist, primaryKeyData, null, partitionKey, rowType, structType);
   }
 
-  public ShuffleHelper(boolean primaryKeyExist, PrimaryKeyData primaryKeyData, RowDataWrapper rowDataWrapper,
-                       PartitionKey partitionKey, RowType rowType, Types.StructType structType) {
+  public PartitionPrimaryKeyHelper(boolean primaryKeyExist,
+                                   PrimaryKeyData primaryKeyData,
+                                   RowDataWrapper rowDataWrapper,
+                                   PartitionKey partitionKey,
+                                   RowType rowType,
+                                   Types.StructType structType) {
     this.primaryKeyExist = primaryKeyExist;
     this.primaryKeyData = primaryKeyData;
     this.rowDataWrapper = rowDataWrapper;
@@ -141,5 +145,13 @@ public class ShuffleHelper implements Serializable {
   public int hashKeyValue(RowData rowData) {
     primaryKeyData.primaryKey(rowDataWrapper.wrap(rowData));
     return primaryKeyData.hashCode();
+  }
+
+  public PrimaryKeyData key(RowData rowData) {
+    if (primaryKeyData == null) {
+      return null;
+    }
+    primaryKeyData.primaryKey(rowDataWrapper.wrap(rowData));
+    return primaryKeyData.copy();
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/ReadShuffleRulePolicy.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/ReadShuffleRulePolicy.java
@@ -37,15 +37,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class ReadShuffleRulePolicy implements ShuffleRulePolicy<RowData, ShuffleKey> {
   private static final Logger LOG = LoggerFactory.getLogger(ReadShuffleRulePolicy.class);
 
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
 
   private final DistributionHashMode distributionHashMode;
 
-  public ReadShuffleRulePolicy(ShuffleHelper helper) {
+  public ReadShuffleRulePolicy(PartitionPrimaryKeyHelper helper) {
     this(helper, DistributionHashMode.autoSelect(helper.isPrimaryKeyExist(), helper.isPartitionKeyExist()));
   }
 
-  public ReadShuffleRulePolicy(ShuffleHelper helper,
+  public ReadShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                DistributionHashMode distributionHashMode) {
     this.helper = helper;
     this.distributionHashMode = distributionHashMode;
@@ -81,11 +81,11 @@ public class ReadShuffleRulePolicy implements ShuffleRulePolicy<RowData, Shuffle
    * Circular polling feed a streamRecord into a special factor node
    */
   static class RoundRobinPartitioner implements Partitioner<ShuffleKey> {
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private final DistributionHashMode distributionHashMode;
     private Random random = null;
 
-    RoundRobinPartitioner(DistributionHashMode distributionHashMode, ShuffleHelper helper) {
+    RoundRobinPartitioner(DistributionHashMode distributionHashMode, PartitionPrimaryKeyHelper helper) {
       this.distributionHashMode = distributionHashMode;
       this.helper = helper;
       if (!distributionHashMode.isSupportPartition() && !distributionHashMode.isSupportPrimaryKey()) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicy.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicy.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, ShuffleKey> {
   private static final Logger LOG = LoggerFactory.getLogger(RoundRobinShuffleRulePolicy.class);
 
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
 
   private final int downStreamOperatorParallelism;
 
@@ -64,14 +64,14 @@ public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, S
     this(null, downStreamOperatorParallelism, fileSplit);
   }
 
-  public RoundRobinShuffleRulePolicy(ShuffleHelper helper,
+  public RoundRobinShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                      int downStreamOperatorParallelism,
                                      int fileSplit) {
     this(helper, downStreamOperatorParallelism, fileSplit,
         DistributionHashMode.autoSelect(helper.isPrimaryKeyExist(), helper.isPartitionKeyExist()));
   }
 
-  public RoundRobinShuffleRulePolicy(ShuffleHelper helper,
+  public RoundRobinShuffleRulePolicy(PartitionPrimaryKeyHelper helper,
                                      int downStreamOperatorParallelism,
                                      int fileSplit, DistributionHashMode distributionHashMode) {
     this.helper = helper;
@@ -176,11 +176,11 @@ public class RoundRobinShuffleRulePolicy implements ShuffleRulePolicy<RowData, S
   static class RoundRobinPartitioner implements Partitioner<ShuffleKey> {
     private final int downStreamOperatorParallelism;
     private final int factor;
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private final DistributionHashMode distributionHashMode;
 
     RoundRobinPartitioner(int downStreamOperatorParallelism, int factor,
-                          DistributionHashMode distributionHashMode, ShuffleHelper helper) {
+                          DistributionHashMode distributionHashMode, PartitionPrimaryKeyHelper helper) {
       this.downStreamOperatorParallelism = downStreamOperatorParallelism;
       this.factor = factor;
       this.distributionHashMode = distributionHashMode;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/util/ArcticUtils.java
@@ -20,7 +20,7 @@ package com.netease.arctic.flink.util;
 
 import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.table.descriptors.ArcticValidator;
 import com.netease.arctic.flink.write.ArcticLogWriter;
@@ -144,7 +144,7 @@ public class ArcticUtils {
                                                      @Nullable String topic,
                                                      TableSchema tableSchema,
                                                      String arcticEmitMode,
-                                                     ShuffleHelper helper,
+                                                     PartitionPrimaryKeyHelper helper,
                                                      ArcticTableLoader tableLoader,
                                                      Duration watermarkWriteGap) {
     if (!arcticWALWriterEnable(properties, arcticEmitMode)) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -19,6 +19,8 @@
 package com.netease.arctic.flink.write;
 
 import com.netease.arctic.data.DataTreeNode;
+import com.netease.arctic.data.PrimaryKeyData;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.shuffle.ShuffleKey;
 import com.netease.arctic.flink.shuffle.ShuffleRulePolicy;
 import com.netease.arctic.flink.table.ArcticTableLoader;
@@ -45,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -65,6 +68,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private final ArcticTableLoader tableLoader;
   private final boolean upsert;
   private final boolean submitEmptySnapshot;
+  private final PartitionPrimaryKeyHelper primaryKeyHelper;
 
   private transient org.apache.iceberg.io.TaskWriter<RowData> writer;
   private transient int subTaskId;
@@ -79,9 +83,9 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    */
   private transient ArcticTable table;
   /**
-   * Track whether there is update_before before update_after or not neglecting primary key if upsert enabled.
+   * Track whether there is update_before before update_after or not if upsert enabled.
    */
-  private transient boolean hasUpdateBefore = false;
+  private Set<PrimaryKeyData> hasUpdateBeforeKeys = new HashSet<>();
 
   public ArcticFileWriter(
       ShuffleRulePolicy<RowData, ShuffleKey> shuffleRule,
@@ -89,7 +93,8 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
       int minFileSplitCount,
       ArcticTableLoader tableLoader,
       boolean upsert,
-      boolean submitEmptySnapshot) {
+      boolean submitEmptySnapshot,
+      PartitionPrimaryKeyHelper primaryKeyHelper) {
     this.shuffleRule = shuffleRule;
     this.taskWriterFactory = taskWriterFactory;
     this.minFileSplitCount = minFileSplitCount;
@@ -98,6 +103,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     this.submitEmptySnapshot = submitEmptySnapshot;
     LOG.info("ArcticFileWriter is created with minFileSplitCount: {}, upsert: {}, submitEmptySnapshot: {}",
         minFileSplitCount, upsert, submitEmptySnapshot);
+    this.primaryKeyHelper = primaryKeyHelper;
   }
 
   @Override
@@ -110,6 +116,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     initTaskWriterFactory(mask);
 
     this.writer = table.io().doAs(taskWriterFactory::create);
+    primaryKeyHelper.open();
   }
 
   @Override
@@ -218,19 +225,19 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   }
 
   /**
-   * If upsert is enabled, turn update_after to insert if there isn't update_after followed by update_before.
-   * But it may lead to some unnecessary delete data if there are some data interspersed with other primary key data.
-   * e.g. K1-UB, K2-UB, K1-UA, K2-UB
+   * Turn update_after to insert if there isn't update_after followed by update_before.
    */
   private void processMultiUpdateAfter(RowData row) {
-    if (!upsert) {
-      return;
-    }
+    PrimaryKeyData key = primaryKeyHelper.key(row);
 
-    if (!hasUpdateBefore && RowKind.UPDATE_AFTER.equals(row.getRowKind())) {
+    if (RowKind.UPDATE_AFTER.equals(row.getRowKind()) && !hasUpdateBeforeKeys.contains(key)) {
       row.setRowKind(RowKind.INSERT);
     }
-    hasUpdateBefore = RowKind.UPDATE_BEFORE.equals(row.getRowKind());
+    if (RowKind.UPDATE_BEFORE.equals(row.getRowKind())) {
+      hasUpdateBeforeKeys.add(key);
+    } else {
+      hasUpdateBeforeKeys.remove(key);
+    }
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/AutomaticLogWriter.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.write.hidden.HiddenLogWriter;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
@@ -52,7 +52,7 @@ public class AutomaticLogWriter extends ArcticLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper,
+      PartitionPrimaryKeyHelper helper,
       ArcticTableLoader tableLoader,
       Duration writeLogstoreWatermarkGap) {
     this.arcticLogWriter =

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/AbstractHiddenLogWriter.java
@@ -20,7 +20,7 @@ package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.data.ChangeAction;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.write.ArcticLogWriter;
 import com.netease.arctic.log.FormatVersion;
 import com.netease.arctic.log.LogData;
@@ -63,7 +63,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
   private final Schema schema;
   private final Properties producerConfig;
   private final String topic;
-  private final ShuffleHelper helper;
+  private final PartitionPrimaryKeyHelper helper;
   protected final LogMsgFactory<RowData> factory;
   protected LogMsgFactory.Producer<RowData> producer;
 
@@ -88,7 +88,7 @@ public abstract class AbstractHiddenLogWriter extends ArcticLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     this.schema = schema;
     this.producerConfig = checkNotNull(producerConfig);
     this.topic = checkNotNull(topic);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/ArcticLogPartitioner.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/ArcticLogPartitioner.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.table.data.RowData;
@@ -36,9 +36,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class ArcticLogPartitioner<T> implements Serializable {
   private static final long serialVersionUID = 9184708069203854226L;
   private final AtomicInteger counter = new AtomicInteger(0);
-  private ShuffleHelper helper;
+  private PartitionPrimaryKeyHelper helper;
 
-  public ArcticLogPartitioner(ShuffleHelper shuffleHelper) {
+  public ArcticLogPartitioner(PartitionPrimaryKeyHelper shuffleHelper) {
     this.helper = shuffleHelper;
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/GlobalFlipCommitter.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
 import org.apache.flink.api.common.functions.AggregateFunction;
@@ -83,7 +83,7 @@ public class GlobalFlipCommitter {
     private final LogMsgFactory<RowData> factory;
     private final Properties producerConfig;
     private final String topic;
-    private final ShuffleHelper helper;
+    private final PartitionPrimaryKeyHelper helper;
     private transient LogMsgFactory.Producer<RowData> producer;
 
     public FlipCommitFunction(
@@ -93,7 +93,7 @@ public class GlobalFlipCommitter {
         LogMsgFactory<RowData> factory,
         Properties producerConfig,
         String topic,
-        ShuffleHelper helper) {
+        PartitionPrimaryKeyHelper helper) {
       this.numberOfTasks = numberOfTasks;
       this.factory = checkNotNull(factory);
       this.logDataJsonSerialization = new LogDataJsonSerialization<>(

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/HiddenLogWriter.java
@@ -19,7 +19,7 @@
 package com.netease.arctic.flink.write.hidden;
 
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
@@ -42,7 +42,7 @@ public class HiddenLogWriter extends AbstractHiddenLogWriter {
       LogMsgFactory<RowData> factory,
       LogData.FieldGetterFactory<RowData> fieldGetterFactory,
       byte[] jobId,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     super(schema, producerConfig, topic, factory, fieldGetterFactory, jobId, helper);
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/LogMsgFactory.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.log.LogData;
 import com.netease.arctic.log.LogDataJsonSerialization;
 import org.apache.flink.configuration.Configuration;
@@ -36,7 +36,7 @@ public interface LogMsgFactory<T> extends Serializable {
       Properties producerConfig,
       String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
-      ShuffleHelper helper);
+      PartitionPrimaryKeyHelper helper);
 
   Consumer<T> createConsumer();
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaFactory.java
@@ -18,7 +18,7 @@
 
 package com.netease.arctic.flink.write.hidden.kafka;
 
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.write.hidden.ArcticLogPartitioner;
 import com.netease.arctic.flink.write.hidden.LogMsgFactory;
 import com.netease.arctic.log.LogDataJsonSerialization;
@@ -38,7 +38,7 @@ public class HiddenKafkaFactory<T> implements LogMsgFactory<T> {
       Properties producerConfig,
       String topic,
       LogDataJsonSerialization<T> logDataJsonSerialization,
-      ShuffleHelper helper) {
+      PartitionPrimaryKeyHelper helper) {
     checkNotNull(topic);
     return new HiddenKafkaProducer<>(
         producerConfig,

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicyTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/shuffle/RoundRobinShuffleRulePolicyTest.java
@@ -34,7 +34,7 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPrimaryKeyPartitionedTable() throws Exception {
-    ShuffleHelper helper = ShuffleHelper.build(testKeyedTable, testKeyedTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper = PartitionPrimaryKeyHelper.build(testKeyedTable, testKeyedTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();
@@ -65,8 +65,8 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPrimaryKeyTableWithoutPartition() throws Exception {
-    ShuffleHelper helper =
-        ShuffleHelper.build(testKeyedNoPartitionTable, testKeyedNoPartitionTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper =
+        PartitionPrimaryKeyHelper.build(testKeyedNoPartitionTable, testKeyedNoPartitionTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();
@@ -102,8 +102,8 @@ public class RoundRobinShuffleRulePolicyTest extends FlinkTestBase {
 
   @Test
   public void testPartitionedTableWithoutPrimaryKey() throws Exception {
-    ShuffleHelper helper =
-        ShuffleHelper.build(testPartitionTable, testPartitionTable.schema(), FLINK_ROW_TYPE);
+    PartitionPrimaryKeyHelper helper =
+        PartitionPrimaryKeyHelper.build(testPartitionTable, testPartitionTable.schema(), FLINK_ROW_TYPE);
     RoundRobinShuffleRulePolicy policy =
         new RoundRobinShuffleRulePolicy(helper, 5, 2);
     Map<Integer, Set<DataTreeNode>> subTaskTreeNodes = policy.getSubtaskTreeNodes();

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -425,6 +425,7 @@ public class TestKeyed extends FlinkTestBase {
     data.add(new Object[]{RowKind.DELETE, 1000011, "c", LocalDateTime.parse("2022-06-18T10:10:11.0")});
     data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
         InternalTypeInfo.ofFields(
@@ -455,6 +456,8 @@ public class TestKeyed extends FlinkTestBase {
     expected.add(new Object[]{RowKind.DELETE, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     Assert.assertEquals(DataUtil.toRowSet(expected),

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/table/TestKeyed.java
@@ -283,11 +283,11 @@ public class TestKeyed extends FlinkTestBase {
     List<ApiExpression> rows = DataUtil.toRows(data);
 
     Table input = getTableEnv().fromValues(DataTypes.ROW(
-        DataTypes.FIELD("id", DataTypes.INT()),
-        DataTypes.FIELD("name", DataTypes.STRING()),
-        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
-      ),
-      rows
+            DataTypes.FIELD("id", DataTypes.INT()),
+            DataTypes.FIELD("name", DataTypes.STRING()),
+            DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+        ),
+        rows
     );
     getTableEnv().createTemporaryView("input", input);
 
@@ -295,20 +295,20 @@ public class TestKeyed extends FlinkTestBase {
 
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
-      "'arctic.emit.mode'='log'" +
-      ", 'log.version'='v1'" +
-      ") */" +
-      " select * from input");
+        "'arctic.emit.mode'='log'" +
+        ", 'log.version'='v1'" +
+        ") */" +
+        " select * from input");
 
     TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
-      "/*+ OPTIONS(" +
-      "'arctic.read.mode'='log'" +
-      ", 'scan.startup.mode'='earliest'" +
-      ")*/" +
-      "");
+        "/*+ OPTIONS(" +
+        "'arctic.read.mode'='log'" +
+        ", 'scan.startup.mode'='earliest'" +
+        ")*/" +
+        "");
 
     Set<Row> actual = new HashSet<>();
     try (CloseableIterator<Row> iterator = result.collect()) {
@@ -417,7 +417,7 @@ public class TestKeyed extends FlinkTestBase {
   }
 
   @Test
-  public void testFileUpsert() throws IOException {
+  public void testFileUpsert() {
     Assume.assumeFalse(kafkaLegacyEnable);
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
@@ -427,6 +427,11 @@ public class TestKeyed extends FlinkTestBase {
     data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     data.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "d", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
         InternalTypeInfo.ofFields(
             DataTypes.INT().getLogicalType(),
@@ -460,6 +465,69 @@ public class TestKeyed extends FlinkTestBase {
     expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
     expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "d", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    Assert.assertEquals(DataUtil.toRowSet(expected),
+        new HashSet<>(sql("select * from arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
+            "'streaming'='false'" +
+            ") */")));
+  }
+
+  @Test
+  public void testFileCDC() {
+    Assume.assumeFalse(kafkaLegacyEnable);
+    List<Object[]> data = new LinkedList<>();
+    data.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.DELETE, 1000015, "b", LocalDateTime.parse("2022-06-17T10:08:11.0")});
+    data.add(new Object[]{RowKind.DELETE, 1000011, "c", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "d", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_BEFORE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    DataStream<RowData> source = getEnv().fromCollection(DataUtil.toRowData(data),
+        InternalTypeInfo.ofFields(
+            DataTypes.INT().getLogicalType(),
+            DataTypes.VARCHAR(100).getLogicalType(),
+            DataTypes.TIMESTAMP().getLogicalType()
+        ));
+
+    Table input = getTableEnv().fromDataStream(source, $("id"), $("name"), $("op_time"));
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+        ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+
+    sql("insert into arcticCatalog." + db + "." + TABLE +
+        "/*+ OPTIONS(" +
+        "'arctic.emit.mode'='file'" +
+        ")*/" + " select * from input");
+
+    List<Object[]> expected = new LinkedList<>();
+    expected.add(new Object[]{RowKind.INSERT, 1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_BEFORE, 1000021, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.UPDATE_AFTER, 1000021, "d", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.DELETE, 1000015, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    expected.add(new Object[]{RowKind.INSERT, 1000021, "f", LocalDateTime.parse("2022-06-17T10:10:11.0")});
     Assert.assertEquals(DataUtil.toRowSet(expected),
         new HashSet<>(sql("select * from arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
             "'streaming'='false'" +
@@ -595,11 +663,11 @@ public class TestKeyed extends FlinkTestBase {
     List<ApiExpression> rows = DataUtil.toRows(data);
 
     Table input = getTableEnv().fromValues(DataTypes.ROW(
-        DataTypes.FIELD("id", DataTypes.INT()),
-        DataTypes.FIELD("name", DataTypes.STRING()),
-        DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
-      ),
-      rows
+            DataTypes.FIELD("id", DataTypes.INT()),
+            DataTypes.FIELD("name", DataTypes.STRING()),
+            DataTypes.FIELD("op_time", DataTypes.TIMESTAMP())
+        ),
+        rows
     );
     getTableEnv().createTemporaryView("input", input);
 
@@ -607,21 +675,21 @@ public class TestKeyed extends FlinkTestBase {
 
     tableProperties.put(LOCATION, tableDir.getAbsolutePath() + "/" + TABLE);
     sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
-      " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
-      ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
+        " id INT, name STRING, op_time TIMESTAMP, PRIMARY KEY (id) NOT ENFORCED " +
+        ") PARTITIONED BY(op_time) WITH %s", toWithClause(tableProperties));
 
     sql("insert into arcticCatalog." + db + "." + TABLE + " /*+ OPTIONS(" +
-      "'arctic.emit.mode'='log'" +
-      ", 'log.version'='v1'" +
-      ") */" +
-      " select * from input");
+        "'arctic.emit.mode'='log'" +
+        ", 'log.version'='v1'" +
+        ") */" +
+        " select * from input");
 
     TableResult result = exec("select id, op_time from arcticCatalog." + db + "." + TABLE +
-      "/*+ OPTIONS(" +
-      "'arctic.read.mode'='log'" +
-      ", 'scan.startup.mode'='earliest'" +
-      ")*/" +
-      "");
+        "/*+ OPTIONS(" +
+        "'arctic.read.mode'='log'" +
+        ", 'scan.startup.mode'='earliest'" +
+        ")*/" +
+        "");
     Set<Row> actual = new HashSet<>();
     try (CloseableIterator<Row> iterator = result.collect()) {
       for (Object[] datum : data) {

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/AutomaticLogWriterTest.java
@@ -22,7 +22,7 @@ import com.netease.arctic.flink.FlinkTestBase;
 import com.netease.arctic.flink.kafka.testutils.KafkaTestBase;
 import com.netease.arctic.flink.metric.MetricsGenerator;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.table.ArcticTableLoader;
 import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.flink.util.DataUtil;
@@ -303,7 +303,7 @@ public class AutomaticLogWriterTest extends FlinkTestBase {
             new HiddenKafkaFactory<>(),
             LogRecordV1.fieldGetterFactory,
             jobId,
-            ShuffleHelper.EMPTY,
+            PartitionPrimaryKeyHelper.EMPTY,
             tableLoader,
             writeLogstoreWatermarkGap);
 

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/hidden/kafka/HiddenLogOperatorsTest.java
@@ -20,7 +20,7 @@ package com.netease.arctic.flink.write.hidden.kafka;
 
 import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
 import com.netease.arctic.flink.shuffle.LogRecordV1;
-import com.netease.arctic.flink.shuffle.ShuffleHelper;
+import com.netease.arctic.flink.shuffle.PartitionPrimaryKeyHelper;
 import com.netease.arctic.flink.util.OneInputStreamOperatorInternTest;
 import com.netease.arctic.flink.util.TestGlobalAggregateManager;
 import com.netease.arctic.flink.write.hidden.HiddenLogWriter;
@@ -465,7 +465,7 @@ public class HiddenLogOperatorsTest {
             new HiddenKafkaFactory<>(),
             LogRecordV1.fieldGetterFactory,
             jobId,
-            ShuffleHelper.EMPTY
+            PartitionPrimaryKeyHelper.EMPTY
         );
 
     OneInputStreamOperatorInternTest<RowData, RowData> harness =


### PR DESCRIPTION
FIX #1025 

## Why are the changes needed?
To make sure only one primary key in key table with upsert enabled, it's necessary to delete data firstly when update_after not followed by update_before.

It may lead to some unnecessary delete data if there are some data interspersed with other primary key data. e.g. K1-UB, K2-UB, K1-UA, K2-UB

## Brief change log

  - *The flink 1.12 and 1.14, 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
