### PR TITLE
[ARCTIC-1231] Add a timeout strategy to avoid blocking the UTs ArcticSourceTest

### DIFF
--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
@@ -67,6 +67,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,6 +90,9 @@ public class FlinkTestBase extends TableTestBase {
   @ClassRule
   public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
       MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @Rule
+  public TestName name = new TestName();
 
   public static boolean IS_LOCAL = true;
   public static String METASTORE_URL = "thrift://127.0.0.1:" + AMS.port();

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -69,7 +69,6 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
-import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.TypeUtil;
@@ -122,6 +121,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
   protected static final String sinkTableName = "test_sink_exactly_once";
   protected static final TableIdentifier FAIL_TABLE_ID =
       TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, sinkTableName);
+
 
   @Before
   public void testSetup() throws IOException {
@@ -342,22 +342,22 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_keyed_tb");
     KeyedTable table = testCatalog
-      .newTableBuilder(tableId, TABLE_SCHEMA)
-      .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
-      .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
-      .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
-      .create().asKeyedTable();
+        .newTableBuilder(tableId, TABLE_SCHEMA)
+        .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+        .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
+        .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+        .create().asKeyedTable();
 
     TaskWriter<RowData> taskWriter = createTaskWriter(table, false);
     List<RowData> changeData = new ArrayList<RowData>() {{
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+          RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+          RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+          RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+          RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
     }};
     for (RowData record : changeData) {
       taskWriter.write(record);
@@ -372,7 +372,9 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
       Assert.assertTrue(table.io().exists(dataFile.path().toString()));
     }
 
-    ArcticSource<RowData> arcticSource = initArcticSource(true, SCAN_STARTUP_MODE_EARLIEST, tableId);
+    final Duration monitorInterval = Duration.ofSeconds(1);
+    ArcticSource<RowData> arcticSource =
+        initArcticSourceWithMonitorInterval(true, SCAN_STARTUP_MODE_EARLIEST, tableId, monitorInterval);
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     // enable checkpoint
     env.enableCheckpointing(1000);
@@ -394,7 +396,10 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     LOG.info("commit empty snapshot");
     AppendFiles changeAppend = table.changeTable().newAppend();
     changeAppend.commit();
-    Thread.sleep(ScanContext.MONITOR_INTERVAL.defaultValue().toMillis() * 2);
+
+    final long timeWait = (monitorInterval.toMillis() * 2);
+    LOG.info("try sleep {}, wait snapshot expired and scan the empty snapshot.", timeWait);
+    Thread.sleep(timeWait);
 
     expireSnapshots(table.changeTable(), System.currentTimeMillis(), new HashSet<>());
 
@@ -413,22 +418,22 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_keyed_tb");
     KeyedTable table = testCatalog
-      .newTableBuilder(tableId, TABLE_SCHEMA)
-      .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
-      .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
-      .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
-      .create().asKeyedTable();
+        .newTableBuilder(tableId, TABLE_SCHEMA)
+        .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+        .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
+        .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+        .create().asKeyedTable();
 
     TaskWriter<RowData> taskWriter = createTaskWriter(table, true);
     List<RowData> baseData = new ArrayList<RowData>() {{
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+          RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+          RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+          RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+          RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
     }};
     for (RowData record : baseData) {
       taskWriter.write(record);
@@ -443,7 +448,9 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
       Assert.assertTrue(table.io().exists(dataFile.path().toString()));
     }
 
-    ArcticSource<RowData> arcticSource = initArcticSource(true, SCAN_STARTUP_MODE_EARLIEST, tableId);
+    final Duration monitorInterval = Duration.ofSeconds(1);
+    ArcticSource<RowData> arcticSource =
+        initArcticSourceWithMonitorInterval(true, SCAN_STARTUP_MODE_EARLIEST, tableId, monitorInterval);
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     // enable checkpoint
     env.enableCheckpointing(1000);
@@ -465,7 +472,10 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     LOG.info("commit empty snapshot");
     AppendFiles changeAppend = table.changeTable().newAppend();
     changeAppend.commit();
-    Thread.sleep(ScanContext.MONITOR_INTERVAL.defaultValue().toMillis() * 2);
+
+    final long timeWait = (monitorInterval.toMillis() * 2);
+    LOG.info("try sleep {}, wait snapshot expired and scan the empty snapshot.", timeWait);
+    Thread.sleep(timeWait);
 
     expireSnapshots(table.baseTable(), System.currentTimeMillis(), new HashSet<>());
 
@@ -635,17 +645,62 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final ArrayList<RowData> result = new ArrayList<>(numElements);
     final Iterator<RowData> iterator = client.iterator;
 
-    while (iterator.hasNext()) {
-      result.add(convert(iterator.next()));
-      if (result.size() == numElements) {
-        return result;
+    CollectTask collectTask = new CollectTask(result, iterator, numElements);
+    new Thread(collectTask).start();
+
+    long start = System.currentTimeMillis();
+    final long timeout = 60 * 1000;
+    long intervalOneSecond = 1;
+    while (collectTask.running) {
+      // TODO a more proper timeout strategy?
+      long timeFlies = System.currentTimeMillis() - start;
+      if (timeFlies / 1000 >= intervalOneSecond) {
+        LOG.info("time flies: {} ms.", timeFlies);
+        intervalOneSecond++;
+      }
+      if (System.currentTimeMillis() - start > timeout) {
+        LOG.error(
+            "this task [{}] try to collect records from unbounded stream but timeout {}. As of now, collect result:{}.",
+            client.client.getJobID().toString(),
+            timeout,
+            result.toArray());
+        break;
       }
     }
 
-    throw new IllegalArgumentException(
+    Assert.assertEquals(
         String.format(
-            "The stream ended before reaching the requested %d records. Only %d records were received.",
-            numElements, result.size()));
+            "The stream ended before reaching the requested %d records. Only %d records were received, received list:%s.",
+            numElements, result.size(), Arrays.toString(result.toArray())),
+        numElements,
+        result.size());
+
+    return result;
+  }
+
+  private static class CollectTask implements Runnable {
+    final ArrayList<RowData> result;
+    final Iterator<RowData> iterator;
+    final int limit;
+
+    boolean running = true;
+
+    public CollectTask(ArrayList<RowData> result, Iterator<RowData> iterator, int limit) {
+      this.result = result;
+      this.iterator = iterator;
+      this.limit = limit;
+    }
+
+    @Override
+    public void run() {
+      while (iterator.hasNext()) {
+        result.add(convert(iterator.next()));
+        if (result.size() == limit) {
+          running = false;
+          return;
+        }
+      }
+    }
   }
 
   private ClientAndIterator<RowData> executeAndCollectWithClient(
@@ -656,7 +711,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
                 WatermarkStrategy.noWatermarks(),
                 "ArcticParallelSource")
             .setParallelism(PARALLELISM);
-    return DataStreamUtils.collectWithClient(source, "testUpdateSnapshot");
+    return DataStreamUtils.collectWithClient(source, "job_" + name.getMethodName());
   }
 
   private static GenericRowData convert(RowData row) {
@@ -675,23 +730,23 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final AtomicInteger deleteFiles = new AtomicInteger(0);
     Set<String> parentDirectory = new HashSet<>();
     arcticInternalTable.expireSnapshots()
-      .retainLast(1)
-      .expireOlderThan(olderThan)
-      .deleteWith(file -> {
-        try {
-          if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
-            arcticInternalTable.io().deleteFile(file);
+        .retainLast(1)
+        .expireOlderThan(olderThan)
+        .deleteWith(file -> {
+          try {
+            if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
+              arcticInternalTable.io().deleteFile(file);
+            }
+            parentDirectory.add(new Path(file).getParent().toString());
+            deleteFiles.incrementAndGet();
+          } catch (Throwable t) {
+            LOG.warn("failed to delete file " + file, t);
+          } finally {
+            toDeleteFiles.incrementAndGet();
           }
-          parentDirectory.add(new Path(file).getParent().toString());
-          deleteFiles.incrementAndGet();
-        } catch (Throwable t) {
-          LOG.warn("failed to delete file " + file, t);
-        } finally {
-          toDeleteFiles.incrementAndGet();
-        }
-      })
-      .cleanExpiredFiles(true)
-      .commit();
+        })
+        .cleanExpiredFiles(true)
+        .commit();
     parentDirectory.forEach(parent -> TableFileUtils.deleteEmptyDirectory(arcticInternalTable.io(), parent, exclude));
     LOG.info("to delete {} files, success delete {} files", toDeleteFiles.get(), deleteFiles.get());
   }
