### PR TITLE
[ARCTIC-1273] When using derby to execute quickstart, the table was erroneously accessed before it was created

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/ArcticMetaStore.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/ArcticMetaStore.java
@@ -186,6 +186,12 @@ public class ArcticMetaStore {
   }
 
   public static void startMetaStore(Configuration conf) throws Throwable {
+    //prepare env
+    if (conf.getString(ArcticMetaStoreConf.DB_TYPE).equals("derby")) {
+      DerbyService derbyService = new DerbyService();
+      derbyService.createTable();
+    }
+
     // init config
     initConfig();
     try {
@@ -195,11 +201,6 @@ public class ArcticMetaStore {
       int queueSizePerSelector = conf.getInteger(ArcticMetaStoreConf.THRIFT_QUEUE_SIZE_PER_THREAD);
       boolean useCompactProtocol = conf.get(ArcticMetaStoreConf.USE_THRIFT_COMPACT_PROTOCOL);
       int port = conf.getInteger(ArcticMetaStoreConf.THRIFT_BIND_PORT);
-
-      if (conf.getString(ArcticMetaStoreConf.DB_TYPE).equals("derby")) {
-        DerbyService derbyService = new DerbyService();
-        derbyService.createTable();
-      }
 
       LOG.info("Starting arctic metastore on port " + port);
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/DerbyService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/DerbyService.java
@@ -21,6 +21,8 @@ package com.netease.arctic.ams.server.service.impl;
 import com.netease.arctic.ams.server.service.IJDBCService;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,6 +32,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 public class DerbyService extends IJDBCService {
+  public static final Logger LOG = LoggerFactory.getLogger(DerbyService.class);
+
   public void createTable() throws Exception {
     try (SqlSession sqlSession = getSqlSession(true)) {
       Connection connection = sqlSession.getConnection();
@@ -42,6 +46,9 @@ public class DerbyService extends IJDBCService {
         ScriptRunner runner = new ScriptRunner(connection);
         runner.runScript(new InputStreamReader(new FileInputStream(getDerbyInitSqlDir()), "UTF-8"));
       }
+    } catch (Exception e) {
+      LOG.error("create derby table error", e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
resolve #1273 

## Brief change log

 prepare derby env before init container/optimize config

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
