### PR TITLE
[ARCTIC-1208] Optimizing of native Iceberg table supports optimizing a part of partitions at a time

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractIcebergOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractIcebergOptimizePlan.java
@@ -54,16 +54,19 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractIcebergOptimizePlan extends AbstractOptimizePlan {
 
-  protected final long currentSnapshotId;
   protected List<FileScanTask> fileScanTasks;
   protected SequenceNumberFetcher sequenceNumberFetcher;
 
   public AbstractIcebergOptimizePlan(ArcticTable arcticTable, TableOptimizeRuntime tableOptimizeRuntime,
                                      List<FileScanTask> fileScanTasks,
                                      int queueId, long currentTime, long currentSnapshotId) {
-    super(arcticTable, tableOptimizeRuntime, queueId, currentTime);
+    super(arcticTable, tableOptimizeRuntime, queueId, currentTime, currentSnapshotId);
     this.fileScanTasks = fileScanTasks;
-    this.currentSnapshotId = currentSnapshotId;
+  }
+
+  @Override
+  protected boolean limitFileCnt() {
+    return true;
   }
 
   protected List<FileScanTask> filterRepeatFileScanTask(Collection<FileScanTask> fileScanTasks) {
@@ -176,14 +179,9 @@ public abstract class AbstractIcebergOptimizePlan extends AbstractOptimizePlan {
 
   protected SequenceNumberFetcher seqNumberFetcher() {
     if (null == sequenceNumberFetcher) {
-      sequenceNumberFetcher = new SequenceNumberFetcher(arcticTable.asUnkeyedTable(), currentSnapshotId);
+      sequenceNumberFetcher = new SequenceNumberFetcher(arcticTable.asUnkeyedTable(), getCurrentSnapshotId());
     }
     return sequenceNumberFetcher;
-  }
-
-  @Override
-  protected long getCurrentSnapshotId() {
-    return currentSnapshotId;
   }
 
   private long getTargetSize() {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractOptimizePlan.java
@@ -136,19 +136,19 @@ public abstract class AbstractOptimizePlan {
   }
 
   protected List<String> getPartitionsToOptimizeInOrder() {
-    List<PartitionWeight> partitionWeights = new ArrayList<>();
-    for (String partition : allPartitions) {
-      if (partitionNeedPlan(partition)) {
-        partitionWeights.add(new PartitionWeight(partition, getPartitionWeight(partition)));
-      }
-    }
-    if (partitionWeights.size() > 0) {
-      LOG.info("{} filter partitions to optimize, partition count {}", tableId(), partitionWeights.size());
+    List<String> partitionNeedOptimizedInOrder = allPartitions.stream()
+        .filter(this::partitionNeedPlan)
+        .map(partition -> new PartitionWeight(partition, getPartitionWeight(partition)))
+        .sorted()
+        .map(PartitionWeight::getPartition)
+        .collect(Collectors.toList());
+    if (partitionNeedOptimizedInOrder.size() > 0) {
+      LOG.info("{} filter partitions to optimize, partition count {}", tableId(),
+          partitionNeedOptimizedInOrder.size());
     } else {
       LOG.debug("{} filter partitions to optimize, partition count 0", tableId());
     }
-    Collections.sort(partitionWeights);
-    return partitionWeights.stream().map(PartitionWeight::getPartition).collect(Collectors.toList());
+    return partitionNeedOptimizedInOrder;
   }
 
   protected long getPartitionWeight(String partitionToPath) {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractOptimizePlan.java
@@ -81,9 +81,8 @@ public abstract class AbstractOptimizePlan {
     List<BasicOptimizeTask> tasks = collectTasks(getPartitionsToOptimizeInOrder());
 
     long endTime = System.nanoTime();
-    LOG.info("{} ==== {} plan tasks cost {} ns, {} ms", tableId(), getOptimizeType(), endTime - startTime,
-        (endTime - startTime) / 1_000_000);
-    LOG.info("{} {} plan get {} tasks", tableId(), getOptimizeType(), tasks.size());
+    LOG.info("{} ==== {} plan tasks get {} tasks, cost {} ns, {} ms", tableId(), getOptimizeType(), tasks.size(),
+        endTime - startTime, (endTime - startTime) / 1_000_000);
     return buildOptimizePlanResult(tasks);
   }
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BasicOptimizeCommit.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/BasicOptimizeCommit.java
@@ -88,8 +88,8 @@ public class BasicOptimizeCommit {
         LOG.info("{} get no tasks to commit", arcticTable.id());
         return true;
       }
-      LOG.info("{} get tasks to commit for partitions {}", arcticTable.id(),
-          optimizeTasksToCommit.keySet());
+      LOG.info("{} get tasks to commit with from snapshot id = {}, for partitions {} ", arcticTable.id(),
+          baseSnapshotId, optimizeTasksToCommit.keySet());
 
       // collect files
       PartitionSpec spec = arcticTable.spec();

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergFullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergFullOptimizePlan.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -45,7 +46,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class IcebergFullOptimizePlan extends AbstractIcebergOptimizePlan {
   private static final Logger LOG = LoggerFactory.getLogger(IcebergFullOptimizePlan.class);
 
-  protected final Map<String, List<FileScanTask>> partitionFileList = new LinkedHashMap<>();
+  private final Map<String, List<FileScanTask>> partitionFileList = new LinkedHashMap<>();
+  // cache partitionDeleteFileTotalSize
+  private final Map<String, Long> partitionDeleteFileTotalSize = new HashMap<>();
 
   public IcebergFullOptimizePlan(ArcticTable arcticTable, TableOptimizeRuntime tableOptimizeRuntime,
                                  List<FileScanTask> fileScanTasks,
@@ -59,7 +62,7 @@ public class IcebergFullOptimizePlan extends AbstractIcebergOptimizePlan {
     for (FileScanTask fileScanTask : fileScanTasks) {
       DataFile dataFile = fileScanTask.file();
       String partitionPath = arcticTable.spec().partitionToPath(dataFile.partition());
-      currentPartitions.add(partitionPath);
+      allPartitions.add(partitionPath);
       List<FileScanTask> fileScanTasks = partitionFileList.computeIfAbsent(partitionPath, p -> new ArrayList<>());
       fileScanTasks.add(fileScanTask);
       addCnt.getAndIncrement();
@@ -71,19 +74,10 @@ public class IcebergFullOptimizePlan extends AbstractIcebergOptimizePlan {
 
   @Override
   protected boolean partitionNeedPlan(String partitionToPath) {
-    List<FileScanTask> partitionFileScanTasks = partitionFileList.get(partitionToPath);
-    if (CollectionUtils.isEmpty(partitionFileScanTasks)) {
-      LOG.debug("{} ==== don't need {} optimize plan, skip partition {}, there are no data files",
-          tableId(), getOptimizeType(), partitionToPath);
+    long deleteFilesTotalSize = getPartitionDeleteFileTotalSize(partitionToPath);
+    if (deleteFilesTotalSize == 0) {
       return false;
     }
-
-    Set<DeleteFile> partitionDeleteFiles = new HashSet<>();
-    for (FileScanTask partitionFileScanTask : partitionFileScanTasks) {
-      partitionDeleteFiles.addAll(partitionFileScanTask.deletes());
-    }
-
-    double deleteFilesTotalSize = partitionDeleteFiles.stream().mapToLong(DeleteFile::fileSizeInBytes).sum();
 
     long targetSize = PropertyUtil.propertyAsLong(arcticTable.properties(),
         TableProperties.SELF_OPTIMIZING_TARGET_SIZE,
@@ -103,6 +97,33 @@ public class IcebergFullOptimizePlan extends AbstractIcebergOptimizePlan {
             "delete files totalSize is {}, target size is {}",
         tableId(), getOptimizeType(), partitionToPath, deleteFilesTotalSize, targetSize);
     return false;
+  }
+
+  private long getPartitionDeleteFileTotalSize(String partitionToPath) {
+    Long cached = partitionDeleteFileTotalSize.get(partitionToPath);
+    if (cached != null) {
+      return cached;
+    }
+    List<FileScanTask> partitionFileScanTasks = partitionFileList.get(partitionToPath);
+    if (CollectionUtils.isEmpty(partitionFileScanTasks)) {
+      LOG.debug("{} ==== don't need {} optimize plan, skip partition {}, there are no data files",
+          tableId(), getOptimizeType(), partitionToPath);
+      return 0;
+    }
+
+    Set<DeleteFile> partitionDeleteFiles = new HashSet<>();
+    for (FileScanTask partitionFileScanTask : partitionFileScanTasks) {
+      partitionDeleteFiles.addAll(partitionFileScanTask.deletes());
+    }
+
+    long deleteFileTotalSize = partitionDeleteFiles.stream().mapToLong(DeleteFile::fileSizeInBytes).sum();
+    partitionDeleteFileTotalSize.put(partitionToPath, deleteFileTotalSize);
+    return deleteFileTotalSize;
+  }
+
+  @Override
+  protected long getPartitionWeight(String partitionToPath) {
+    return getPartitionDeleteFileTotalSize(partitionToPath);
   }
 
   @Override

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergMinorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/IcebergMinorOptimizePlan.java
@@ -54,6 +54,8 @@ public class IcebergMinorOptimizePlan extends AbstractIcebergOptimizePlan {
   private final Map<String, Set<DeleteFile>> partitionDeleteFiles = new HashMap<>();
   // delete file path -> related data files
   private final Map<String, Set<FileScanTask>> deleteDataFileMap = new HashMap<>();
+  // cache partitionSmallFileCnt
+  private final Map<String, Integer> partitionSmallFileCnt = new HashMap<>();
 
   public IcebergMinorOptimizePlan(ArcticTable arcticTable, TableOptimizeRuntime tableOptimizeRuntime,
                                   List<FileScanTask> fileScanTasks,
@@ -67,7 +69,7 @@ public class IcebergMinorOptimizePlan extends AbstractIcebergOptimizePlan {
     for (FileScanTask fileScanTask : fileScanTasks) {
       StructLike partition = fileScanTask.file().partition();
       String partitionPath = arcticTable.asUnkeyedTable().spec().partitionToPath(partition);
-      currentPartitions.add(partitionPath);
+      allPartitions.add(partitionPath);
       // add DataFile info
       if (fileScanTask.file().fileSizeInBytes() <= smallFileSize) {
         // collect small data file info
@@ -101,29 +103,44 @@ public class IcebergMinorOptimizePlan extends AbstractIcebergOptimizePlan {
 
   @Override
   protected boolean partitionNeedPlan(String partitionToPath) {
-    List<FileScanTask> smallDataFileTask = partitionSmallDataFilesTask.getOrDefault(partitionToPath, new ArrayList<>());
+    int smallFileCount = getPartitionSmallFileCount(partitionToPath);
 
-    Set<DeleteFile> smallDeleteFile = partitionDeleteFiles.getOrDefault(partitionToPath, new HashSet<>()).stream()
-        .filter(deleteFile -> deleteFile.fileSizeInBytes() <= getSmallFileSize(arcticTable.properties()))
-        .collect(Collectors.toSet());
-    for (FileScanTask task : smallDataFileTask) {
-      smallDeleteFile.addAll(task.deletes());
-    }
-
-    long smallFileCountThreshold = CompatiblePropertyUtil.propertyAsInt(arcticTable.properties(),
+    int smallFileCountThreshold = CompatiblePropertyUtil.propertyAsInt(arcticTable.properties(),
         TableProperties.SELF_OPTIMIZING_MINOR_TRIGGER_FILE_CNT,
         TableProperties.SELF_OPTIMIZING_MINOR_TRIGGER_FILE_CNT_DEFAULT);
     // partition has greater than 12 small files to optimize(include data files and delete files)
-    long smallFileCount = smallDataFileTask.size() + smallDeleteFile.size();
     if (smallFileCount >= smallFileCountThreshold) {
-      LOG.debug("{} ==== need iceberg minor optimize plan, partition is {}, " +
-              "small file count is {}, small DataFile count is {}, small DeleteFile count is {}",
-          tableId(), partitionToPath, smallFileCount, smallDataFileTask.size(), smallDeleteFile.size());
+      LOG.info("{} ==== need iceberg minor optimize plan, partition is {}, small file count is {}, threshold is {}",
+          tableId(), partitionToPath, smallFileCount, smallFileCountThreshold);
       return true;
     }
 
     LOG.debug("{} ==== don't need {} optimize plan, skip partition {}", tableId(), getOptimizeType(), partitionToPath);
     return false;
+  }
+
+  @Override
+  protected long getPartitionWeight(String partitionToPath) {
+    return getPartitionSmallFileCount(partitionToPath);
+  }
+
+  private int getPartitionSmallFileCount(String partitionToPath) {
+    Integer cached = partitionSmallFileCnt.get(partitionToPath);
+    if (cached != null) {
+      return cached;
+    }
+    List<FileScanTask> smallDataFileTask = partitionSmallDataFilesTask.getOrDefault(partitionToPath, new ArrayList<>());
+
+    final long smallFileSize = getSmallFileSize(arcticTable.properties());
+    Set<DeleteFile> smallDeleteFile = partitionDeleteFiles.getOrDefault(partitionToPath, new HashSet<>()).stream()
+        .filter(deleteFile -> deleteFile.fileSizeInBytes() <= smallFileSize)
+        .collect(Collectors.toSet());
+    for (FileScanTask task : smallDataFileTask) {
+      smallDeleteFile.addAll(task.deletes());
+    }
+    int smallFileCount = smallDataFileTask.size() + smallDeleteFile.size();
+    partitionSmallFileCnt.put(partitionToPath, smallFileCount);
+    return smallFileCount;
   }
 
   @Override

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/OptimizingIntegrationTest.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/OptimizingIntegrationTest.java
@@ -56,6 +56,7 @@ public class OptimizingIntegrationTest {
   private static final TableIdentifier TB_9 = TableIdentifier.of(HIVE_CATALOG, DATABASE, "hive_table9");
   private static final TableIdentifier TB_10 = TableIdentifier.of(HIVE_CATALOG, DATABASE, "hive_table10");
   private static final TableIdentifier TB_11 = TableIdentifier.of(CATALOG, DATABASE, "test_table11");
+  private static final TableIdentifier TB_12 = TableIdentifier.of(ICEBERG_CATALOG, DATABASE, "iceberg_table12");
 
   private static final ConcurrentHashMap<String, ArcticCatalog> catalogsCache = new ConcurrentHashMap<>();
 
@@ -162,6 +163,14 @@ public class OptimizingIntegrationTest {
     assertTableExist(TB_7);
     IcebergHadoopOptimizingTest testCase = new IcebergHadoopOptimizingTest(TB_7, table, getOptimizeHistoryStartId());
     testCase.testPartitionIcebergTableOptimizing();
+  }
+
+  @Test
+  public void testPartitionIcebergTablePartialOptimizing() throws IOException {
+    Table table = createIcebergTable(TB_12, SPEC);
+    assertTableExist(TB_12);
+    IcebergHadoopOptimizingTest testCase = new IcebergHadoopOptimizingTest(TB_12, table, getOptimizeHistoryStartId());
+    testCase.testPartitionIcebergTablePartialOptimizing();
   }
 
   @Test

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizeCommit.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizeCommit.java
@@ -6,6 +6,7 @@ import com.netease.arctic.ams.server.model.OptimizeTaskRuntime;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.ams.server.utils.JDBCSqlSessionFactoryProvider;
 import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.SerializationUtils;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
@@ -32,17 +33,16 @@ import java.util.stream.Collectors;
 public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
   @Test
   public void testNoPartitionTableMajorOptimizeCommit() throws Exception {
-    icebergNoPartitionTable.asUnkeyedTable().updateProperties()
-        .set(TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
-            TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
+    UnkeyedTable table = icebergNoPartitionTable.asUnkeyedTable();
+    table.updateProperties()
         .set(TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
         .commit();
-    List<DataFile> dataFiles = insertDataFiles(icebergNoPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), dataFiles);
+    List<DataFile> dataFiles = insertDataFiles(table, 10, 10);
+    insertEqDeleteFiles(table, 1);
+    insertPosDeleteFiles(table, dataFiles);
     Set<String> oldDataFilesPath = new HashSet<>();
     Set<String> oldDeleteFilesPath = new HashSet<>();
-    try (CloseableIterable<FileScanTask> filesIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
         .planFiles()) {
       filesIterable.forEach(fileScanTask -> {
         oldDataFilesPath.add((String) fileScanTask.file().path());
@@ -51,18 +51,19 @@ public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
     }
 
     List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> filesIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
         .planFiles()) {
       fileScanTasks = Lists.newArrayList(filesIterable);
     }
 
-    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(icebergNoPartitionTable,
-        new TableOptimizeRuntime(icebergNoPartitionTable.id()),
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
         fileScanTasks, 1, System.currentTimeMillis(),
-        icebergNoPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
+        currentSnapshotId);
     List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
 
-    List<DataFile> resultFiles = insertOptimizeTargetDataFiles(icebergNoPartitionTable.asUnkeyedTable(), 10);
+    List<DataFile> resultFiles = insertDataFiles(table, 10, 1);
     List<OptimizeTaskItem> taskItems = tasks.stream().map(task -> {
       OptimizeTaskRuntime optimizeRuntime = new OptimizeTaskRuntime(task.getTaskId());
       optimizeRuntime.setPreparedTime(System.currentTimeMillis());
@@ -82,12 +83,12 @@ public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
     Map<String, List<OptimizeTaskItem>> partitionTasks = taskItems.stream()
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
-    IcebergOptimizeCommit optimizeCommit = new IcebergOptimizeCommit(icebergNoPartitionTable, partitionTasks);
-    optimizeCommit.commit(icebergNoPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
+    IcebergOptimizeCommit optimizeCommit = new IcebergOptimizeCommit(table, partitionTasks);
+    optimizeCommit.commit(currentSnapshotId);
 
     Set<String> newDataFilesPath = new HashSet<>();
     Set<String> newDeleteFilesPath = new HashSet<>();
-    try (CloseableIterable<FileScanTask> fileIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> fileIterable = table.newScan()
         .planFiles()) {
       fileIterable.forEach(fileScanTask -> {
         newDataFilesPath.add((String) fileScanTask.file().path());
@@ -101,18 +102,17 @@ public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
 
   @Test
   public void testPartitionTableMajorOptimizeCommit() throws Exception {
-    icebergPartitionTable.asUnkeyedTable().updateProperties()
-        .set(TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
-            TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
+    UnkeyedTable table = icebergPartitionTable.asUnkeyedTable();
+    table.updateProperties()
         .set(TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
         .set(org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")
         .commit();
-    List<DataFile> dataFiles = insertDataFiles(icebergPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergPartitionTable.asUnkeyedTable(), dataFiles);
+    List<DataFile> dataFiles = insertDataFiles(table, 10, 10);
+    insertEqDeleteFiles(table, 1);
+    insertPosDeleteFiles(table, dataFiles);
     Set<String> oldDataFilesPath = new HashSet<>();
     Set<String> oldDeleteFilesPath = new HashSet<>();
-    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan().planFiles()) {
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan().planFiles()) {
       filesIterable.forEach(fileScanTask -> {
         oldDataFilesPath.add((String) fileScanTask.file().path());
         fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
@@ -120,17 +120,17 @@ public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
     }
 
     List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan().planFiles()) {
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan().planFiles()) {
       fileScanTasks = Lists.newArrayList(filesIterable);
     }
 
-    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(icebergPartitionTable,
-        new TableOptimizeRuntime(icebergPartitionTable.id()),
+    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
         fileScanTasks, 1, System.currentTimeMillis(),
-        icebergPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
+        table.currentSnapshot().snapshotId());
     List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
 
-    List<DataFile> resultFiles = insertOptimizeTargetDataFiles(icebergPartitionTable.asUnkeyedTable(), 10);
+    List<DataFile> resultFiles = insertDataFiles(table, 10, 1);
     List<OptimizeTaskItem> taskItems = tasks.stream().map(task -> {
       OptimizeTaskRuntime optimizeRuntime = new OptimizeTaskRuntime(task.getTaskId());
       optimizeRuntime.setPreparedTime(System.currentTimeMillis());
@@ -150,12 +150,12 @@ public class TestIcebergFullOptimizeCommit extends TestIcebergBase {
     Map<String, List<OptimizeTaskItem>> partitionTasks = taskItems.stream()
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
-    IcebergOptimizeCommit optimizeCommit = new IcebergOptimizeCommit(icebergPartitionTable, partitionTasks);
-    optimizeCommit.commit(icebergPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
+    IcebergOptimizeCommit optimizeCommit = new IcebergOptimizeCommit(table, partitionTasks);
+    optimizeCommit.commit(table.currentSnapshot().snapshotId());
 
     Set<String> newDataFilesPath = new HashSet<>();
     Set<String> newDeleteFilesPath = new HashSet<>();
-    try (CloseableIterable<FileScanTask> fileIterable = icebergPartitionTable.asUnkeyedTable().newScan().planFiles()) {
+    try (CloseableIterable<FileScanTask> fileIterable = table.newScan().planFiles()) {
       fileIterable.forEach(fileScanTask -> {
         newDataFilesPath.add((String) fileScanTask.file().path());
         fileScanTask.deletes().forEach(deleteFile -> newDeleteFilesPath.add((String) deleteFile.path()));

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizePlan.java
@@ -3,6 +3,7 @@ package com.netease.arctic.ams.server.optimize;
 import com.netease.arctic.ams.server.model.BasicOptimizeTask;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.table.UnkeyedTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.io.CloseableIterable;
@@ -15,72 +16,111 @@ import java.util.List;
 public class TestIcebergFullOptimizePlan extends TestIcebergBase {
   @Test
   public void testNoPartitionFullOptimize() throws Exception {
-    icebergNoPartitionTable.asUnkeyedTable().updateProperties()
-        .set(com.netease.arctic.table.TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
-            com.netease.arctic.table.TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
+    UnkeyedTable table = icebergNoPartitionTable.asUnkeyedTable();
+    table.updateProperties()
         .set(com.netease.arctic.table.TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
         .commit();
-    List<DataFile> dataFiles = insertDataFiles(icebergNoPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), dataFiles);
+    List<DataFile> dataFiles = insertDataFiles(table, 10, 10);
+    insertEqDeleteFiles(table, 1);
+    insertPosDeleteFiles(table, dataFiles);
     List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> fileIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> fileIterable = table.newScan()
         .planFiles()) {
       fileScanTasks = Lists.newArrayList(fileIterable);
     }
-    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(icebergNoPartitionTable,
-        new TableOptimizeRuntime(icebergNoPartitionTable.id()),
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
         fileScanTasks, 1, System.currentTimeMillis(),
-        icebergNoPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
-    List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
-    Assert.assertEquals(1, tasks.size());
+        currentSnapshotId);
+    OptimizePlanResult planResult = optimizePlan.plan();
+    assertPlanResult(planResult, 1, 1, currentSnapshotId);
+    assertTask(planResult.getOptimizeTasks().get(0), "", 10, 0, 1, 1);
   }
 
   @Test
   public void testPartitionFullOptimize() throws Exception {
-    icebergPartitionTable.asUnkeyedTable().updateProperties()
-        .set(com.netease.arctic.table.TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
-            com.netease.arctic.table.TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
+    UnkeyedTable table = icebergPartitionTable.asUnkeyedTable();
+    table.updateProperties()
         .set(com.netease.arctic.table.TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
         .commit();
-    List<DataFile> dataFiles = insertDataFiles(icebergPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergPartitionTable.asUnkeyedTable(), dataFiles);
+    // partition1
+    List<DataFile> dataFiles = insertDataFiles(table, "name1", 10, 10, 1);
+    insertEqDeleteFiles(table, "name1", 1);
+    insertPosDeleteFiles(table, dataFiles);
+    // partition2
+    insertDataFiles(table, "name2", 10, 10, 1);
+    insertEqDeleteFiles(table, "name2", 1);
     List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> fileIterable = icebergPartitionTable.asUnkeyedTable().newScan().planFiles()) {
+    try (CloseableIterable<FileScanTask> fileIterable = table.newScan()
+        .planFiles()) {
       fileScanTasks = Lists.newArrayList(fileIterable);
     }
-    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(icebergPartitionTable,
-        new TableOptimizeRuntime(icebergPartitionTable.id()),
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
         fileScanTasks, 1, System.currentTimeMillis(),
-        icebergPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
-    List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
-    Assert.assertEquals(1, tasks.size());
+        currentSnapshotId);
+    OptimizePlanResult planResult = optimizePlan.plan();
+    assertPlanResult(planResult, 2, 2, currentSnapshotId);
+    assertTask(planResult.getOptimizeTasks().get(0), "name=name1", 10, 0, 1, 1);
+    assertTask(planResult.getOptimizeTasks().get(1), "name=name2", 10, 0, 1, 0);
+  }
+
+  @Test
+  public void testPartitionPartialFullOptimize() throws Exception {
+    UnkeyedTable table = icebergPartitionTable.asUnkeyedTable();
+    table.updateProperties()
+        .set(TableProperties.SELF_OPTIMIZING_MAX_FILE_CNT, "18")
+        .set(com.netease.arctic.table.TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
+        .commit();
+    insertDataFiles(table, "name1", 5, 1, 1);
+    insertDataFiles(table, "name2", 10, 1, 100);
+    insertDataFiles(table, "name3", 8, 1, 200);
+    insertDataFiles(table, "name4", 2, 1, 300);
+    insertEqDeleteFiles(table, "name1", 1);
+    insertEqDeleteFiles(table, "name1", 2);
+    insertEqDeleteFiles(table, "name1", 3);
+    insertEqDeleteFiles(table, "name2", 100);
+    insertEqDeleteFiles(table, "name3", 200);
+    insertEqDeleteFiles(table, "name3", 201);
+    List<FileScanTask> fileScanTasks;
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan().planFiles()) {
+      fileScanTasks = Lists.newArrayList(filesIterable);
+    }
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
+        fileScanTasks, 1, System.currentTimeMillis(),
+        currentSnapshotId);
+    OptimizePlanResult planResult = optimizePlan.plan();
+    assertPlanResult(planResult, 2, 2, currentSnapshotId);
+    assertTask(planResult.getOptimizeTasks().get(0), "name=name1", 5, 0, 3, 0);
+    assertTask(planResult.getOptimizeTasks().get(1), "name=name3", 8, 0, 2, 0);
   }
 
   @Test
   public void testBinPackPlan() throws Exception {
-    // small file size 1000, target size 3000
-    int fragmentRatio = 3;
-    icebergNoPartitionTable.asUnkeyedTable().updateProperties()
-        .set(TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO, fragmentRatio + "")
+    UnkeyedTable table = icebergNoPartitionTable.asUnkeyedTable();
+    int packFileCnt = 3;
+    List<DataFile> dataFiles = insertDataFiles(table, 10, 10);
+    long targetSize = dataFiles.get(0).fileSizeInBytes() * packFileCnt + 100;
+    table.updateProperties()
         .set(TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
-        .set(TableProperties.SELF_OPTIMIZING_TARGET_SIZE, "3000")
+        .set(TableProperties.SELF_OPTIMIZING_TARGET_SIZE, targetSize + "")
         .commit();
-    // write 50 data files with size =~ 1000
-    List<DataFile> dataFiles = insertDataFiles(icebergNoPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), dataFiles);
+    insertEqDeleteFiles(table, 1);
+    insertPosDeleteFiles(table, dataFiles);
     List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> fileIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> fileIterable = table.newScan()
         .planFiles()) {
       fileScanTasks = Lists.newArrayList(fileIterable);
     }
-    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(icebergNoPartitionTable,
-        new TableOptimizeRuntime(icebergNoPartitionTable.id()),
+    IcebergFullOptimizePlan optimizePlan = new IcebergFullOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
         fileScanTasks, 1, System.currentTimeMillis(),
-        icebergNoPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
+        table.currentSnapshot().snapshotId());
     List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
-    Assert.assertEquals((int) Math.ceil(1.0 * dataFiles.size() / fragmentRatio), tasks.size());
+    Assert.assertEquals((int) Math.ceil(1.0 * dataFiles.size() / packFileCnt), tasks.size());
   }
 }

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergMinorOptimizeCommit.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergMinorOptimizeCommit.java
@@ -5,7 +5,7 @@ import com.netease.arctic.ams.server.model.BasicOptimizeTask;
 import com.netease.arctic.ams.server.model.OptimizeTaskRuntime;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.ams.server.utils.JDBCSqlSessionFactoryProvider;
-import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.SerializationUtils;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -35,92 +35,13 @@ import java.util.stream.Collectors;
 public class TestIcebergMinorOptimizeCommit extends TestIcebergBase {
   @Test
   public void testNoPartitionTableMinorOptimizeCommit() throws Exception {
-    icebergNoPartitionTable.asUnkeyedTable().updateProperties()
-        .set(TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
-            TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
-        .commit();
-    List<DataFile> dataFiles = insertDataFiles(icebergNoPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), dataFiles);
+    UnkeyedTable table = icebergNoPartitionTable.asUnkeyedTable();
+    List<DataFile> dataFiles = insertDataFiles(table, 10, 1);
+    insertEqDeleteFiles(table, 1);
+    insertPosDeleteFiles(table, dataFiles);
     Set<String> oldDataFilesPath = new HashSet<>();
     Set<String> oldDeleteFilesPath = new HashSet<>();
-    try (CloseableIterable<FileScanTask> filesIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
-        .planFiles()) {
-      filesIterable.forEach(fileScanTask -> {
-        if (fileScanTask.file().fileSizeInBytes() <= 1000) {
-          oldDataFilesPath.add((String) fileScanTask.file().path());
-          fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
-        }
-      });
-    }
-
-    List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> filesIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
-        .planFiles()) {
-      fileScanTasks = Lists.newArrayList(filesIterable);
-    }
-
-    icebergNoPartitionTable.asUnkeyedTable().newScan().planFiles();
-    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(icebergNoPartitionTable,
-        new TableOptimizeRuntime(icebergNoPartitionTable.id()),
-        fileScanTasks, 1, System.currentTimeMillis(),
-        icebergNoPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
-    List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
-
-    List<DataFile> resultDataFiles = insertOptimizeTargetDataFiles(icebergNoPartitionTable.asUnkeyedTable(), 10);
-    List<DeleteFile> resultDeleteFiles = insertPosDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), resultDataFiles);
-    List<ContentFile<?>> resultFiles = new ArrayList<>();
-    resultFiles.addAll(resultDataFiles);
-    resultFiles.addAll(resultDeleteFiles);
-    List<OptimizeTaskItem> taskItems = tasks.stream().map(task -> {
-      OptimizeTaskRuntime optimizeRuntime = new OptimizeTaskRuntime(task.getTaskId());
-      optimizeRuntime.setPreparedTime(System.currentTimeMillis());
-      optimizeRuntime.setStatus(OptimizeStatus.Prepared);
-      optimizeRuntime.setReportTime(System.currentTimeMillis());
-      if (resultFiles != null) {
-        optimizeRuntime.setNewFileSize(resultFiles.get(0).fileSizeInBytes());
-        optimizeRuntime.setTargetFiles(resultFiles.stream().map(SerializationUtils::toByteBuffer).collect(Collectors.toList()));
-      }
-      List<ByteBuffer> finalTargetFiles = optimizeRuntime.getTargetFiles();
-      optimizeRuntime.setTargetFiles(finalTargetFiles);
-      optimizeRuntime.setNewFileCnt(finalTargetFiles.size());
-      // 1min
-      optimizeRuntime.setCostTime(60 * 1000);
-      return new OptimizeTaskItem(task, optimizeRuntime);
-    }).collect(Collectors.toList());
-    Map<String, List<OptimizeTaskItem>> partitionTasks = taskItems.stream()
-        .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
-
-    IcebergOptimizeCommit optimizeCommit = new IcebergOptimizeCommit(icebergNoPartitionTable, partitionTasks);
-    optimizeCommit.commit(icebergNoPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
-
-    Set<String> newDataFilesPath = new HashSet<>();
-    Set<String> newDeleteFilesPath = new HashSet<>();
-    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan()
-        .planFiles()) {
-      filesIterable.forEach(fileScanTask -> {
-        if (fileScanTask.file().fileSizeInBytes() <= 1000) {
-          newDataFilesPath.add((String) fileScanTask.file().path());
-          fileScanTask.deletes().forEach(deleteFile -> newDeleteFilesPath.add((String) deleteFile.path()));
-        }
-      });
-    }
-    Assert.assertNotEquals(oldDataFilesPath, newDataFilesPath);
-    Assert.assertNotEquals(oldDeleteFilesPath, newDeleteFilesPath);
-  }
-
-  @Test
-  public void testPartitionTableMinorOptimizeCommit() throws Exception {
-    icebergPartitionTable.asUnkeyedTable().updateProperties()
-        .set(TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
-            TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
-        .commit();
-    List<DataFile> dataFiles = insertDataFiles(icebergPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergPartitionTable.asUnkeyedTable(), dataFiles);
-    Set<String> oldDataFilesPath = new HashSet<>();
-    Set<String> oldDeleteFilesPath = new HashSet<>();
-    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
         .planFiles()) {
       filesIterable.forEach(fileScanTask -> {
         oldDataFilesPath.add((String) fileScanTask.file().path());
@@ -129,19 +50,21 @@ public class TestIcebergMinorOptimizeCommit extends TestIcebergBase {
     }
 
     List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
         .planFiles()) {
       fileScanTasks = Lists.newArrayList(filesIterable);
     }
 
-    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(icebergPartitionTable,
-        new TableOptimizeRuntime(icebergPartitionTable.id()),
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    table.newScan().planFiles();
+    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
         fileScanTasks, 1, System.currentTimeMillis(),
-        icebergPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
+        currentSnapshotId);
     List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
 
-    List<DataFile> resultDataFiles = insertOptimizeTargetDataFiles(icebergPartitionTable.asUnkeyedTable(), 10);
-    List<DeleteFile> resultDeleteFiles = insertPosDeleteFiles(icebergPartitionTable.asUnkeyedTable(), resultDataFiles);
+    List<DataFile> resultDataFiles = insertDataFiles(table, 1, 10);
+    List<DeleteFile> resultDeleteFiles = insertPosDeleteFiles(table, resultDataFiles);
     List<ContentFile<?>> resultFiles = new ArrayList<>();
     resultFiles.addAll(resultDataFiles);
     resultFiles.addAll(resultDeleteFiles);
@@ -164,18 +87,85 @@ public class TestIcebergMinorOptimizeCommit extends TestIcebergBase {
     Map<String, List<OptimizeTaskItem>> partitionTasks = taskItems.stream()
         .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
 
-    IcebergOptimizeCommit optimizeCommit = new IcebergOptimizeCommit(icebergPartitionTable, partitionTasks);
-    optimizeCommit.commit(icebergPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
+    IcebergOptimizeCommit optimizeCommit = new IcebergOptimizeCommit(table, partitionTasks);
+    optimizeCommit.commit(currentSnapshotId);
 
     Set<String> newDataFilesPath = new HashSet<>();
     Set<String> newDeleteFilesPath = new HashSet<>();
-    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
         .planFiles()) {
       filesIterable.forEach(fileScanTask -> {
-        if (fileScanTask.file().fileSizeInBytes() <= 1000) {
-          newDataFilesPath.add((String) fileScanTask.file().path());
-          fileScanTask.deletes().forEach(deleteFile -> newDeleteFilesPath.add((String) deleteFile.path()));
-        }
+        newDataFilesPath.add((String) fileScanTask.file().path());
+        fileScanTask.deletes().forEach(deleteFile -> newDeleteFilesPath.add((String) deleteFile.path()));
+      });
+    }
+    Assert.assertNotEquals(oldDataFilesPath, newDataFilesPath);
+    Assert.assertNotEquals(oldDeleteFilesPath, newDeleteFilesPath);
+  }
+
+  @Test
+  public void testPartitionTableMinorOptimizeCommit() throws Exception {
+    UnkeyedTable table = icebergPartitionTable.asUnkeyedTable();
+    List<DataFile> dataFiles = insertDataFiles(table, 10, 1);
+    insertEqDeleteFiles(table, 1);
+    insertPosDeleteFiles(table, dataFiles);
+    Set<String> oldDataFilesPath = new HashSet<>();
+    Set<String> oldDeleteFilesPath = new HashSet<>();
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
+        .planFiles()) {
+      filesIterable.forEach(fileScanTask -> {
+        oldDataFilesPath.add((String) fileScanTask.file().path());
+        fileScanTask.deletes().forEach(deleteFile -> oldDeleteFilesPath.add((String) deleteFile.path()));
+      });
+    }
+
+    List<FileScanTask> fileScanTasks;
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
+        .planFiles()) {
+      fileScanTasks = Lists.newArrayList(filesIterable);
+    }
+
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
+        fileScanTasks, 1, System.currentTimeMillis(),
+        currentSnapshotId);
+    List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
+
+    List<DataFile> resultDataFiles = insertDataFiles(table, 1, 10);
+    List<DeleteFile> resultDeleteFiles = insertPosDeleteFiles(table, resultDataFiles);
+    List<ContentFile<?>> resultFiles = new ArrayList<>();
+    resultFiles.addAll(resultDataFiles);
+    resultFiles.addAll(resultDeleteFiles);
+    List<OptimizeTaskItem> taskItems = tasks.stream().map(task -> {
+      OptimizeTaskRuntime optimizeRuntime = new OptimizeTaskRuntime(task.getTaskId());
+      optimizeRuntime.setPreparedTime(System.currentTimeMillis());
+      optimizeRuntime.setStatus(OptimizeStatus.Prepared);
+      optimizeRuntime.setReportTime(System.currentTimeMillis());
+      if (resultFiles != null) {
+        optimizeRuntime.setNewFileSize(resultFiles.get(0).fileSizeInBytes());
+        optimizeRuntime.setTargetFiles(resultFiles.stream().map(SerializationUtils::toByteBuffer).collect(Collectors.toList()));
+      }
+      List<ByteBuffer> finalTargetFiles = optimizeRuntime.getTargetFiles();
+      optimizeRuntime.setTargetFiles(finalTargetFiles);
+      optimizeRuntime.setNewFileCnt(finalTargetFiles.size());
+      // 1min
+      optimizeRuntime.setCostTime(60 * 1000);
+      return new OptimizeTaskItem(task, optimizeRuntime);
+    }).collect(Collectors.toList());
+    Map<String, List<OptimizeTaskItem>> partitionTasks = taskItems.stream()
+        .collect(Collectors.groupingBy(taskItem -> taskItem.getOptimizeTask().getPartition()));
+
+    IcebergOptimizeCommit optimizeCommit = new IcebergOptimizeCommit(table, partitionTasks);
+    optimizeCommit.commit(currentSnapshotId);
+
+    Set<String> newDataFilesPath = new HashSet<>();
+    Set<String> newDeleteFilesPath = new HashSet<>();
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
+        .planFiles()) {
+      filesIterable.forEach(fileScanTask -> {
+        newDataFilesPath.add((String) fileScanTask.file().path());
+        fileScanTask.deletes().forEach(deleteFile -> newDeleteFilesPath.add((String) deleteFile.path()));
       });
     }
     Assert.assertNotEquals(oldDataFilesPath, newDataFilesPath);

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergMinorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergMinorOptimizePlan.java
@@ -1,13 +1,12 @@
 package com.netease.arctic.ams.server.optimize;
 
-import com.netease.arctic.ams.server.model.BasicOptimizeTask;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.table.UnkeyedTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
@@ -15,44 +14,104 @@ import java.util.List;
 public class TestIcebergMinorOptimizePlan extends TestIcebergBase {
   @Test
   public void testUnPartitionMinorOptimize() throws Exception {
-    icebergNoPartitionTable.asUnkeyedTable().updateProperties()
+    UnkeyedTable table = icebergNoPartitionTable.asUnkeyedTable();
+    // 10 small files
+    List<DataFile> smallDataFiles = insertDataFiles(table, "", 12, 1, 200);
+    table.updateProperties()
         .set(TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
-            TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
+            TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / (smallDataFiles.get(0).fileSizeInBytes() + 100) + "")
         .commit();
-    List<DataFile> dataFiles = insertDataFiles(icebergNoPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergNoPartitionTable.asUnkeyedTable(), dataFiles);
+    // 10 big files
+    List<DataFile> dataFiles = insertDataFiles(table, "", 12, 10, 1);
+
+    // 1 equ-delete for 1 small file
+    insertEqDeleteFiles(table, 200);
+    // 1 equ-delete for 1 big file
+    insertEqDeleteFiles(table, 1);
+    // 1 pos-delete for each big file
+    insertPosDeleteFiles(table, dataFiles);
+
     List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> filesIterable = icebergNoPartitionTable.asUnkeyedTable().newScan()
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
         .planFiles()) {
       fileScanTasks = Lists.newArrayList(filesIterable);
     }
-    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(icebergNoPartitionTable,
-        new TableOptimizeRuntime(icebergNoPartitionTable.id()),
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
         fileScanTasks, 1, System.currentTimeMillis(),
-        icebergNoPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
-    List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
-    Assert.assertEquals(2, tasks.size());
+        currentSnapshotId);
+    OptimizePlanResult planResult = optimizePlan.plan();
+    assertPlanResult(planResult, 1, 2, currentSnapshotId);
+    assertTask(planResult.getOptimizeTasks().get(0), "", 0, 12, 1, 0);
+    assertTask(planResult.getOptimizeTasks().get(1), "", 12, 0, 1, 1);
   }
 
   @Test
   public void testPartitionMinorOptimize() throws Exception {
-    icebergPartitionTable.asUnkeyedTable().updateProperties()
+    UnkeyedTable table = icebergPartitionTable.asUnkeyedTable();
+    // partition1:
+    // 10 small files
+    List<DataFile> smallDataFiles = insertDataFiles(table, "name1", 12, 1, 200);
+    table.updateProperties()
         .set(TableProperties.SELF_OPTIMIZING_FRAGMENT_RATIO,
-            TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / 1000 + "")
+            TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT / (smallDataFiles.get(0).fileSizeInBytes() + 100) + "")
         .commit();
-    List<DataFile> dataFiles = insertDataFiles(icebergPartitionTable.asUnkeyedTable(), 10);
-    insertEqDeleteFiles(icebergPartitionTable.asUnkeyedTable(), 5);
-    insertPosDeleteFiles(icebergPartitionTable.asUnkeyedTable(), dataFiles);
+    // 10 big files
+    List<DataFile> dataFiles = insertDataFiles(table, "name1", 12, 10, 1);
+
+    // 1 equ-delete for 1 small file
+    insertEqDeleteFiles(table, "name1", 200);
+    // 1 equ-delete for 1 small file
+    insertEqDeleteFiles(table, "name1", 1);
+    // 1 pos-delete for each big file
+    insertPosDeleteFiles(table, dataFiles);
+
+    // partition2:
+    // 10 small files
+    insertDataFiles(table, "name2", 12, 1, 300);
+
     List<FileScanTask> fileScanTasks;
-    try (CloseableIterable<FileScanTask> filesIterable = icebergPartitionTable.asUnkeyedTable().newScan().planFiles()) {
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan()
+        .planFiles()) {
       fileScanTasks = Lists.newArrayList(filesIterable);
     }
-    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(icebergPartitionTable,
-        new TableOptimizeRuntime(icebergPartitionTable.id()),
-        fileScanTasks,1, System.currentTimeMillis(),
-        icebergPartitionTable.asUnkeyedTable().currentSnapshot().snapshotId());
-    List<BasicOptimizeTask> tasks = optimizePlan.plan().getOptimizeTasks();
-    Assert.assertEquals(2, tasks.size());
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
+        fileScanTasks, 1, System.currentTimeMillis(),
+        currentSnapshotId);
+    OptimizePlanResult planResult = optimizePlan.plan();
+    assertPlanResult(planResult, 2, 3, currentSnapshotId);
+    assertTask(planResult.getOptimizeTasks().get(0), "name=name1", 0, 12, 1, 0);
+    assertTask(planResult.getOptimizeTasks().get(1), "name=name1", 12, 0, 1, 1);
+    assertTask(planResult.getOptimizeTasks().get(2), "name=name2", 0, 12, 0, 0);
+  }
+
+  @Test
+  public void testPartitionPartialMinorOptimize() throws Exception {
+    UnkeyedTable table = icebergPartitionTable.asUnkeyedTable();
+    table.updateProperties()
+        .set(TableProperties.SELF_OPTIMIZING_MAX_FILE_CNT, "18")
+        .set(TableProperties.SELF_OPTIMIZING_MINOR_TRIGGER_FILE_CNT, "4")
+        .commit();
+    insertDataFiles(table, "name1", 5, 1, 1);
+    insertDataFiles(table, "name2", 10, 1, 100);
+    insertDataFiles(table, "name3", 8, 1, 200);
+    insertDataFiles(table, "name4", 2, 1, 300);
+
+    List<FileScanTask> fileScanTasks;
+    try (CloseableIterable<FileScanTask> filesIterable = table.newScan().planFiles()) {
+      fileScanTasks = Lists.newArrayList(filesIterable);
+    }
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    IcebergMinorOptimizePlan optimizePlan = new IcebergMinorOptimizePlan(table,
+        new TableOptimizeRuntime(table.id()),
+        fileScanTasks, 1, System.currentTimeMillis(),
+        currentSnapshotId);
+    OptimizePlanResult planResult = optimizePlan.plan();
+    assertPlanResult(planResult, 2, 2, currentSnapshotId);
+    assertTask(planResult.getOptimizeTasks().get(0), "name=name2", 0, 10, 0, 0);
+    assertTask(planResult.getOptimizeTasks().get(1), "name=name3", 0, 8, 0, 0);
   }
 }

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -87,7 +87,7 @@ public class TableProperties {
   public static final long SELF_OPTIMIZING_TARGET_SIZE_DEFAULT = 134217728; // 128 MB
 
   public static final String SELF_OPTIMIZING_MAX_FILE_CNT = "self-optimizing.max-file-count";
-  public static final int SELF_OPTIMIZING_MAX_FILE_CNT_DEFAULT = 100000;
+  public static final int SELF_OPTIMIZING_MAX_FILE_CNT_DEFAULT = 10000;
 
   public static final String SELF_OPTIMIZING_FRAGMENT_RATIO = "self-optimizing.fragment-ratio";
   public static final int SELF_OPTIMIZING_FRAGMENT_RATIO_DEFAULT = 8;

--- a/site/docs/ch/configurations.md
+++ b/site/docs/ch/configurations.md
@@ -15,7 +15,7 @@ Self-optimizing 配置对 Iceberg format, Mixed streaming format 都会生效。
 | self-optimizing.num-retries                         | 5                | self-optimizing 失败时的重试次数                               |
 | self-optimizing.execute.timeout                     | 1800000（30分钟） | self-optimizing 执行超时时间，超时会失败重试                                  |
 | self-optimizing.target-size                         | 134217728（128MB）| self-optimizing 的目标文件大小                                |
-| self-optimizing.max-file-count                      | 100000           | 一次 self-optimizing 最多处理的文件个数                           |               |
+| self-optimizing.max-file-count                      | 10000            | 一次 self-optimizing 最多处理的文件个数                           |               |
 | self-optimizing.fragment-ratio                      | 8                | fragment 文件大小阈值，实际计算时取倒数与  self-optimizing.target-size 的值相乘                         |
 | self-optimizing.minor.trigger.file-count            | 12               | 触发 minor optimizing 的 fragment 最少文件数量             |
 | self-optimizing.minor.trigger.interval              | 3600000（1小时）  | 触发 minor optimizing 的最长时间间隔                        |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1208 

## Brief change log

  - Support only optimizing a part of partitions for Minor/Full Optimizing of native Iceberg table
  - when optimizing, partitions should be sorted by priority, and collect tasks one by one
  - for the native Iceberg table's Minor Optimizing, the priority should be the small-files count in the partition
  - for the native Iceberg table's Full Optimizing, the priority should be the delete-file size in the partition


## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