@@ -719,10 +774,13 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         false);
   }
 
-  private ArcticSource<RowData> initArcticSource(boolean isStreaming, String scanStartupMode,
-                                                 TableIdentifier tableIdentifier) {
+  private ArcticSource<RowData> initArcticSourceWithMonitorInterval(
+      boolean isStreaming,
+      String scanStartupMode,
+      TableIdentifier tableIdentifier,
+      Duration monitorInterval) {
     ArcticTableLoader tableLoader = ArcticTableLoader.of(tableIdentifier, catalogBuilder);
-    ArcticScanContext arcticScanContext = initArcticScanContext(isStreaming, scanStartupMode);
+    ArcticScanContext arcticScanContext = initArcticScanContext(isStreaming, scanStartupMode, monitorInterval);
     ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
     ReaderFunction<RowData> rowDataReaderFunction = initRowDataReadFunction(table.asKeyedTable());
     TypeInformation<RowData> typeInformation = InternalTypeInfo.of(FlinkSchemaUtil.convert(table.schema()));
@@ -734,6 +792,11 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         typeInformation,
         table.name(),
         false);
+  }
+
+  private ArcticSource<RowData> initArcticSource(boolean isStreaming, String scanStartupMode,
+                                                 TableIdentifier tableIdentifier) {
+    return initArcticSourceWithMonitorInterval(isStreaming, scanStartupMode, tableIdentifier, Duration.ofMillis(500));
   }
 
   private ArcticSource<RowData> initArcticDimSource(boolean isStreaming) {
@@ -768,6 +831,11 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         true,
         keyedTable.io()
     );
