### PR TITLE
[ARCTIC-1210][Spark][BUG]Fix bug:  NPE exception when execute create table like command without using arctic

### DIFF
--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/analysis/RewriteArcticCommand.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/analysis/RewriteArcticCommand.scala
@@ -54,7 +54,7 @@ case class RewriteArcticCommand(sparkSession: SparkSession) extends Rule[Logical
         }
         c.copy(properties = propertiesMap, writeOptions = optionsMap)
       case CreateTableLikeCommand(targetTable, sourceTable, storage, provider, properties, ifNotExists)
-        if provider.get != null && provider.get.equals("arctic") =>
+        if provider.isDefined && provider.get != null && provider.get.equals("arctic") =>
           val (sourceCatalog, sourceIdentifier) = buildCatalogAndIdentifier(sparkSession, sourceTable)
           val (targetCatalog, targetIdentifier) = buildCatalogAndIdentifier(sparkSession, targetTable)
           val table = sourceCatalog.loadTable(sourceIdentifier)

--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/analysis/RewriteArcticCommand.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/analysis/RewriteArcticCommand.scala
@@ -82,7 +82,6 @@ case class RewriteArcticCommand(sparkSession: SparkSession) extends Rule[Logical
           case arcticTable: ArcticSparkTable if arcticTable.table().isKeyedTable =>
             targetProperties += ("primary.keys" -> String.join(",", arcticTable.table().asKeyedTable().primaryKeySpec().fieldNames()))
           case _ =>
-
         }
         targetProperties += ("provider" -> "arctic")
         CreateV2Table(targetCatalog, targetIdentifier,

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
@@ -166,7 +166,7 @@ public class TestArcticSessionCatalog extends SparkTestContext {
         " ''props.test1'' = ''val1'', \n" +
         " ''props.test2'' = ''val2'' ) ", database, table3);
 
-    sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
+    sql("create table {0}.{1} like {2}.{3} using arctic", database, table2, database, table3);
     sql("desc table {0}.{1}", database, table2);
     assertDescResult(rows, Lists.newArrayList("id"));
 
@@ -179,29 +179,7 @@ public class TestArcticSessionCatalog extends SparkTestContext {
   }
 
   @Test
-  public void testCreateHiveTableLikeWithNoProvider() throws TException {
-    sql("set spark.sql.arctic.delegate.enabled=true");
-    sql("use spark_catalog");
-    sql("create table {0}.{1} ( \n" +
-        " id int , \n" +
-        " name string , \n " +
-        " ts timestamp  \n" +
-        ") stored as parquet \n" +
-        " partitioned by ( ts ) \n" +
-        " tblproperties ( \n" +
-        " ''props.test1'' = ''val1'', \n" +
-        " ''props.test2'' = ''val2'' ) ", database, table3);
-
-    sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
-    Table hiveTableA = hms.getClient().getTable(database, table2);
-    Assert.assertNotNull(hiveTableA);
-    sql("drop table {0}.{1}", database, table2);
-
-    sql("drop table {0}.{1}", database, table3);
-  }
-
-  @Test
-  public void testCreateArcticTableLikeWithNoProvider() {
+  public void testCreateTableLikeWithNoProvider() throws TException {
     sql("set spark.sql.arctic.delegate.enabled=true");
     sql("use spark_catalog");
     sql("create table {0}.{1} ( \n" +
@@ -216,11 +194,8 @@ public class TestArcticSessionCatalog extends SparkTestContext {
         " ''props.test2'' = ''val2'' ) ", database, table3);
 
     sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
-    sql("desc table {0}.{1}", database, table2);
-    assertDescResult(rows, Lists.newArrayList("id"));
-
-    sql("desc table extended {0}.{1}", database, table2);
-    assertDescResult(rows, Lists.newArrayList("id"));
+    Table hiveTableA = hms.getClient().getTable(database, table2);
+    Assert.assertNotNull(hiveTableA);
     sql("drop table {0}.{1}", database, table2);
 
     sql("drop table {0}.{1}", database, table3);

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
@@ -206,6 +206,7 @@ public class TestArcticSessionCatalog extends SparkTestContext {
 
   @Test
   public void testCreateTableLikeWithoutArcticCatalogWithNoProvider() throws TException {
+    sql("set spark.sql.arctic.delegate.enabled=true");
     sql("use catalog");
     sql("create table {0}.{1} ( \n" +
         " id int , \n" +
@@ -220,10 +221,9 @@ public class TestArcticSessionCatalog extends SparkTestContext {
     sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
     Table hiveTableA = hms.getClient().getTable(database, table2);
     Assert.assertNotNull(hiveTableA);
+    sql("drop table {0}.{1}", database, table3);
     sql("use spark_catalog");
     sql("drop table {0}.{1}", database, table2);
-
-    sql("drop table {0}.{1}", database, table3);
   }
 
 

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
@@ -61,6 +62,8 @@ public class TestArcticSessionCatalog extends SparkTestContext {
 
     configs.put("spark.sql.catalog.spark_catalog", ArcticSparkSessionCatalog.class.getName());
     configs.put("spark.sql.catalog.spark_catalog.url", amsUrl + "/" + catalogNameHive);
+    configs.put("spark.sql.catalog.catalog", SparkCatalog.class.getName());
+    configs.put("spark.sql.catalog.catalog.type", "hive");
     configs.put("spark.sql.arctic.delegate.enabled", "true");
 
     setUpSparkSession(configs);
@@ -196,6 +199,28 @@ public class TestArcticSessionCatalog extends SparkTestContext {
     sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
     Table hiveTableA = hms.getClient().getTable(database, table2);
     Assert.assertNotNull(hiveTableA);
+    sql("drop table {0}.{1}", database, table2);
+
+    sql("drop table {0}.{1}", database, table3);
+  }
+
+  @Test
+  public void testCreateTableLikeWithoutArcticCatalogWithNoProvider() throws TException {
+    sql("use catalog");
+    sql("create table {0}.{1} ( \n" +
+        " id int , \n" +
+        " name string , \n " +
+        " ts timestamp  \n" +
+        ") stored as parquet \n" +
+        " partitioned by ( ts ) \n" +
+        " tblproperties ( \n" +
+        " ''props.test1'' = ''val1'', \n" +
+        " ''props.test2'' = ''val2'' ) ", database, table3);
+
+    sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
+    Table hiveTableA = hms.getClient().getTable(database, table2);
+    Assert.assertNotNull(hiveTableA);
+    sql("use spark_catalog");
     sql("drop table {0}.{1}", database, table2);
 
     sql("drop table {0}.{1}", database, table3);

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
@@ -166,13 +166,61 @@ public class TestArcticSessionCatalog extends SparkTestContext {
         " ''props.test1'' = ''val1'', \n" +
         " ''props.test2'' = ''val2'' ) ", database, table3);
 
-    sql("create table {0}.{1} like {2}.{3} using arctic", database, table2, database, table3);
+    sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
     sql("desc table {0}.{1}", database, table2);
     assertDescResult(rows, Lists.newArrayList("id"));
 
     sql("desc table extended {0}.{1}", database, table2);
     assertDescResult(rows, Lists.newArrayList("id"));
 
+    sql("drop table {0}.{1}", database, table2);
+
+    sql("drop table {0}.{1}", database, table3);
+  }
+
+  @Test
+  public void testCreateHiveTableLikeWithNoProvider() throws TException {
+    sql("set spark.sql.arctic.delegate.enabled=true");
+    sql("use spark_catalog");
+    sql("create table {0}.{1} ( \n" +
+        " id int , \n" +
+        " name string , \n " +
+        " ts timestamp  \n" +
+        ") stored as parquet \n" +
+        " partitioned by ( ts ) \n" +
+        " tblproperties ( \n" +
+        " ''props.test1'' = ''val1'', \n" +
+        " ''props.test2'' = ''val2'' ) ", database, table3);
+
+    sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
+    Table hiveTableA = hms.getClient().getTable(database, table2);
+    Assert.assertNotNull(hiveTableA);
+    sql("drop table {0}.{1}", database, table2);
+
+    sql("drop table {0}.{1}", database, table3);
+  }
+
+  @Test
+  public void testCreateArcticTableLikeWithNoProvider() {
+    sql("set spark.sql.arctic.delegate.enabled=true");
+    sql("use spark_catalog");
+    sql("create table {0}.{1} ( \n" +
+        " id int , \n" +
+        " name string , \n " +
+        " ts timestamp,  \n" +
+        " primary key (id) \n" +
+        ") using arctic \n" +
+        " partitioned by ( ts ) \n" +
+        " tblproperties ( \n" +
+        " ''props.test1'' = ''val1'', \n" +
+        " ''props.test2'' = ''val2'' ) ", database, table3);
+
+    sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
+    sql("desc table {0}.{1}", database, table2);
+    assertDescResult(rows, Lists.newArrayList("id"));
+
+    sql("desc table extended {0}.{1}", database, table2);
+    assertDescResult(rows, Lists.newArrayList("id"));
     sql("drop table {0}.{1}", database, table2);
 
     sql("drop table {0}.{1}", database, table3);

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
@@ -206,7 +206,6 @@ public class TestArcticSessionCatalog extends SparkTestContext {
 
   @Test
   public void testCreateTableLikeWithoutArcticCatalogWithNoProvider() throws TException {
-    sql("set spark.sql.arctic.delegate.enabled=true");
     sql("use catalog");
     sql("create table {0}.{1} ( \n" +
         " id int , \n" +
@@ -221,8 +220,8 @@ public class TestArcticSessionCatalog extends SparkTestContext {
     sql("create table {0}.{1} like {2}.{3}", database, table2, database, table3);
     Table hiveTableA = hms.getClient().getTable(database, table2);
     Assert.assertNotNull(hiveTableA);
-    sql("drop table {0}.{1}", database, table3);
     sql("use spark_catalog");
+    sql("drop table {0}.{1}", database, table3);
     sql("drop table {0}.{1}", database, table2);
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1210 

When execute create table like command without using arctic it will throw NPE exception.

## Brief change log
Achieve the following effects:
1. In ArcticSparkSessionCataog, provider = 'arctic' can create the arctic table
2. In ArcticSparkCatalog, the provider must be arctic or None. If it is None, the default value is arctic

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
