### PR TITLE
[ARCTIC-1227] should not be case sensitive when reading the hive upgrade table schema

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -123,6 +123,7 @@
                 <configuration>
                     <includes>
                         <include>**/ArcticHiveTestMain.java</include>
+                        <include>**/TestAdaptHiveReadConf.java</include>
                     </includes>
                 </configuration>
             </plugin>

--- a/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveApplyNameMapping.java
+++ b/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveApplyNameMapping.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.parquet;
+
+import org.apache.iceberg.mapping.NameMapping;
+
+import java.util.Arrays;
+
+public class AdaptHiveApplyNameMapping extends ApplyNameMapping {
+  AdaptHiveApplyNameMapping(NameMapping nameMapping) {
+    super(nameMapping);
+  }
+
+  @Override
+  protected String[] currentPath() {
+    return Arrays.stream(super.currentPath()).map(String::toLowerCase).toArray(String[]::new);
+  }
+}

--- a/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveReadConf.java
+++ b/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveReadConf.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.parquet;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -245,7 +246,8 @@ class AdaptHiveReadConf<T> {
     return listBuilder.build();
   }
 
-  private static NameMapping convertNameMapping(MessageType fileSchema, NameMapping nameMapping) {
+  @VisibleForTesting
+  static NameMapping convertNameMapping(MessageType fileSchema, NameMapping nameMapping) {
     return NameMapping.of(convertNameMapping(fileSchema, nameMapping.asMappedFields().fields()));
   }
 

--- a/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveReadConf.java
+++ b/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveReadConf.java
@@ -83,7 +83,7 @@ class AdaptHiveReadConf<T> {
       typeWithIds = fileSchema;
       this.projection = ParquetSchemaUtil.pruneColumns(fileSchema, expectedSchema);
     } else if (nameMapping != null) {
-      typeWithIds = ParquetSchemaUtil.applyNameMapping(fileSchema, convertNameMapping(fileSchema, nameMapping));
+      typeWithIds = (MessageType) ParquetTypeVisitor.visit(fileSchema, new AdaptHiveApplyNameMapping(nameMapping));
       this.projection = ParquetSchemaUtil.pruneColumns(typeWithIds, expectedSchema);
     } else {
       typeWithIds = ParquetSchemaUtil.addFallbackIds(fileSchema);

--- a/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveReadConf.java
+++ b/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveReadConf.java
@@ -19,14 +19,11 @@
 
 package org.apache.iceberg.parquet;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.mapping.MappedField;
-import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -36,7 +33,6 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -244,36 +240,5 @@ class AdaptHiveReadConf<T> {
       }
     }
     return listBuilder.build();
-  }
-
-  @VisibleForTesting
-  static NameMapping convertNameMapping(MessageType fileSchema, NameMapping nameMapping) {
-    return NameMapping.of(convertNameMapping(fileSchema, nameMapping.asMappedFields().fields()));
-  }
-
-  private static MappedFields convertNameMapping(MessageType fileSchema, MappedFields mappedFields) {
-    if (mappedFields == null) {
-      return null;
-    }
-    return MappedFields.of(convertNameMapping(fileSchema, mappedFields.fields()));
-  }
-
-  private static List<MappedField> convertNameMapping(MessageType fileSchema, List<MappedField> fields) {
-    return fields.stream()
-        .map(mappedField -> {
-          Set<String> lowercaseNames =
-              mappedField.names().stream().map(name -> {
-                for (Type t : fileSchema.getFields()) {
-                  if (t.getName().equalsIgnoreCase(name)) {
-                    return t.getName();
-                  }
-                }
-                return name;
-              }).collect(Collectors.toSet());
-          return MappedField.of(mappedField.id(), lowercaseNames, convertNameMapping(
-              fileSchema,
-              mappedField.nestedMapping()));
-        })
-        .collect(Collectors.toList());
   }
 }

--- a/hive/src/test/java/org/apache/iceberg/parquet/TestAdaptHiveReadConf.java
+++ b/hive/src/test/java/org/apache/iceberg/parquet/TestAdaptHiveReadConf.java
@@ -18,33 +18,149 @@
 
 package org.apache.iceberg.parquet;
 