+  }
+
+  private ArcticScanContext initArcticScanContext(boolean isStreaming, String scanStartupMode, Duration monitorInterval) {
+    return ArcticScanContext.arcticBuilder().streaming(isStreaming).scanStartupMode(scanStartupMode)
+        .monitorInterval(monitorInterval).build();
   }
 
   private ArcticScanContext initArcticScanContext(boolean isStreaming, String scanStartupMode) {

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
@@ -67,6 +67,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,6 +91,9 @@ public class FlinkTestBase extends TableTestBase {
   @ClassRule
   public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
       MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @Rule
+  public TestName name = new TestName();
 
   public static boolean IS_LOCAL = true;
   public static String METASTORE_URL = "thrift://127.0.0.1:" + AMS.port();

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/FlinkTestBase.java
@@ -67,6 +67,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,6 +91,9 @@ public class FlinkTestBase extends TableTestBase {
   @ClassRule
   public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
       MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @Rule
+  public TestName name = new TestName();
 
   public static boolean IS_LOCAL = true;
   public static String METASTORE_URL = "thrift://127.0.0.1:" + AMS.port();

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/ArcticSourceTest.java
@@ -69,7 +69,6 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
-import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.TypeUtil;
@@ -342,22 +341,22 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_keyed_tb");
     KeyedTable table = testCatalog
-      .newTableBuilder(tableId, TABLE_SCHEMA)
-      .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
-      .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
-      .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
-      .create().asKeyedTable();
+        .newTableBuilder(tableId, TABLE_SCHEMA)
+        .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+        .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
+        .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+        .create().asKeyedTable();
 
     TaskWriter<RowData> taskWriter = createTaskWriter(table, false);
     List<RowData> changeData = new ArrayList<RowData>() {{
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+          RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+          RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+          RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+          RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
     }};
     for (RowData record : changeData) {
       taskWriter.write(record);
@@ -372,7 +371,9 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
       Assert.assertTrue(table.io().exists(dataFile.path().toString()));
     }
 
-    ArcticSource<RowData> arcticSource = initArcticSource(true, SCAN_STARTUP_MODE_EARLIEST, tableId);
+    final Duration monitorInterval = Duration.ofSeconds(1);
+    ArcticSource<RowData> arcticSource =
+        initArcticSourceWithMonitorInterval(true, SCAN_STARTUP_MODE_EARLIEST, tableId, monitorInterval);
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     // enable checkpoint
     env.enableCheckpointing(1000);
@@ -394,7 +395,10 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     LOG.info("commit empty snapshot");
     AppendFiles changeAppend = table.changeTable().newAppend();
     changeAppend.commit();
-    Thread.sleep(ScanContext.MONITOR_INTERVAL.defaultValue().toMillis() * 2);
+
+    final long timeWait = (monitorInterval.toMillis() * 2);
+    LOG.info("try sleep {}, wait snapshot expired and scan the empty snapshot.", timeWait);
+    Thread.sleep(timeWait);
 
     expireSnapshots(table.changeTable(), System.currentTimeMillis(), new HashSet<>());
 
@@ -413,22 +417,22 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final String MAX_CONTINUOUS_EMPTY_COMMITS = "flink.max-continuous-empty-commits";
     TableIdentifier tableId = TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, "test_keyed_tb");
     KeyedTable table = testCatalog
-      .newTableBuilder(tableId, TABLE_SCHEMA)
-      .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
-      .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
-      .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
-      .create().asKeyedTable();
+        .newTableBuilder(tableId, TABLE_SCHEMA)
+        .withProperty(TableProperties.LOCATION, tableDir.getPath() + "/" + tableId.getTableName())
+        .withProperty(MAX_CONTINUOUS_EMPTY_COMMITS, "1")
+        .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+        .create().asKeyedTable();
 
     TaskWriter<RowData> taskWriter = createTaskWriter(table, true);
     List<RowData> baseData = new ArrayList<RowData>() {{
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
+          RowKind.INSERT, 1, StringData.fromString("john"), TimestampData.fromLocalDateTime(ldt)));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
+          RowKind.INSERT, 2, StringData.fromString("lily"), TimestampData.fromLocalDateTime(ldt)));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+          RowKind.INSERT, 3, StringData.fromString("jake"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
       add(GenericRowData.ofKind(
-        RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
+          RowKind.INSERT, 4, StringData.fromString("sam"), TimestampData.fromLocalDateTime(ldt.plusDays(1))));
     }};
     for (RowData record : baseData) {
       taskWriter.write(record);
@@ -443,7 +447,9 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
       Assert.assertTrue(table.io().exists(dataFile.path().toString()));
     }
 
