### PR TITLE
[ARCTIC-1233] Arctic filestore write task can't been restored from checkpoint after modifying the sink parallelism

### DIFF
--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/ArcticFileWriter.java
@@ -26,9 +26,6 @@ import com.netease.arctic.flink.util.ArcticUtils;
 import com.netease.arctic.table.ArcticTable;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -62,15 +59,11 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   private final TaskWriterFactory<RowData> taskWriterFactory;
   private final int minFileSplitCount;
   private final ArcticTableLoader tableLoader;
-  private final boolean upsert;
   private final boolean submitEmptySnapshot;
 
   private transient org.apache.iceberg.io.TaskWriter<RowData> writer;
   private transient int subTaskId;
   private transient int attemptId;
-  private transient String jobId;
-  private transient long checkpointId = 1;
-  private transient ListState<Long> checkpointState;
   /**
    * Load table in runtime, because that table's refresh method will be invoked in serialization.
    * And it will set {@link org.apache.hadoop.security.UserGroupInformation#authenticationMethod} to KERBEROS
@@ -89,7 +82,6 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     this.taskWriterFactory = taskWriterFactory;
     this.minFileSplitCount = minFileSplitCount;
     this.tableLoader = tableLoader;
-    this.upsert = upsert;
     this.submitEmptySnapshot = submitEmptySnapshot;
     LOG.info("ArcticFileWriter is created with minFileSplitCount: {}, upsert: {}, submitEmptySnapshot: {}",
         minFileSplitCount, upsert, submitEmptySnapshot);
@@ -98,7 +90,6 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
   @Override
   public void open() {
     this.attemptId = getRuntimeContext().getAttemptNumber();
-    this.jobId = getContainingTask().getEnvironment().getJobID().toString();
     table = ArcticUtils.loadArcticTable(tableLoader);
 
     long mask = getMask(subTaskId);
@@ -112,27 +103,11 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
     super.initializeState(context);
 
     this.subTaskId = getRuntimeContext().getIndexOfThisSubtask();
-    checkpointState =
-        context.getOperatorStateStore()
-            .getListState(
-                new ListStateDescriptor<>(
-                    subTaskId + "-task-file-writer-state",
-                    LongSerializer.INSTANCE));
-
-    if (context.isRestored()) {
-      // get last success ckp num from state when failover continuously
-      checkpointId = checkpointState.get().iterator().next();
-      // prepare for the writer init in open(). It is used for next ckpId.
-      checkpointId++;
-    }
   }
 
   @Override
   public void snapshotState(StateSnapshotContext context) throws Exception {
     super.snapshotState(context);
-
-    checkpointState.clear();
-    checkpointState.add(context.getCheckpointId());
   }
 
   private void initTaskWriterFactory(long mask) {
@@ -140,11 +115,6 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
       ((ArcticRowDataTaskWriterFactory) taskWriterFactory).setMask(mask);
     }
     taskWriterFactory.initialize(subTaskId, attemptId);
-  }
-
-  @VisibleForTesting
-  public long getCheckpointId() {
-    return checkpointId;
   }
 
   private long getMask(int subTaskId) {
@@ -166,9 +136,6 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
 
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-    // get ckpId for next cp writer
-    this.checkpointId = checkpointId + 1;
-
     table.io().doAs(() -> {
       completeAndEmitFiles();
 
@@ -229,7 +196,7 @@ public class ArcticFileWriter extends AbstractStreamOperator<WriteResult>
    *
    * @param writeResult the WriteResult to emit
    * @return true if the WriteResult should be emitted, or the WriteResult isn't empty,
-   *         false only if the WriteResult is empty and the submitEmptySnapshot is false.
+   * false only if the WriteResult is empty and the submitEmptySnapshot is false.
    */
   private boolean shouldEmit(WriteResult writeResult) {
     return submitEmptySnapshot || (writeResult != null &&


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix: #1233 

This patch #1010 has changed the txId generation rule, the flink writer operator doesn't need to fetch a transaction with a checkpoint before committing a snapshot from AMS. Then, the checkpoint no longer needs to be generated and maintained in the state.


## Brief change log

  - *Remove the useless code in the file writer operator*
  - *Remove the state which contains a checkpoint in the file writer operator*
  - *The flink 1.12, 1.14, and 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
