### PR TITLE
[ARCTIC-1213] Optimizing of Mixed Format Table supports optimizing a part of partitions at a time

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableQuotaInfo.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/TableQuotaInfo.java
@@ -19,7 +19,6 @@
 package com.netease.arctic.ams.server.model;
 
 import com.netease.arctic.table.TableIdentifier;
-import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
 
@@ -59,7 +58,7 @@ public class TableQuotaInfo implements Comparable<TableQuotaInfo> {
   }
 
   @Override
-  public int compareTo(@NotNull TableQuotaInfo o) {
+  public int compareTo(TableQuotaInfo o) {
     if (quota.compareTo(o.getQuota()) != 0) {
       return quota.compareTo(o.getQuota());
     }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractArcticOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractArcticOptimizePlan.java
@@ -80,18 +80,13 @@ public abstract class AbstractArcticOptimizePlan extends AbstractOptimizePlan {
 
   public AbstractArcticOptimizePlan(ArcticTable arcticTable, TableOptimizeRuntime tableOptimizeRuntime,
                                     List<ContentFileWithSequence<?>> changeFiles,
-                                List<FileScanTask> baseFileScanTasks,
-                                int queueId, long currentTime, long changeSnapshotId, long baseSnapshotId) {
+                                    List<FileScanTask> baseFileScanTasks,
+                                    int queueId, long currentTime, long changeSnapshotId, long baseSnapshotId) {
     super(arcticTable, tableOptimizeRuntime, queueId, currentTime, baseSnapshotId);
     this.baseFileScanTasks = baseFileScanTasks;
     this.changeFiles = changeFiles;
     this.isCustomizeDir = false;
     this.currentChangeSnapshotId = changeSnapshotId;
-  }
-
-  @Override
-  protected boolean limitFileCnt() {
-    return false;
   }
 
   protected BasicOptimizeTask buildOptimizeTask(@Nullable List<DataTreeNode> sourceNodes,
@@ -331,6 +326,13 @@ public abstract class AbstractArcticOptimizePlan extends AbstractOptimizePlan {
     return insertFiles;
   }
 
+  /**
+   * Check a base file should optimize
+   *
+   * @param baseFile  - base file
+   * @param partition - partition
+   * @return true if the file should optimize
+   */
   protected abstract boolean baseFileShouldOptimize(DataFile baseFile, String partition);
 
   protected boolean hasFileToOptimize() {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractIcebergOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractIcebergOptimizePlan.java
@@ -64,11 +64,6 @@ public abstract class AbstractIcebergOptimizePlan extends AbstractOptimizePlan {
     this.fileScanTasks = fileScanTasks;
   }
 
-  @Override
-  protected boolean limitFileCnt() {
-    return true;
-  }
-
   protected List<FileScanTask> filterRepeatFileScanTask(Collection<FileScanTask> fileScanTasks) {
     Set<String> dataFilesPath = new HashSet<>();
     List<FileScanTask> finalFileScanTasks = new ArrayList<>();

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveFullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveFullOptimizePlan.java
@@ -60,7 +60,6 @@ public class SupportHiveFullOptimizePlan extends FullOptimizePlan {
 
   @Override
   protected boolean partitionNeedPlan(String partitionToPath) {
-    long current = System.currentTimeMillis();
 
     List<DeleteFile> posDeleteFiles = getPosDeleteFilesFromFileTree(partitionToPath);
     List<DataFile> baseFiles = getBaseFilesFromFileTree(partitionToPath);
@@ -98,7 +97,7 @@ public class SupportHiveFullOptimizePlan extends FullOptimizePlan {
     }
 
     // check full optimize interval
-    if (checkFullOptimizeInterval(current, partitionToPath) && partitionNeedPlan) {
+    if (checkOptimizeInterval(partitionToPath) && partitionNeedPlan) {
       return true;
     }
 

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsTestBase.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsTestBase.java
@@ -66,7 +66,6 @@ import com.netease.arctic.ams.server.util.DerbyTestUtil;
 import com.netease.arctic.ams.server.utils.CatalogUtil;
 import com.netease.arctic.ams.server.utils.JDBCSqlSessionFactoryProvider;
 import com.netease.arctic.ams.server.utils.SequenceNumberFetcherTest;
-import com.netease.arctic.ams.server.utils.ThreadPool;
 import com.netease.arctic.ams.server.utils.UnKeyedTableUtilTest;
 import com.netease.arctic.catalog.ArcticCatalog;
 import com.netease.arctic.catalog.CatalogLoader;

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
@@ -279,6 +279,50 @@ public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
     Assert.assertEquals(0, tasks.get(0).getDeleteFileCnt());
   }
 
+  @Test
+  public void testPartitionWeight() {
+    List<AbstractOptimizePlan.PartitionWeightWrapper> partitionWeights = new ArrayList<>();
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p1",
+        new MajorOptimizePlan.MajorPartitionWeight(true,0)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p2",
+        new MajorOptimizePlan.MajorPartitionWeight(true, 1)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p3",
+        new MajorOptimizePlan.MajorPartitionWeight(false, 200)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p4",
+        new MajorOptimizePlan.MajorPartitionWeight(false, 100)));
+
+    List<String> sortedPartitions = partitionWeights.stream()
+        .sorted()
+        .map(AbstractOptimizePlan.PartitionWeightWrapper::getPartition)
+        .collect(Collectors.toList());
+    Assert.assertEquals("p2", sortedPartitions.get(0));
+    Assert.assertEquals("p1", sortedPartitions.get(1));
+    Assert.assertEquals("p3", sortedPartitions.get(2));
+    Assert.assertEquals("p4", sortedPartitions.get(3));
+  }
+
+  @Test
+  public void testFullPartitionWeight() {
+    List<AbstractOptimizePlan.PartitionWeightWrapper> partitionWeights = new ArrayList<>();
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p1",
+        new FullOptimizePlan.FullPartitionWeight(true,0)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p2",
+        new FullOptimizePlan.FullPartitionWeight(true, 1)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p3",
+        new FullOptimizePlan.FullPartitionWeight(false, 200)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p4",
+        new FullOptimizePlan.FullPartitionWeight(false, 100)));
+
+    List<String> sortedPartitions = partitionWeights.stream()
+        .sorted()
+        .map(AbstractOptimizePlan.PartitionWeightWrapper::getPartition)
+        .collect(Collectors.toList());
+    Assert.assertEquals("p2", sortedPartitions.get(0));
+    Assert.assertEquals("p1", sortedPartitions.get(1));
+    Assert.assertEquals("p3", sortedPartitions.get(2));
+    Assert.assertEquals("p4", sortedPartitions.get(3));
+  }
+
   private List<DataFile> insertUnKeyedTableDataFiles(ArcticTable arcticTable) {
     List<DataFile> dataFiles = insertUnKeyedTableDataFile(FILE_A.partition(), LocalDateTime.of(2022, 1, 1, 12, 0, 0), 5);
     dataFiles.addAll(insertUnKeyedTableDataFile(FILE_B.partition(), LocalDateTime.of(2022, 1, 2, 12, 0, 0), 5));

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMinorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMinorOptimizePlan.java
@@ -87,6 +87,28 @@ public class TestMinorOptimizePlan extends TestBaseOptimizeBase {
     Assert.assertEquals(10, tasks.get(0).getDeleteFileCnt());
   }
 
+  @Test
+  public void testPartitionWeight() {
+    List<AbstractOptimizePlan.PartitionWeightWrapper> partitionWeights = new ArrayList<>();
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p1",
+        new MinorOptimizePlan.MinorPartitionWeight(true,0)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p2",
+        new MinorOptimizePlan.MinorPartitionWeight(true, 1)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p3",
+        new MinorOptimizePlan.MinorPartitionWeight(false, 200)));
+    partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p4",
+        new MinorOptimizePlan.MinorPartitionWeight(false, 100)));
+
+    List<String> sortedPartitions = partitionWeights.stream()
+        .sorted()
+        .map(AbstractOptimizePlan.PartitionWeightWrapper::getPartition)
+        .collect(Collectors.toList());
+    Assert.assertEquals("p2", sortedPartitions.get(0));
+    Assert.assertEquals("p1", sortedPartitions.get(1));
+    Assert.assertEquals("p3", sortedPartitions.get(2));
+    Assert.assertEquals("p4", sortedPartitions.get(3));
+  }
+
   protected List<DataFile> insertChangeDeleteFiles(ArcticTable arcticTable) throws IOException {
     AtomicInteger taskId = new AtomicInteger();
     List<DataFile> changeDeleteFiles = new ArrayList<>();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1213 

## Brief change log

  - add PartitionWeight to sort partitions when planning
  - PartitionWeight for Mixed Iceberg Format Table's Minor-Optimizing is interval and change files' count
  - PartitionWeight for Mixed Iceberg Format Table's Major-Optimizing is interval and base small files' count
  - PartitionWeight for Mixed Iceberg Format Table's Full-Optimizing is interval and delete files' size
  - PartitionWeight for Mixed Hive Format Table's Major-Optimizing is interval and count of base files not in the hive location
  - PartitionWeight for Mixed Hive Format Table's Full-Optimizing is interval and delete files' size
  - Minor-Optimizing is now triggered by the change files' count instead of delete files' count

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