-import com.google.common.collect.Lists;
-import org.apache.iceberg.mapping.MappedField;
-import org.apache.iceberg.mapping.MappedFields;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
-import org.apache.parquet.schema.Types;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
 public class TestAdaptHiveReadConf {
 
+  private static final org.apache.iceberg.types.Types.StructType SUPPORTED_PRIMITIVES =
+      org.apache.iceberg.types.Types.StructType.of(
+          required(100, "id", org.apache.iceberg.types.Types.LongType.get()),
+          optional(101, "data", org.apache.iceberg.types.Types.StringType.get()),
+          required(102, "b", org.apache.iceberg.types.Types.BooleanType.get()),
+          optional(103, "i", org.apache.iceberg.types.Types.IntegerType.get()),
+          required(104, "l", org.apache.iceberg.types.Types.LongType.get()),
+          optional(105, "f", org.apache.iceberg.types.Types.FloatType.get()),
+          required(106, "d", org.apache.iceberg.types.Types.DoubleType.get()),
+          optional(107, "date", org.apache.iceberg.types.Types.DateType.get()),
+          required(108, "ts", org.apache.iceberg.types.Types.TimestampType.withZone()),
+          required(110, "s", org.apache.iceberg.types.Types.StringType.get()),
+          required(112, "fixed", org.apache.iceberg.types.Types.FixedType.ofLength(7)),
+          optional(113, "bytes", org.apache.iceberg.types.Types.BinaryType.get()),
+          required(114, "dec_9_0", org.apache.iceberg.types.Types.DecimalType.of(9, 0)),
+          required(115, "dec_11_2", org.apache.iceberg.types.Types.DecimalType.of(11, 2)),
+          required(116, "dec_38_10", org.apache.iceberg.types.Types.DecimalType.of(38, 10)) // spark's maximum precision
+      );
+
   @Test
-  public void testConvertNameMapping() {
-    MessageType fileSchema = Types.buildMessage().addField(Types.buildGroup(Type.Repetition.OPTIONAL)
-        .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED).named("X"))
-        .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED).named("Y"))
-        .named("custom_element_name".toUpperCase())).named("table");
-    MappedFields mappedFields = MappedFields.of(Lists.newArrayList(
-        MappedField.of(2, "x"),
-        MappedField.of(3, "y")));
-    MappedField mappedField = MappedField.of(1, "custom_element_name", mappedFields);
-    NameMapping nameMapping = NameMapping.of(mappedField);
-    MessageType actual = (MessageType) ParquetTypeVisitor.visit(fileSchema, new AdaptHiveApplyNameMapping(nameMapping));
-    Assert.assertEquals("custom_element_name".toUpperCase(), actual.getFields().get(0).getName());
-    Assert.assertEquals(1, actual.getFields().get(0).getId().intValue());
-    Assert.assertEquals(2, actual.getFields().get(0).asGroupType().getType("X").getId().intValue());
+  public void testAssignIdsByNameMapping() {
+    org.apache.iceberg.types.Types.StructType hiveStructType = org.apache.iceberg.types.Types.StructType.of(
+        required(0, "id".toUpperCase(), org.apache.iceberg.types.Types.LongType.get()),
+        optional(1, "list_of_maps".toUpperCase(),
+            org.apache.iceberg.types.Types.ListType.ofOptional(
+                2,
+                org.apache.iceberg.types.Types.MapType.ofOptional(3, 4,
+                    org.apache.iceberg.types.Types.StringType.get(),
+                    SUPPORTED_PRIMITIVES))),
+        optional(5, "map_of_lists".toUpperCase(),
+            org.apache.iceberg.types.Types.MapType.ofOptional(6, 7,
+                org.apache.iceberg.types.Types.StringType.get(),
+                org.apache.iceberg.types.Types.ListType.ofOptional(8, SUPPORTED_PRIMITIVES))),
+        required(9, "list_of_lists".toUpperCase(),
+            org.apache.iceberg.types.Types.ListType.ofOptional(
+                10,
+                org.apache.iceberg.types.Types.ListType.ofOptional(11, SUPPORTED_PRIMITIVES))),
+        required(12, "map_of_maps".toUpperCase(),
+            org.apache.iceberg.types.Types.MapType.ofOptional(13, 14,
+                org.apache.iceberg.types.Types.StringType.get(),
+                org.apache.iceberg.types.Types.MapType.ofOptional(15, 16,
+                    org.apache.iceberg.types.Types.StringType.get(),
+                    SUPPORTED_PRIMITIVES))),
+        required(
+            17,
+            "list_of_struct_of_nested_types".toUpperCase(),
+            org.apache.iceberg.types.Types.ListType.ofOptional(19, org.apache.iceberg.types.Types.StructType.of(
+                org.apache.iceberg.types.Types.NestedField.required(
+                    20,
+                    "m1".toUpperCase(),
+                    org.apache.iceberg.types.Types.MapType.ofOptional(21, 22,
+                        org.apache.iceberg.types.Types.StringType.get(),
+                        SUPPORTED_PRIMITIVES)),
+                org.apache.iceberg.types.Types.NestedField.optional(
+                    23,
+                    "l1".toUpperCase(),
+                    org.apache.iceberg.types.Types.ListType.ofRequired(24, SUPPORTED_PRIMITIVES)),
+                org.apache.iceberg.types.Types.NestedField.required(
+                    25,
+                    "l2".toUpperCase(),
+                    org.apache.iceberg.types.Types.ListType.ofRequired(26, SUPPORTED_PRIMITIVES)),
+                org.apache.iceberg.types.Types.NestedField.optional(
+                    27,
+                    "m2".toUpperCase(),
+                    org.apache.iceberg.types.Types.MapType.ofOptional(28, 29,
+                        org.apache.iceberg.types.Types.StringType.get(),
+                        SUPPORTED_PRIMITIVES))
+            )))
+    );
+
+    org.apache.iceberg.types.Types.StructType structType = org.apache.iceberg.types.Types.StructType.of(
+        required(0, "id", org.apache.iceberg.types.Types.LongType.get()),
+        optional(1, "list_of_maps",
+            org.apache.iceberg.types.Types.ListType.ofOptional(
+                2,
+                org.apache.iceberg.types.Types.MapType.ofOptional(3, 4,
+                    org.apache.iceberg.types.Types.StringType.get(),
+                    SUPPORTED_PRIMITIVES))),
+        optional(5, "map_of_lists",
+            org.apache.iceberg.types.Types.MapType.ofOptional(6, 7,
+                org.apache.iceberg.types.Types.StringType.get(),
+                org.apache.iceberg.types.Types.ListType.ofOptional(8, SUPPORTED_PRIMITIVES))),
+        required(9, "list_of_lists",
+            org.apache.iceberg.types.Types.ListType.ofOptional(
+                10,
+                org.apache.iceberg.types.Types.ListType.ofOptional(11, SUPPORTED_PRIMITIVES))),
+        required(12, "map_of_maps",
+            org.apache.iceberg.types.Types.MapType.ofOptional(13, 14,
+                org.apache.iceberg.types.Types.StringType.get(),
+                org.apache.iceberg.types.Types.MapType.ofOptional(15, 16,
+                    org.apache.iceberg.types.Types.StringType.get(),
+                    SUPPORTED_PRIMITIVES))),
+        required(
+            17,
+            "list_of_struct_of_nested_types",
+            org.apache.iceberg.types.Types.ListType.ofOptional(19, org.apache.iceberg.types.Types.StructType.of(
+                org.apache.iceberg.types.Types.NestedField.required(
+                    20,
+                    "m1",
+                    org.apache.iceberg.types.Types.MapType.ofOptional(21, 22,
+                        org.apache.iceberg.types.Types.StringType.get(),
+                        SUPPORTED_PRIMITIVES)),
+                org.apache.iceberg.types.Types.NestedField.optional(
+                    23,
+                    "l1",
+                    org.apache.iceberg.types.Types.ListType.ofRequired(24, SUPPORTED_PRIMITIVES)),
+                org.apache.iceberg.types.Types.NestedField.required(
+                    25,
+                    "l2",
+                    org.apache.iceberg.types.Types.ListType.ofRequired(26, SUPPORTED_PRIMITIVES)),
+                org.apache.iceberg.types.Types.NestedField.optional(
+                    27,
+                    "m2",
+                    org.apache.iceberg.types.Types.MapType.ofOptional(28, 29,
+                        org.apache.iceberg.types.Types.StringType.get(),
+                        SUPPORTED_PRIMITIVES))
+            )))
+    );
+
+    Schema schema = new Schema(TypeUtil.assignFreshIds(structType, new AtomicInteger(0)::incrementAndGet)
+        .asStructType().fields());
+    Schema hiveSchema = new Schema(TypeUtil.assignFreshIds(hiveStructType, new AtomicInteger(0)::incrementAndGet)
+        .asStructType().fields());
+    NameMapping nameMapping = MappingUtil.create(schema);
+    MessageType messageTypeWithIds = ParquetSchemaUtil.convert(hiveSchema, "parquet_type");
+    MessageType messageTypeWithIdsFromNameMapping = (MessageType) ParquetTypeVisitor.visit(
+        RemoveIds.removeIds(messageTypeWithIds),
+        new AdaptHiveApplyNameMapping(nameMapping));
+
+    Assert.assertEquals(messageTypeWithIds, messageTypeWithIdsFromNameMapping);
   }
 }

