### PR TITLE
[ARCTIC-1201][AMS] Optimizing checker should check if table changed before scan files

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
@@ -459,6 +459,10 @@ public class TableOptimizeItem extends IJDBCService {
         tryUpdateOptimizeInfo(TableOptimizeRuntime.OptimizeStatus.Idle, Collections.emptyList(), null);
         return;
       }
+      if (!tableChanged(currentSnapshot)) {
+        tryUpdateOptimizeInfo(TableOptimizeRuntime.OptimizeStatus.Idle, Collections.emptyList(), null);
+        return;
+      }
       List<FileScanTask> fileScanTasks;
       TableScan tableScan = arcticTable.asUnkeyedTable().newScan();
       tableScan = tableScan.useSnapshot(currentSnapshot.snapshotId());
@@ -526,6 +530,10 @@ public class TableOptimizeItem extends IJDBCService {
               TableOptimizeRuntime.OptimizeStatus.Pending, optimizePlanResult.getOptimizeTasks(), OptimizeType.Major);
         } else {
           if (isKeyedTable()) {
+            if (!changeStoreChanged(changeCurrentSnapshot)) {
+              tryUpdateOptimizeInfo(TableOptimizeRuntime.OptimizeStatus.Idle, Collections.emptyList(), null);
+              return;
+            }
             MinorOptimizePlan minorPlan =
                 getMinorPlan(-1, System.currentTimeMillis(), baseFiles, baseCurrentSnapshot,
                     changeCurrentSnapshot, partitionOptimizedSequence, legacyPartitionMaxTransactionId);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1201 

## Brief change log

- check table changed before optimizing checker scan files, only for native iceberg table, keyed table's minor plan, because major and full plan have to be triggered by interval, it doesn't need table to be changed

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