-    ArcticSource<RowData> arcticSource = initArcticSource(true, SCAN_STARTUP_MODE_EARLIEST, tableId);
+    final Duration monitorInterval = Duration.ofSeconds(1);
+    ArcticSource<RowData> arcticSource =
+        initArcticSourceWithMonitorInterval(true, SCAN_STARTUP_MODE_EARLIEST, tableId, monitorInterval);
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     // enable checkpoint
     env.enableCheckpointing(1000);
@@ -465,7 +471,10 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     LOG.info("commit empty snapshot");
     AppendFiles changeAppend = table.changeTable().newAppend();
     changeAppend.commit();
-    Thread.sleep(ScanContext.MONITOR_INTERVAL.defaultValue().toMillis() * 2);
+
+    final long timeWait = (monitorInterval.toMillis() * 2);
+    LOG.info("try sleep {}, wait snapshot expired and scan the empty snapshot.", timeWait);
+    Thread.sleep(timeWait);
 
     expireSnapshots(table.baseTable(), System.currentTimeMillis(), new HashSet<>());
 
@@ -669,7 +678,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
   }
 
   private List<RowData> collectRecordsFromUnboundedStream(
-      final ClientAndIterator<RowData> client, final int numElements) {
+      final ClientAndIterator<RowData> client, final int numElements) throws InterruptedException {
 
     checkNotNull(client, "client");
     checkArgument(numElements > 0, "numElement must be > 0");
@@ -677,17 +686,66 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final ArrayList<RowData> result = new ArrayList<>(numElements);
     final Iterator<RowData> iterator = client.iterator;
 
-    while (iterator.hasNext()) {
-      result.add(convert(iterator.next()));
-      if (result.size() == numElements) {
-        return result;
+    LOG.info("begin collect records by the UT {}, ", name.getMethodName());
+
+    CollectTask collectTask = new CollectTask(result, iterator, numElements);
+    new Thread(collectTask).start();
+
+    long start = System.currentTimeMillis();
+    final long timeout = 60 * 1000;
+    long intervalOneSecond = 1;
+    while (collectTask.running) {
+      // TODO a more proper timeout strategy?
+      long timeFlies = System.currentTimeMillis() - start;
+      if (timeFlies / 1000 >= intervalOneSecond) {
+        LOG.info("time flies: {} ms.", timeFlies);
+        intervalOneSecond++;
+      }
+      Thread.sleep(10);
+      if (timeFlies > timeout) {
+        LOG.error(
+            "this task [{}] try to collect records from unbounded stream but timeout {}. As of now, collect result:{}.",
+            client.client.getJobID().toString(),
+            timeout,
+            result.toArray());
+        break;
       }
     }
 
-    throw new IllegalArgumentException(
+    Assert.assertEquals(
         String.format(
-            "The stream ended before reaching the requested %d records. Only %d records were received.",
-            numElements, result.size()));
+            "The stream ended before reaching the requested %d records. Only %d records were received, received list:%s.",
+            numElements, result.size(), Arrays.toString(result.toArray())),
+        numElements,
+        result.size());
+
+    return result;
+  }
+
+  private static class CollectTask implements Runnable {
+    final ArrayList<RowData> result;
+    final Iterator<RowData> iterator;
+    final int limit;
+
+    boolean running = true;
+
+    public CollectTask(ArrayList<RowData> result, Iterator<RowData> iterator, int limit) {
+      this.result = result;
+      this.iterator = iterator;
+      this.limit = limit;
+    }
+
+    @Override
+    public void run() {
+      while (iterator.hasNext()) {
+        result.add(convert(iterator.next()));
+        LOG.info("collected records size:{}.", result.size());
+        if (result.size() == limit) {
+          running = false;
+          return;
+        }
+      }
+    }
   }
 
   private ClientAndIterator<RowData> executeAndCollectWithClient(
@@ -698,7 +756,7 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
                 WatermarkStrategy.noWatermarks(),
                 "ArcticParallelSource")
             .setParallelism(PARALLELISM);
-    return DataStreamUtils.collectWithClient(source, "testUpdateSnapshot");
+    return DataStreamUtils.collectWithClient(source, "job_" + name.getMethodName());
   }
 
   private static GenericRowData convert(RowData row) {
@@ -717,23 +775,23 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
     final AtomicInteger deleteFiles = new AtomicInteger(0);
     Set<String> parentDirectory = new HashSet<>();
     arcticInternalTable.expireSnapshots()
-      .retainLast(1)
-      .expireOlderThan(olderThan)
-      .deleteWith(file -> {
-        try {
-          if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
-            arcticInternalTable.io().deleteFile(file);
+        .retainLast(1)
+        .expireOlderThan(olderThan)
+        .deleteWith(file -> {
+          try {
+            if (!exclude.contains(file) && !exclude.contains(new Path(file).getParent().toString())) {
+              arcticInternalTable.io().deleteFile(file);
+            }
+            parentDirectory.add(new Path(file).getParent().toString());
+            deleteFiles.incrementAndGet();
+          } catch (Throwable t) {
+            LOG.warn("failed to delete file " + file, t);
+          } finally {
+            toDeleteFiles.incrementAndGet();
           }
-          parentDirectory.add(new Path(file).getParent().toString());
-          deleteFiles.incrementAndGet();
-        } catch (Throwable t) {
-          LOG.warn("failed to delete file " + file, t);
-        } finally {
-          toDeleteFiles.incrementAndGet();
-        }
-      })
-      .cleanExpiredFiles(true)
-      .commit();
+        })
+        .cleanExpiredFiles(true)
+        .commit();
     parentDirectory.forEach(parent -> TableFileUtils.deleteEmptyDirectory(arcticInternalTable.io(), parent, exclude));
     LOG.info("to delete {} files, success delete {} files", toDeleteFiles.get(), deleteFiles.get());
   }
