### PR TITLE
[ARCTCI-1255][Spark]Fix bug: When using session catalog , load table will throw exception

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
@@ -116,7 +116,7 @@ public class ArcticSparkSessionCatalog<T extends TableCatalog & SupportsNamespac
   public Table loadTable(Identifier ident) throws NoSuchTableException {
     Table table = getSessionCatalog().loadTable(ident);
     if (isArcticTable(table)) {
-      return arcticCatalog.loadTable(ident);
+      return getArcticCatalog().loadTable(ident);
     }
     return table;
   }

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
@@ -294,4 +294,20 @@ public class TestArcticSessionCatalog extends SparkTestContext {
     sql("drop table {0}.{1}", database, table);
   }
 
+  @Test
+  public void testLoadTable() throws TException {
+    sql("use {0}", catalogNameHive);
+    sql("create table {0}.{1} ( id int, data string) using arctic", database, table_D);
+    sql("insert overwrite {0}.{1} values \n" +
+        "(1, ''aaa''), \n " +
+        "(2, ''bbb''), \n " +
+        "(3, ''ccc'') \n ", database, table_D);
+    Table tableA = hms.getClient().getTable(database, table_D);
+    Assert.assertNotNull(tableA);
+    sql("use spark_catalog");
+    rows = sql("select * from {0}.{1}", database, table_D);
+    Assert.assertEquals(rows.size(), 3);
+    sql("drop table {0}.{1}", database, table_D);
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix #1255 
When using ArcticSparkSessionCatalog, skip the table creation and then execute the query existing tables directly, it will throw NPE.
This problem caused by the arcticCatalog not initialized
This pr needs to cherry-pick to the 0.3.x

## Brief change log

The change is in the com.netease.arctic.spark.ArcticSparkSessionCatalog#loadTable()


## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
