### PR TITLE
[ARCTIC-1238][Flink] Remove the code that sets the UID.Solve the problem of UID conflicts in a multi-sink scenario

### DIFF
--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -157,13 +157,11 @@ public class FlinkSink {
               new ArcticWriter<>(logWriter, fileWriter, metricsGenerator))
           .name(String.format("ArcticWriter %s(%s)", table.name(), arcticEmitMode))
           .setParallelism(writeOperatorParallelism);
-      context.generateUid("arctic-writer").ifPresent(writerStream::uid);
 
       if (committer != null) {
         writerStream = writerStream.transform(FILES_COMMITTER_NAME, Types.VOID, committer)
             .setParallelism(1)
             .setMaxParallelism(1);
-        context.generateUid("arctic-committer").ifPresent(writerStream::uid);
       }
 
       return writerStream.addSink(new DiscardingSink<>())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

resolve https://github.com/NetEase/arctic/issues/1238
## Brief change log
Remove code from the `withEmit `method in the `FlinkSink `class
`context.generateUid("arctic-writer").ifPresent(writerStream::uid);`
`context.generateUid("arctic-committer").ifPresent(writerStream::uid);`

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