@@ -761,10 +819,13 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         false);
   }
 
-  private ArcticSource<RowData> initArcticSource(boolean isStreaming, String scanStartupMode,
-                                                 TableIdentifier tableIdentifier) {
+  private ArcticSource<RowData> initArcticSourceWithMonitorInterval(
+      boolean isStreaming,
+      String scanStartupMode,
+      TableIdentifier tableIdentifier,
+      Duration monitorInterval) {
     ArcticTableLoader tableLoader = ArcticTableLoader.of(tableIdentifier, catalogBuilder);
-    ArcticScanContext arcticScanContext = initArcticScanContext(isStreaming, scanStartupMode);
+    ArcticScanContext arcticScanContext = initArcticScanContext(isStreaming, scanStartupMode, monitorInterval);
     ArcticTable table = ArcticUtils.loadArcticTable(tableLoader);
     ReaderFunction<RowData> rowDataReaderFunction = initRowDataReadFunction(table.asKeyedTable());
     TypeInformation<RowData> typeInformation = InternalTypeInfo.of(FlinkSchemaUtil.convert(table.schema()));
@@ -776,6 +837,11 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         typeInformation,
         table.name(),
         false);
+  }
+
+  private ArcticSource<RowData> initArcticSource(boolean isStreaming, String scanStartupMode,
+                                                 TableIdentifier tableIdentifier) {
+    return initArcticSourceWithMonitorInterval(isStreaming, scanStartupMode, tableIdentifier, Duration.ofMillis(500));
   }
 
   private ArcticSource<RowData> initArcticDimSource(boolean isStreaming) {
@@ -810,6 +876,11 @@ public class ArcticSourceTest extends RowDataReaderFunctionTest implements Seria
         true,
         keyedTable.io()
     );
+  }
+
+  private ArcticScanContext initArcticScanContext(boolean isStreaming, String scanStartupMode, Duration monitorInterval) {
+    return ArcticScanContext.arcticBuilder().streaming(isStreaming).scanStartupMode(scanStartupMode)
+        .monitorInterval(monitorInterval).build();
   }
 
   private ArcticScanContext initArcticScanContext(boolean isStreaming, String scanStartupMode) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix: #1231  
## Brief change log

  - *Add a timeout strategy to the ArcticSourceTest in the flink modules*
  - *The flink 1.12, 1.14, and 1.15 versions are affected.*
  - *Add some logs to help locate the problem*
  - *Reduce the processing time during executing the ArctciSourceTest UTs*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no) no 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no
