### PR TITLE
[ARCTIC-1167][core][hive] fix Unkeyed Table location and metadata file pattern for `Trash`

### DIFF
--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/service/impl/TrashCleanServiceTest.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/service/impl/TrashCleanServiceTest.java
@@ -21,17 +21,12 @@ package com.netease.arctic.ams.server.service.impl;
 import com.netease.arctic.TableTestBase;
 import com.netease.arctic.io.TableTrashManagers;
 import com.netease.arctic.table.ArcticTable;
-import com.netease.arctic.table.KeyedTable;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-
-import static org.junit.Assert.*;
 
 public class TrashCleanServiceTest extends TableTestBase {
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -39,13 +34,14 @@ public class TrashCleanServiceTest extends TableTestBase {
   @Test
   public void clean() {
     ArcticTable table = this.testKeyedTable;
-    String file1 = createTrashFileInDay(table, 9, "test1.parquet");
-    String file2 = createTrashFileInDay(table, 9, "test2.parquet");
-    String file3 = createTrashFileInDay(table, 9, "test/test3.parquet");
-    String file4 = createTrashFileInDay(table, 8, "test4.parquet");
-    String file5 = createTrashFileInDay(table, 7, "test5.parquet");
-    String file6 = createTrashFileInDay(table, 6, "test6.parquet");
-    String file7 = createTrashFileInDay(table, 0, "test7.parquet");
+    String trashLocation = TableTrashManagers.build(table).getTrashLocation();
+    String file1 = createTrashFileInDay(table, trashLocation, 9, "test1.parquet");
+    String file2 = createTrashFileInDay(table, trashLocation, 9, "test2.parquet");
+    String file3 = createTrashFileInDay(table, trashLocation, 9, "test/test3.parquet");
+    String file4 = createTrashFileInDay(table, trashLocation, 8, "test4.parquet");
+    String file5 = createTrashFileInDay(table, trashLocation, 7, "test5.parquet");
+    String file6 = createTrashFileInDay(table, trashLocation, 6, "test6.parquet");
+    String file7 = createTrashFileInDay(table, trashLocation, 0, "test7.parquet");
     Assert.assertTrue(table.io().exists(file1));
     Assert.assertTrue(table.io().exists(file2));
     Assert.assertTrue(table.io().exists(file3));
@@ -65,8 +61,7 @@ public class TrashCleanServiceTest extends TableTestBase {
     Assert.assertTrue(table.io().exists(file7));
   }
 
-  private String createTrashFileInDay(ArcticTable table, int day, String fileName) {
-    String trashLocation = TableTrashManagers.getTrashLocation(table.id(), table.location(), null);
+  private String createTrashFileInDay(ArcticTable table, String trashLocation, int day, String fileName) {
     String filePath = trashLocation + "/" + LocalDate.now().minusDays(day).format(DATE_FORMATTER) + "/" + fileName;
     OutputFile outputFile = table.io().newOutputFile(filePath);
     outputFile.createOrOverwrite();

--- a/core/src/main/java/com/netease/arctic/catalog/BasicArcticCatalog.java
+++ b/core/src/main/java/com/netease/arctic/catalog/BasicArcticCatalog.java
@@ -221,13 +221,14 @@ public class BasicArcticCatalog implements ArcticCatalog {
 
   protected UnkeyedTable loadUnKeyedTable(TableMeta tableMeta) {
     TableIdentifier tableIdentifier = TableIdentifier.of(tableMeta.getTableIdentifier());
+    String tableLocation = checkLocation(tableMeta, MetaTableProperties.LOCATION_KEY_TABLE);
     String baseLocation = checkLocation(tableMeta, MetaTableProperties.LOCATION_KEY_BASE);
     Table table = tableMetaStore.doAs(() -> tables.load(baseLocation));
 
-    ArcticFileIO arcticFileIO = ArcticFileIOs.buildTableFileIO(tableIdentifier, baseLocation, tableMeta.getProperties(),
+    ArcticFileIO fileIO = ArcticFileIOs.buildTableFileIO(tableIdentifier, tableLocation, tableMeta.getProperties(),
         tableMetaStore, catalogMeta.getCatalogProperties());
     return new BasicUnkeyedTable(tableIdentifier, CatalogUtil.useArcticTableOperations(table, baseLocation,
-        arcticFileIO, tableMetaStore.getConfiguration()), arcticFileIO, client, catalogMeta.getCatalogProperties());
+        fileIO, tableMetaStore.getConfiguration()), fileIO, client, catalogMeta.getCatalogProperties());
   }
 
   protected String checkLocation(TableMeta meta, String locationKey) {
@@ -644,6 +645,7 @@ public class BasicArcticCatalog implements ArcticCatalog {
 
     protected UnkeyedTable createUnKeyedTable(TableMeta meta) {
       TableIdentifier tableIdentifier = TableIdentifier.of(meta.getTableIdentifier());
+      String tableLocation = checkLocation(meta, MetaTableProperties.LOCATION_KEY_TABLE);
       String baseLocation = checkLocation(meta, MetaTableProperties.LOCATION_KEY_BASE);
 
       fillTableProperties(meta);
@@ -654,7 +656,7 @@ public class BasicArcticCatalog implements ArcticCatalog {
           throw new IllegalStateException("create table failed", e);
         }
       });
-      ArcticFileIO fileIO = ArcticFileIOs.buildTableFileIO(tableIdentifier, baseLocation, meta.getProperties(),
+      ArcticFileIO fileIO = ArcticFileIOs.buildTableFileIO(tableIdentifier, tableLocation, meta.getProperties(),
           tableMetaStore, catalogMeta.getCatalogProperties());
       return new BasicUnkeyedTable(tableIdentifier, CatalogUtil.useArcticTableOperations(table, baseLocation, fileIO,
           tableMetaStore.getConfiguration()), fileIO, client, catalogMeta.getCatalogProperties());

--- a/core/src/main/java/com/netease/arctic/io/BasicTableTrashManager.java
+++ b/core/src/main/java/com/netease/arctic/io/BasicTableTrashManager.java
@@ -178,4 +178,9 @@ class BasicTableTrashManager implements TableTrashManager {
     }
     return null;
   }
+
+  @Override
+  public String getTrashLocation() {
+    return trashLocation;
+  }
 }

--- a/core/src/main/java/com/netease/arctic/io/TableTrashManager.java
+++ b/core/src/main/java/com/netease/arctic/io/TableTrashManager.java
@@ -68,4 +68,11 @@ public interface TableTrashManager extends Serializable {
    * @param expirationDate -
    */
   void cleanFiles(LocalDate expirationDate);
+
+  /**
+   * Get the root location of table trash.
+   *
+   * @return trash root location
+   */
+  String getTrashLocation();
 }

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -192,7 +192,7 @@ public class TableProperties {
   public static final String TABLE_TRASH_FILE_PATTERN_DEFAULT = ".+\\.parquet" +
       "|.*snap-[0-9]+-[0-9]+-.+\\.avro" + // snap-1515213806302741636-1-UUID.avro
       "|.*version-hint.text" + // version-hint.text
-      "|.*V[0-9]+\\.metadata\\.json" + // V123.metadata.json
+      "|.*v[0-9]+\\.metadata\\.json" + // v123.metadata.json
       "|.*[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}-m[0-9]+\\.avro"; // UUID-m0.avro
 
   /**

--- a/core/src/test/java/com/netease/arctic/io/BasicTableTrashManagerTest.java
+++ b/core/src/test/java/com/netease/arctic/io/BasicTableTrashManagerTest.java
@@ -35,9 +35,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+
 public class BasicTableTrashManagerTest extends TableTestBase {
   public BasicTableTrashManagerTest() {
-    super(TableFormat.MIXED_ICEBERG, true, true);
+    super(TableFormat.MIXED_ICEBERG, false, true);
   }
 
   @Rule
@@ -55,8 +56,7 @@ public class BasicTableTrashManagerTest extends TableTestBase {
   @Test
   public void testDeleteAndRestore() {
     TableTrashManager tableTrashManager = TableTrashManagers.build(getArcticTable());
-    String trashLocation =
-        TableTrashManagers.getTrashLocation(getArcticTable().id(), getArcticTable().location(), null);
+    String trashLocation = tableTrashManager.getTrashLocation();
 
     String relativeFilePath = "base/test/test1.parquet";
     String path = createFile(getArcticTable().io(), getArcticTable().location() + File.separator + relativeFilePath);
@@ -96,8 +96,7 @@ public class BasicTableTrashManagerTest extends TableTestBase {
   @Test
   public void testDeleteDirectory() {
     TableTrashManager tableTrashManager = TableTrashManagers.build(getArcticTable());
-    String trashLocation =
-        TableTrashManagers.getTrashLocation(getArcticTable().id(), getArcticTable().location(), null);
+    String trashLocation = tableTrashManager.getTrashLocation();
     String relativeFilePath = "base/test/test1.parquet";
     String path = createFile(getArcticTable().io(), getArcticTable().location() + File.separator + relativeFilePath);
 
@@ -117,8 +116,7 @@ public class BasicTableTrashManagerTest extends TableTestBase {
   @Test
   public void testRestoreDirectory() {
     TableTrashManager tableTrashManager = TableTrashManagers.build(getArcticTable());
-    String trashLocation =
-        TableTrashManagers.getTrashLocation(getArcticTable().id(), getArcticTable().location(), null);
+    String trashLocation = tableTrashManager.getTrashLocation();
     String relativeFilePath = "base/test/test1.parquet";
     String path = createFile(getArcticTable().io(), getArcticTable().location() + File.separator + relativeFilePath);
 
@@ -148,8 +146,7 @@ public class BasicTableTrashManagerTest extends TableTestBase {
   @Test
   public void testCleanFiles() {
     BasicTableTrashManager tableTrashManager = ((BasicTableTrashManager) TableTrashManagers.build(getArcticTable()));
-    String trashLocation =
-        TableTrashManagers.getTrashLocation(getArcticTable().id(), getArcticTable().location(), null);
+    String trashLocation = tableTrashManager.getTrashLocation();
     String file1 = getArcticTable().location() + File.separator + "base/test/test1.parquet";
     String file2 = getArcticTable().location() + File.separator + "base/test/test2.parquet";
     String file3 = getArcticTable().location() + File.separator + "base/test3/test3.parquet";

--- a/core/src/test/java/com/netease/arctic/io/BuildTableTrashManagerTest.java
+++ b/core/src/test/java/com/netease/arctic/io/BuildTableTrashManagerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.io;
+
+import com.netease.arctic.ams.api.properties.TableFormat;
+import com.netease.arctic.catalog.TableTestBase;
+import com.netease.arctic.table.TableIdentifier;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.netease.arctic.ams.api.properties.CatalogMetaProperties.KEY_WAREHOUSE;
+
+@RunWith(Parameterized.class)
+public class BuildTableTrashManagerTest extends TableTestBase {
+
+  public BuildTableTrashManagerTest(TableFormat testFormat, boolean keyedTable, boolean partitionedTable) {
+    super(testFormat, keyedTable, partitionedTable);
+  }
+
+  @Parameterized.Parameters(name = "testFormat = {0}, keyedTable = {1}, partitionedTable = {2}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        {TableFormat.MIXED_ICEBERG, true, true},
+        {TableFormat.MIXED_ICEBERG, true, false},
+        {TableFormat.MIXED_ICEBERG, false, true},
+        {TableFormat.MIXED_ICEBERG, false, false}};
+  }
+
+  @Test
+  public void build() {
+    TableIdentifier id = getArcticTable().id();
+    TableTrashManager trashManager = TableTrashManagers.build(getArcticTable());
+    Assert.assertEquals(id, trashManager.tableId());
+    Assert.assertEquals(getTableTrashLocation(id), trashManager.getTrashLocation());
+  }
+
+  private String getTableTrashLocation(TableIdentifier id) {
+    String catalogDir = getCatalogMeta().getCatalogProperties().get(KEY_WAREHOUSE);
+    return String.format("%s/%s/%s/%s", catalogDir, id.getDatabase(), id.getTableName(),
+        TableTrashManagers.DEFAULT_TRASH_DIR);
+  }
+
+}

--- a/core/src/test/java/com/netease/arctic/io/RecoverableArcticFileIOTest.java
+++ b/core/src/test/java/com/netease/arctic/io/RecoverableArcticFileIOTest.java
@@ -145,6 +145,8 @@ public class RecoverableArcticFileIOTest extends TableTestBase {
     Assert.assertTrue(recoverableArcticFileIO.matchTrashFilePattern(getArcticTable().location() +
         "/metadata/version-hint.text"));
     Assert.assertTrue(recoverableArcticFileIO.matchTrashFilePattern(getArcticTable().location() +
+        "/metadata/v2.metadata.json"));
+    Assert.assertTrue(recoverableArcticFileIO.matchTrashFilePattern(getArcticTable().location() +
         "/metadata/snap-1515213806302741636-1-85fc817e-941d-4e9a-ab41-2dbf7687bfcd.avro"));
     Assert.assertTrue(recoverableArcticFileIO.matchTrashFilePattern(getArcticTable().location() +
         "/metadata/3ce7600d-4853-45d0-8533-84c12a611916-m0.avro"));

--- a/core/src/test/java/com/netease/arctic/io/TableTrashManagersTest.java
+++ b/core/src/test/java/com/netease/arctic/io/TableTrashManagersTest.java
@@ -33,4 +33,12 @@ public class TableTrashManagersTest {
     Assert.assertEquals(String.format("/tmp/xxx/%s/%s/%s/.trash", id.getCatalog(), id.getDatabase(), id.getTableName()),
         TableTrashManagers.getTrashLocation(id, "/table/location", "/tmp/xxx"));
   }
+
+  @Test
+  public void getTrashParentLocation() {
+    TableIdentifier id = TableTestHelpers.TEST_TABLE_ID;
+    String trashParentLocation = TableTrashManagers.getTrashParentLocation(id, "/tmp/xxx");
+    Assert.assertEquals(String.format("/tmp/xxx/%s/%s/%s", id.getCatalog(), id.getDatabase(), id.getTableName()),
+        trashParentLocation);
+  }
 }

--- a/hive/src/test/java/com/netease/arctic/hive/io/BuildHiveTableTrashManagerTest.java
+++ b/hive/src/test/java/com/netease/arctic/hive/io/BuildHiveTableTrashManagerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.hive.io;
+
+import com.netease.arctic.hive.catalog.HiveTableTestBase;
+import com.netease.arctic.io.TableTrashManager;
+import com.netease.arctic.io.TableTrashManagers;
+import com.netease.arctic.table.TableIdentifier;
+import org.apache.thrift.TException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class BuildHiveTableTrashManagerTest extends HiveTableTestBase {
+
+  public BuildHiveTableTrashManagerTest(boolean keyedTable,
+                                        boolean partitionedTable) {
+    super(keyedTable, partitionedTable);
+  }
+
+  @Parameterized.Parameters(name = "keyedTable = {0}, partitionedTable = {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        {true, true},
+        {true, false},
+        {false, true},
+        {false, false}};
+  }
+
+  @Test
+  public void build() throws TException {
+    TableIdentifier id = getArcticTable().id();
+    TableTrashManager trashManager = TableTrashManagers.build(getArcticTable());
+    Assert.assertEquals(id, trashManager.tableId());
+    Assert.assertEquals(getTableTrashLocation(id), trashManager.getTrashLocation());
+  }
+
+  private String getTableTrashLocation(TableIdentifier id) throws TException {
+    String databaseLocation = TEST_HMS.getHiveClient().getDatabase(id.getDatabase()).getLocationUri();
+    return String.format("%s/%s/%s", databaseLocation, id.getTableName(),
+        TableTrashManagers.DEFAULT_TRASH_DIR);
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1167 

## Brief change log

  - Unkeyed Table's location is the base location, and the parent location should be used as the Trash location
  - for metadata file, the file pattern should be `v123.metadata.json` instream of `V123.metadata.json`

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