--- a/hive/src/test/java/org/apache/iceberg/parquet/TestAdaptHiveReadConf.java
+++ b/hive/src/test/java/org/apache/iceberg/parquet/TestAdaptHiveReadConf.java
@@ -18,7 +18,9 @@
 
 package org.apache.iceberg.parquet;
 
+import com.google.common.collect.Lists;
 import org.apache.iceberg.mapping.MappedField;
+import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -31,13 +33,18 @@ public class TestAdaptHiveReadConf {
 
   @Test
   public void testConvertNameMapping() {
-    String fieldName = "Test";
-    MessageType fileSchema = Types.buildMessage().addField(Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE,
-        Type.Repetition.REQUIRED).named(fieldName)).named("table");
-    MappedField mappedField = MappedField.of(1, fieldName.toLowerCase());
+    MessageType fileSchema = Types.buildMessage().addField(Types.buildGroup(Type.Repetition.OPTIONAL)
+        .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED).named("X"))
+        .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE, Type.Repetition.REQUIRED).named("Y"))
+        .named("custom_element_name".toUpperCase())).named("table");
+    MappedFields mappedFields = MappedFields.of(Lists.newArrayList(
+        MappedField.of(2, "x"),
+        MappedField.of(3, "y")));
+    MappedField mappedField = MappedField.of(1, "custom_element_name", mappedFields);
     NameMapping nameMapping = NameMapping.of(mappedField);
