### PR TITLE
[ARCTIC-1243][Spark]ArcticSparkCatalog supports the configuration of catalog properties

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkCatalog.java
@@ -417,7 +417,7 @@ public class ArcticSparkCatalog implements TableCatalog, SupportsNamespaces {
     if (StringUtils.isBlank(catalogUrl)) {
       throw new IllegalArgumentException("lack required properties: url");
     }
-    catalog = CatalogLoader.load(catalogUrl, Maps.newHashMap());
+    catalog = CatalogLoader.load(catalogUrl, options);
   }
 
   @Override

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -140,6 +140,7 @@ public class SparkTestContext extends ExternalResource {
 
     configs.put("spark.sql.catalog." + catalogNameArctic, ArcticSparkCatalog.class.getName());
     configs.put("spark.sql.catalog." + catalogNameArctic + ".url", amsUrl + "/" + catalogNameArctic);
+    configs.put("spark.sql.catalog." + catalogNameArctic + ".auth.load-from-ams", "false");
     return configs;
   }
 
@@ -172,6 +173,7 @@ public class SparkTestContext extends ExternalResource {
 
     configs.put("spark.sql.catalog." + catalogNameHive, ArcticSparkCatalog.class.getName());
     configs.put("spark.sql.catalog." + catalogNameHive + ".url", amsUrl + "/" + catalogNameHive);
+    configs.put("spark.sql.catalog." + catalogNameHive + ".auth.load-from-ams", "false");
     return configs;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

resolve #1243 

Previously, the Spark client was not allowed to pass the Catalog configuration except for the catalog url, but now it supports the configuration of catalog properties in spark-default.conf like this:
spark.sql.catalog.arctic_catalog.auth.load-from-ams = false.

## Brief change log

change initialize() in ArcticSparkCatalog

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
