### PR TITLE
[Arctic-1203][Spark][Bugfix]: Support truncate transform in spark optimize write

### DIFF
--- a/spark/v3.1/spark/pom.xml
+++ b/spark/v3.1/spark/pom.xml
@@ -200,6 +200,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-api</artifactId>
+            <version>${iceberg.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.netease.arctic</groupId>
             <artifactId>arctic-ams-api</artifactId>
             <version>${project.version}</version>

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/ArcticSparkCatalogTestGroup.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/ArcticSparkCatalogTestGroup.java
@@ -60,6 +60,7 @@ import java.util.Map;
     TestKeyedTableDML.class,
     TestKeyedTableDMLInsertOverwriteDynamic.class,
     TestKeyedTableDMLInsertOverwriteStatic.class,
+    TestInsertOverwritePartitionTransform.class,
     TestUnKeyedTableDDL.class,
     TestMigrateNonHiveTable.class,
     TestOptimizeWrite.class,

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -63,6 +63,7 @@ import org.apache.iceberg.util.StructLikeMap;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.thrift.TException;
@@ -607,5 +608,19 @@ public class SparkTestContext extends ExternalResource {
 
   protected interface Action {
     void invoke();
+  }
+
+  public static Row recordToRow(Record record) {
+    Object[] values = new Object[record.size()];
+    for (int i = 0; i < values.length; i++) {
+      Object v = record.get(i);
+      if (v instanceof LocalDateTime) {
+        v = new Timestamp(((LocalDateTime) v).atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
+      } else if (v instanceof OffsetDateTime) {
+        v = new Timestamp(((OffsetDateTime) v).toInstant().toEpochMilli());
+      }
+      values[i] = v;
+    }
+    return RowFactory.create(values);
   }
 }

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestInsertOverwritePartitionTransform.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestInsertOverwritePartitionTransform.java
@@ -105,6 +105,7 @@ public class TestInsertOverwritePartitionTransform extends SparkTestBase {
     sql("use " + catalogNameArctic);
     sql("DROP TABLE IF EXISTS " + database + "." + table);
     sql("DROP TABLE IF EXISTS " + source);
+    sql("DROP DATABASE IF EXISTS " + database);
   }
 
   @Test

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestInsertOverwritePartitionTransform.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestInsertOverwritePartitionTransform.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.spark;
+
+import com.netease.arctic.spark.util.RecordGenerator;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.TableIdentifier;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RunWith(Parameterized.class)
+public class TestInsertOverwritePartitionTransform extends SparkTestBase {
+
+  private final String table = "tbl";
+  private final String database = "database";
+
+  private final String source = "_tmp_source";
+  private final TableIdentifier tableIdent = TableIdentifier.of(catalogNameArctic, database, table);
+
+  private List<GenericRecord> records;
+  private final String transform;
+  private final String createTableDDL = "CREATE TABLE " + database + "." + table + "( " +
+      "id int, \n" +
+      "data string, \n" +
+      "ts timestamp, \n" +
+      "ts_long long, \n" +
+      "PRIMARY KEY(id) \n" +
+      ") using arctic \n" +
+      "PARTITIONED BY ( {0} )";
+
+  @Parameterized.Parameters(name = "Transform = {0}")
+  public static List<String> parameters() {
+    return Lists.newArrayList(
+        "days(ts) ",
+        "date(ts) ",
+        "months(ts)",
+        "years(ts)",
+        "hours(ts) ",
+        "date_hour(ts)",
+        "bucket(8, id)",
+        "truncate(86400, ts_long)"
+    );
+  }
+
+  public TestInsertOverwritePartitionTransform(String transform) {
+    this.transform = transform;
+  }
+
+  @Before
+  public void before() {
+    sql("use " + catalogNameArctic);
+    sql("CREATE DATABASE IF NOT EXISTS " + database);
+    sql(createTableDDL, transform);
+
+    ArcticTable arcticTable = loadTable(tableIdent);
+    RecordGenerator recordGenerator = RecordGenerator
+        .buildFor(arcticTable.schema())
+        .withSequencePrimaryKey(arcticTable.asKeyedTable().primaryKeySpec())
+        .build();
+    records = Lists.newArrayList();
+    for (int i = 0; i < 100; i++) {
+      GenericRecord record = recordGenerator.newRecord();
+      records.add(record);
+    }
+    List<Row> datas = records.stream()
+        .map(SparkTestContext::recordToRow)
+        .collect(Collectors.toList());
+
+    Dataset<Row> dataset = spark.createDataFrame(datas, SparkSchemaUtil.convert(arcticTable.schema()));
+    dataset.registerTempTable(source);
+  }
+
+  @After
+  public void after() {
+    sql("use " + catalogNameArctic);
+    sql("DROP TABLE IF EXISTS " + database + "." + table);
+    sql("DROP TABLE IF EXISTS " + source);
+  }
+
+  @Test
+  public void testInsertOverwrite() {
+    sql("SELECT * FROM " + source);
+    sql("INSERT OVERWRITE " + database + "." + table + " SELECT * FROM  " + source);
+    rows = sql("SELECT * FROM " + database + "." + table);
+
+    Assert.assertEquals(records.size(), rows.size());
+  }
+
+  public List<GenericRecord> records(Schema schema, int count) {
+    List<GenericRecord> records = Lists.newArrayList();
+    List<Types.NestedField> columns = Lists.newArrayList(schema.columns());
+    for (int i = 0; i < count; i++) {
+      GenericRecord record = GenericRecord.create(schema);
+
+      records.add(record);
+    }
+    return records;
+  }
+}

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/util/RecordGenerator.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/util/RecordGenerator.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.spark.util;
+
+import com.google.common.collect.Maps;
+import com.netease.arctic.table.PrimaryKeySpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.RandomUtil;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RecordGenerator {
+
+  private final Schema schema;
+
+  private final ArrayList<Types.NestedField> columns;
+  private final Map<String, ValueGenerator> fieldGenerator = Maps.newHashMap();
+
+  public RecordGenerator(Schema schema, Map<String, ValueGenerator> fieldGenerator, long seed) {
+    this.schema = schema;
+    this.columns = Lists.newArrayList(schema.columns());
+    for (Types.NestedField f : columns) {
+      ValueGenerator generator = fieldGenerator.get(f.name());
+      if (generator == null) {
+        generator = new RandomValueGenerator(seed);
+      }
+      this.fieldGenerator.put(f.name(), generator);
+    }
+  }
+
+  public GenericRecord newRecord() {
+    GenericRecord record = GenericRecord.create(schema);
+    for (int i = 0; i < columns.size(); i++) {
+      Types.NestedField f = columns.get(i);
+      ValueGenerator generator = fieldGenerator.get(f.name());
+      record.set(i, generator.get(f.type()));
+    }
+    return record;
+  }
+
+  public static Builder buildFor(Schema schema) {
+    return new Builder(schema);
+  }
+
+  public static class Builder {
+    final Schema schema;
+    final Map<String, ValueGenerator> valueGeneratorMap = Maps.newHashMap();
+
+    protected Builder(Schema schema) {
+      this.schema = schema;
+    }
+
+    public Builder withSequencePrimaryKey(PrimaryKeySpec keySpec) {
+      for (String col : keySpec.fieldNames()) {
+        Types.NestedField f = schema.findField(col);
+        switch (f.type().typeId()) {
+          case LONG:
+          case INTEGER:
+            valueGeneratorMap.put(f.name(), new SequenceValueGenerator());
+        }
+      }
+      return this;
+    }
+
+    public RecordGenerator build() {
+      return new RecordGenerator(schema, valueGeneratorMap, 0);
+    }
+  }
+
+  public interface ValueGenerator {
+    Object get(Type type);
+  }
+
+  static class RandomValueGenerator implements ValueGenerator {
+    private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
+
+    private final Random random;
+
+    public RandomValueGenerator(long seed) {
+      this.random = new Random(seed);
+    }
+
+    @Override
+    public Object get(Type type) {
+      Object value = RandomUtil.generatePrimitive(type.asPrimitiveType(), random);
+    
+      switch (type.typeId()) {
+        case TIME:
+          return LocalTime.ofNanoOfDay((long) value * 1000);
+        case TIMESTAMP:
+          if (((Types.TimestampType) type).shouldAdjustToUTC()) {
+            return EPOCH.plus((long) value, ChronoUnit.MICROS);
+          } else {
+            return EPOCH.plus((long) value, ChronoUnit.MICROS).toLocalDateTime();
+          }
+      }
+      return value;
+    }
+  }
+
+  static class SequenceValueGenerator extends RandomValueGenerator {
+    AtomicLong value = new AtomicLong(0);
+
+    public SequenceValueGenerator() {
+      super(0);
+    }
+
+    @Override
+    public Object get(Type type) {
+
+      switch (type.typeId()) {
+        case LONG:
+          return value.incrementAndGet();
+        case INTEGER:
+          return (int) value.incrementAndGet();
+      }
+      return super.get(type);
+    }
+  }
+}


### PR DESCRIPTION
## Why are the changes needed?

fix #1203 to support truncate type transform when do optimize for spark insert overwrite.


## Brief change log

- Add truncate support when convert expression from `connector.expression` to `catalyst.expression` 
- Add a new unit test to cover all types of transforms

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no) 
