### PR TITLE
[Arctic-1266][AMS]: Use ArcticSparkSessionCatalog for terminal

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/SparkContextUtil.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/SparkContextUtil.java
@@ -19,8 +19,10 @@
 package com.netease.arctic.ams.server.terminal;
 
 import com.netease.arctic.ams.server.config.Configuration;
+import com.netease.arctic.ams.server.utils.CatalogUtil;
 import com.netease.arctic.spark.ArcticSparkCatalog;
 import com.netease.arctic.spark.ArcticSparkExtensions;
+import com.netease.arctic.spark.ArcticSparkSessionCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions;
@@ -50,8 +52,16 @@ public class SparkContextUtil {
           sparkConf.put("spark.sql.catalog." + catalog + "." + key, property);
         }
       } else {
-        sparkConf.put("spark.sql.catalog." + catalog, ArcticSparkCatalog.class.getName());
-        sparkConf.put("spark.sql.catalog." + catalog + ".url", catalogUrlBase + catalog);
+        String sparkCatalogPrefix = "spark.sql.catalog." + catalog;
+        String catalogClassName = ArcticSparkCatalog.class.getName();
+        if (sessionConfig.getBoolean(
+            TerminalSessionFactory.SessionConfigOptions.USING_SESSION_CATALOG_FOR_HIVE) &&
+            CatalogUtil.isHiveCatalog(catalog)) {
+          sparkCatalogPrefix = "spark.sql.catalog.spark_catalog";
+          catalogClassName = ArcticSparkSessionCatalog.class.getName();
+        }
+        sparkConf.put(sparkCatalogPrefix, catalogClassName);
+        sparkConf.put(sparkCatalogPrefix + ".url", catalogUrlBase + catalog);
       }
     }
     return sparkConf;

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/TerminalSession.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/TerminalSession.java
@@ -18,6 +18,8 @@
 
 package com.netease.arctic.ams.server.terminal;
 
+import com.netease.arctic.ams.server.utils.CatalogUtil;
+
 import java.util.List;
 import java.util.Map;
 
@@ -84,4 +86,13 @@ public interface TerminalSession {
    * close session and release resources.
    */
   void release();
+
+  static boolean canUseSparkSessionCatalog(Map<String, String> sessionConf, String catalog) {
+    String usingSessionCatalogForHiveKey =
+        TerminalSessionFactory.SessionConfigOptions.USING_SESSION_CATALOG_FOR_HIVE.key();
+    String usingSessionCatalogForHive =
+        sessionConf.getOrDefault(usingSessionCatalogForHiveKey, "false");
+    return usingSessionCatalogForHive.equals("true") &&
+        CatalogUtil.isHiveCatalog(catalog);
+  }
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/TerminalSessionFactory.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/TerminalSessionFactory.java
@@ -70,6 +70,11 @@ public interface TerminalSessionFactory {
         .booleanType()
         .noDefaultValue();
 
+    public static ConfigOption<Boolean> USING_SESSION_CATALOG_FOR_HIVE = ConfigOptions
+        .key("using-session-catalog-for-hive")
+        .booleanType()
+        .defaultValue(false);
+
     public static ConfigOption<String> catalogConnector(String catalog) {
       return ConfigOptions.key("session.catalog." + catalog + ".connector")
           .stringType()

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/kyuubi/KyuubiSession.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/kyuubi/KyuubiSession.java
@@ -50,8 +50,17 @@ public class KyuubiSession implements TerminalSession {
   @Override
   public ResultSet executeStatement(String catalog, String statement) {
     if (currentCatalog == null || !currentCatalog.equalsIgnoreCase(catalog)) {
-      logs.add("current catalog is " + currentCatalog + ", switch to " + catalog + " before execution");
-      execute("use `" + catalog + "`");
+      if (TerminalSession.canUseSparkSessionCatalog(sessionConf, catalog)) {
+        logs.add(String.format("current catalog is %s, " +
+                "since it's a hive type catalog and can use spark session catalog, " +
+                "switch to spark_catalog before execution",
+                currentCatalog));
+        execute("use `spark_catalog`");
+      } else {
+        logs.add(String.format("current catalog is %s, switch to %s before execution",
+            currentCatalog, catalog));
+        execute("use `" + catalog + "`");
+      }
       this.currentCatalog = catalog;
     }
     java.sql.ResultSet rs = null;

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/kyuubi/KyuubiTerminalSessionFactory.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/kyuubi/KyuubiTerminalSessionFactory.java
@@ -19,7 +19,6 @@
 package com.netease.arctic.ams.server.terminal.kyuubi;
 
 import com.clearspring.analytics.util.Lists;
-import com.google.common.collect.Maps;
 import com.netease.arctic.ams.server.config.ConfigOption;
 import com.netease.arctic.ams.server.config.ConfigOptions;
 import com.netease.arctic.ams.server.config.Configuration;
@@ -111,7 +110,7 @@ public class KyuubiTerminalSessionFactory implements TerminalSessionFactory {
     logMessage(logs, "try to create a kyuubi connection via url: " + kyuubiJdbcUrl);
     logMessage(logs, "");
 
-    Map<String, String> sessionConf = Maps.newLinkedHashMap();
+    Map<String, String> sessionConf = configuration.toMap();
     sessionConf.put("jdbc.url", kyuubiJdbcUrl);
     Properties properties = new Properties();
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/local/LocalSessionFactory.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/terminal/local/LocalSessionFactory.java
@@ -27,7 +27,6 @@ import com.netease.arctic.ams.server.terminal.TerminalSessionFactory;
 import com.netease.arctic.spark.ArcticSparkExtensions;
 import com.netease.arctic.table.TableMetaStore;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions;
 import org.apache.spark.SparkConf;
@@ -66,7 +65,7 @@ public class LocalSessionFactory implements TerminalSessionFactory {
     initializeLogs.add("initialize session, session factory: " + LocalSessionFactory.class.getName());
 
     Map<String, String> sparkConf = SparkContextUtil.getSparkConf(configuration);
-    Map<String, String> finallyConf = Maps.newLinkedHashMap();
+    Map<String, String> finallyConf = configuration.toMap();
     sparkConf.put(REFRESH_CATALOG_BEFORE_USAGE, "true");
     if (isNativeIceberg) {
       org.apache.hadoop.conf.Configuration metaConf = metaStore.getConfiguration();

--- a/site/docs/ch/guides/deployment.md
+++ b/site/docs/ch/guides/deployment.md
@@ -244,6 +244,8 @@ Terminal 在 local 模式执行的情况下，可以配置 Spark 相关参数
 arctic.ams.terminal.backend: local
 arctic.ams.terminal.local.spark.sql.session.timeZone: UTC
 arctic.ams.terminal.local.spark.sql.iceberg.handle-timestamp-without-timezone: false
+# When the catalog type is hive, using spark session catalog automatically in the terminal to access hive tables
+arctic.ams.terminal.local.using-session-catalog-for-hive: true
 ```
 
 ## 启动 AMS


### PR DESCRIPTION
## Why are the changes needed?

Fix  #1266 
Support terminal access hive table when switch to a catalog with HMS metastore 。

## Brief change log

- Use ArcticSparkSessionCatalog for terminal
- Add a config properties to support access hive in terminal.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)