-    NameMapping actual = AdaptHiveReadConf.convertNameMapping(fileSchema, nameMapping);
-    Assert.assertNotNull(actual.find(fieldName));
-    Assert.assertEquals(1, (int) actual.find(fieldName).id());
+    MessageType actual = (MessageType) ParquetTypeVisitor.visit(fileSchema, new AdaptHiveApplyNameMapping(nameMapping));
+    Assert.assertEquals("custom_element_name".toUpperCase(), actual.getFields().get(0).getName());
+    Assert.assertEquals(1, actual.getFields().get(0).getId().intValue());
+    Assert.assertEquals(2, actual.getFields().get(0).asGroupType().getType("X").getId().intValue());
   }
 }

--- a/hive/src/test/java/org/apache/iceberg/parquet/TestAdaptHiveReadConf.java
+++ b/hive/src/test/java/org/apache/iceberg/parquet/TestAdaptHiveReadConf.java
@@ -18,7 +18,6 @@
 
 package org.apache.iceberg.parquet;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
@@ -26,6 +25,8 @@ import org.apache.iceberg.types.TypeUtil;
 import org.apache.parquet.schema.MessageType;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;

--- a/hive/src/test/java/org/apache/iceberg/parquet/TestAdaptHiveReadConf.java
+++ b/hive/src/test/java/org/apache/iceberg/parquet/TestAdaptHiveReadConf.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.parquet;
+
+import org.apache.iceberg.mapping.MappedField;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestAdaptHiveReadConf {
+
+  @Test
+  public void testConvertNameMapping() {
+    String fieldName = "Test";
+    MessageType fileSchema = Types.buildMessage().addField(Types.primitive(PrimitiveType.PrimitiveTypeName.DOUBLE,
+        Type.Repetition.REQUIRED).named(fieldName)).named("table");
+    MappedField mappedField = MappedField.of(1, fieldName.toLowerCase());
+    NameMapping nameMapping = NameMapping.of(mappedField);
+    NameMapping actual = AdaptHiveReadConf.convertNameMapping(fileSchema, nameMapping);
+    Assert.assertNotNull(actual.find(fieldName));
+    Assert.assertEquals(1, (int) actual.find(fieldName).id());
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

resolve #1227 

## Brief change log

Case differences are ignored when matching parquet file schema and namemapping

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
