### PR TITLE
[Arctic-1265][BugFix][Spark]: Disable optimize write for upsert

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/util/ArcticSparkUtils.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/util/ArcticSparkUtils.java
@@ -18,10 +18,8 @@
 
 package com.netease.arctic.spark.util;
 
-import com.netease.arctic.table.ArcticTable;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.util.Utf8;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.Spark3Util;
@@ -38,9 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ArcticSparkUtils {
   private static final Logger LOG = LoggerFactory.getLogger(ArcticSparkUtils.class);
@@ -99,21 +95,5 @@ public class ArcticSparkUtils {
       default:
     }
     return value;
-  }
-
-  public static boolean isPrimaryKeyIncludeAllPartitions(ArcticTable table) {
-    Preconditions.checkArgument(table.isKeyedTable(), "it's must be a keyed table");
-    List<String> pkCols = table.asKeyedTable().primaryKeySpec().fieldNames();
-    PartitionSpec ptSpec = table.spec();
-
-    boolean withTransform = ptSpec.fields().stream()
-        .anyMatch(f -> !f.transform().isIdentity());
-    if (withTransform) {
-      return false;
-    }
-    List<String> ptCols = ptSpec.fields().stream()
-        .map(f -> table.schema().findField(f.sourceId()).name())
-        .collect(Collectors.toList());
-    return new HashSet<>(pkCols).containsAll(ptCols);
   }
 }

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/util/ArcticSparkUtils.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/util/ArcticSparkUtils.java
@@ -18,27 +18,19 @@
 
 package com.netease.arctic.spark.util;
 
-import com.netease.arctic.spark.table.ArcticSparkTable;
-import com.netease.arctic.table.DistributionHashMode;
-import com.netease.arctic.table.PrimaryKeySpec;
-import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.table.ArcticTable;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.util.Utf8;
-import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.ByteBuffers;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
-import org.apache.spark.sql.connector.expressions.Expressions;
-import org.apache.spark.sql.connector.expressions.Transform;
-import org.apache.spark.sql.connector.iceberg.distributions.Distribution;
-import org.apache.spark.sql.connector.iceberg.distributions.Distributions;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
@@ -46,14 +38,9 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
-
-import static com.netease.arctic.table.TableProperties.WRITE_DISTRIBUTION_MODE;
-import static com.netease.arctic.table.TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT;
-import static org.apache.iceberg.spark.Spark3Util.toTransforms;
+import java.util.stream.Collectors;
 
 public class ArcticSparkUtils {
   private static final Logger LOG = LoggerFactory.getLogger(ArcticSparkUtils.class);
@@ -86,61 +73,6 @@ public class ArcticSparkUtils {
     }
   }
 
-  public static Distribution buildRequiredDistribution(ArcticSparkTable arcticSparkTable) {
-    // Fallback to use distribution mode parsed from table properties .
-    String modeName = PropertyUtil.propertyAsString(
-        arcticSparkTable.properties(),
-        WRITE_DISTRIBUTION_MODE,
-        WRITE_DISTRIBUTION_MODE_DEFAULT);
-    DistributionMode writeMode = DistributionMode.fromName(modeName);
-    switch (writeMode) {
-      case NONE:
-        return null;
-
-      case HASH:
-        DistributionHashMode distributionHashMode = DistributionHashMode.valueOfDesc(
-            arcticSparkTable.properties().getOrDefault(
-                TableProperties.WRITE_DISTRIBUTION_HASH_MODE,
-                TableProperties.WRITE_DISTRIBUTION_HASH_MODE_DEFAULT));
-        List<Transform> transforms = new ArrayList<>();
-        if (DistributionHashMode.AUTO.equals(distributionHashMode)) {
-          distributionHashMode = DistributionHashMode.autoSelect(
-              arcticSparkTable.table().isKeyedTable(),
-              !arcticSparkTable.table().spec().isUnpartitioned());
-        }
-        if (distributionHashMode.isSupportPrimaryKey()) {
-          Transform transform = toTransformsFromPrimary(
-              arcticSparkTable,
-              arcticSparkTable.table().asKeyedTable().primaryKeySpec());
-          transforms.add(transform);
-          if (distributionHashMode.isSupportPartition()) {
-            transforms.addAll(Arrays.asList(toTransforms(arcticSparkTable.table().spec())));
-          }
-          return Distributions.clustered(transforms.stream().filter(Objects::nonNull).toArray(Transform[]::new));
-        } else {
-          if (distributionHashMode.isSupportPartition()) {
-            return Distributions.clustered(toTransforms(arcticSparkTable.table().spec()));
-          } else {
-            return null;
-          }
-        }
-
-      case RANGE:
-        LOG.warn("Fallback to use 'none' distribution mode, because {}={} is not supported in spark now",
-            WRITE_DISTRIBUTION_MODE, DistributionMode.RANGE.modeName());
-        return null;
-
-      default:
-        throw new RuntimeException("Unrecognized write.distribution-mode: " + writeMode);
-    }
-  }
-
-  private static Transform toTransformsFromPrimary(ArcticSparkTable arcticSparkTable, PrimaryKeySpec primaryKeySpec) {
-    int numBucket = PropertyUtil.propertyAsInt(arcticSparkTable.properties(),
-        TableProperties.BASE_FILE_INDEX_HASH_BUCKET, TableProperties.BASE_FILE_INDEX_HASH_BUCKET_DEFAULT);
-    return Expressions.bucket(numBucket, primaryKeySpec.fieldNames().get(0));
-  }
-
   public static Object convertConstant(Type type, Object value) {
     if (value == null) {
       return null;
@@ -167,5 +99,21 @@ public class ArcticSparkUtils {
       default:
     }
     return value;
+  }
+
+  public static boolean isPrimaryKeyIncludeAllPartitions(ArcticTable table) {
+    Preconditions.checkArgument(table.isKeyedTable(), "it's must be a keyed table");
+    List<String> pkCols = table.asKeyedTable().primaryKeySpec().fieldNames();
+    PartitionSpec ptSpec = table.spec();
+
+    boolean withTransform = ptSpec.fields().stream()
+        .anyMatch(f -> !f.transform().isIdentity());
+    if (withTransform) {
+      return false;
+    }
+    List<String> ptCols = ptSpec.fields().stream()
+        .map(f -> table.schema().findField(f.sourceId()).name())
+        .collect(Collectors.toList());
+    return new HashSet<>(pkCols).containsAll(ptCols);
   }
 }

--- a/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/optimize/OptimizeWriteRule.scala
+++ b/spark/v3.1/spark/src/main/scala/com/netease/arctic/spark/sql/catalyst/optimize/OptimizeWriteRule.scala
@@ -19,9 +19,9 @@
 package com.netease.arctic.spark.sql.catalyst.optimize
 
 import com.netease.arctic.spark.sql.ArcticExtensionUtils.{isArcticIcebergRelation, isArcticRelation}
-import com.netease.arctic.spark.sql.catalyst.plans.{AppendArcticData, OverwriteArcticPartitionsDynamic, ReplaceArcticData}
+import com.netease.arctic.spark.sql.catalyst.plans.OverwriteArcticPartitionsDynamic
 import com.netease.arctic.spark.table.{ArcticIcebergSparkTable, ArcticSparkTable}
-import com.netease.arctic.spark.util.{ArcticSparkUtils, DistributionAndOrderingUtil}
+import com.netease.arctic.spark.util.DistributionAndOrderingUtil
 import com.netease.arctic.spark.{SparkSQLProperties, SupportSparkAdapter}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Expression, SortOrder}
@@ -61,18 +61,6 @@ case class OptimizeWriteRule(spark: SparkSession) extends Rule[LogicalPlan] with
       val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
       a.copy(query = newQuery, writeOptions = options)
 
-    case a @ AppendArcticData(r: DataSourceV2Relation, query, _, writeOptions)
-      if isArcticRelation(r) && optimizeForRowLevelOperation(r) =>
-      val newQuery = distributionQuery(query, r.table, rowLevelOperation = false, writeBase = false)
-      val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
-      a.copy(query = newQuery, writeOptions = options)
-
-    case a @ ReplaceArcticData(r: DataSourceV2Relation, query, writeOptions)
-      if isArcticRelation(r) && optimizeForRowLevelOperation(r) =>
-      val newQuery = distributionQuery(query, r.table, rowLevelOperation = false, writeBase = false)
-      val options = writeOptions + ("writer.distributed-and-ordered" -> "true")
-      a.copy(query = newQuery, writeOptions = options)
-
     case o @ OverwriteArcticPartitionsDynamic(r: DataSourceV2Relation, query, _, writeOptions)
       if isArcticRelation(r) =>
       val newQuery = distributionQuery(query, r.table, rowLevelOperation = false)
@@ -93,16 +81,6 @@ case class OptimizeWriteRule(spark: SparkSession) extends Rule[LogicalPlan] with
       if isArcticIcebergRelation(r) =>
       val newQuery = distributionQuery(query, r.table, rowLevelOperation = false)
       o.copy(query = newQuery)
-  }
-
-  import com.netease.arctic.spark.sql.ArcticExtensionUtils._
-
-  def optimizeForRowLevelOperation(r: DataSourceV2Relation): Boolean = {
-    val table = r.table.asArcticTable
-    if (table.table().isUnkeyedTable) {
-      return false
-    }
-    ArcticSparkUtils.isPrimaryKeyIncludeAllPartitions(table.table())
   }
 
   def optimizeWriteEnabled(): Boolean = {

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/ArcticSparkCatalogTestGroup.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/ArcticSparkCatalogTestGroup.java
@@ -77,7 +77,9 @@ import java.util.Map;
     TestHiveTableDropPartitions.class,
     TestHiveTableTruncate.class,
     TestKeyedTableMergeInto.class,
-    TestUnKeyedTableMergeInto.class})
+    TestUnKeyedTableMergeInto.class,
+    TestUpsert.class
+})
 public class ArcticSparkCatalogTestGroup {
 
   @BeforeClass

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/SparkTestContext.java
@@ -625,4 +625,12 @@ public class SparkTestContext extends ExternalResource {
     }
     return RowFactory.create(values);
   }
+
+  public Map<String, String> properties(String... kv) {
+    Map<String, String> props = Maps.newHashMap();
+    for (int i = 0; i < kv.length; i = i + 2) {
+      props.put(kv[i], kv[i + 1]);
+    }
+    return props;
+  }
 }

--- a/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestUpsert.java
+++ b/spark/v3.1/spark/src/test/java/com/netease/arctic/spark/TestUpsert.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.spark;
+
+import com.clearspring.analytics.util.Lists;
+import com.netease.arctic.catalog.ArcticCatalog;
+import com.netease.arctic.spark.util.RecordGenerator;
+import com.netease.arctic.table.PrimaryKeySpec;
+import com.netease.arctic.table.TableIdentifier;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.glassfish.jersey.internal.guava.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TestUpsert extends SparkTestBase {
+  private final String database = "db";
+  private final String table = "sink_table";
+  private final String sourceTable = "source_table";
+  private final String initView = "init_view";
+  private final TableIdentifier identifier = TableIdentifier.of(catalogNameArctic, database, table);
+
+  private List<GenericRecord> sources;
+  private List<GenericRecord> initialize;
+
+  private Schema schema;
+  private int newRecordSize = 300;
+  private int upsertRecordSize = 200;
+
+  @Before
+  public void before() throws AnalysisException {
+    sql("use " + catalogNameArctic);
+    sql("create database if not exists {0}", database);
+
+    schema = new Schema(
+        Types.NestedField.of(1, false, "order_key", Types.IntegerType.get()),
+        Types.NestedField.of(2, false, "line_number", Types.IntegerType.get()),
+        Types.NestedField.of(3, false, "data", Types.StringType.get()),
+        Types.NestedField.of(4, false, "pt", Types.StringType.get())
+    );
+
+    ArcticCatalog catalog = catalog(catalogNameArctic);
+    PrimaryKeySpec primaryKeySpec = PrimaryKeySpec.builderFor(schema)
+        .addColumn("order_key")
+        .addColumn("line_number").build();
+
+    PartitionSpec partitionSpec = PartitionSpec.builderFor(schema)
+        .identity("pt").build();
+    catalog.newTableBuilder(identifier, schema)
+        .withPrimaryKeySpec(primaryKeySpec)
+        .withPartitionSpec(partitionSpec)
+        .withProperties(properties(
+            "write.upsert.enabled", "true",
+            "base.file-index.hash-bucket", "4"
+        )).create();
+
+    RecordGenerator generator = RecordGenerator.buildFor(schema)
+        .withSequencePrimaryKey(primaryKeySpec)
+        .withRandomDate("pt")
+        .build();
+    initialize = generator.records(1000);
+
+    Dataset<Row> dataset = spark.createDataFrame(
+        initialize.stream().map(SparkTestContext::recordToRow).collect(Collectors.toList()),
+        SparkSchemaUtil.convert(schema));
+    dataset.createTempView(initView);
+
+    sources = upsertSource(initialize, generator,
+        primaryKeySpec, partitionSpec, upsertRecordSize, newRecordSize);
+    dataset = spark.createDataFrame(
+        sources.stream().map(SparkTestContext::recordToRow).collect(Collectors.toList()),
+        SparkSchemaUtil.convert(schema));
+    dataset.createTempView(sourceTable);
+  }
+
+  @Test
+  public void testKeyedTableUpsert() {
+    sql("set `spark.sql.arctic.check-source-data-uniqueness.enabled`=`true`");
+    sql("set `spark.sql.arctic.optimize-write-enabled`=`true`");
+
+    sql("INSERT OVERWRITE " + database + "." + table + " SELECT * FROM " + initView);
+    sql("insert into table " + database + '.' + table + " SELECT * FROM " + sourceTable);
+
+    rows = sql("SELECT * FROM " + database + "." + table);
+    Assert.assertEquals(initialize.size() + newRecordSize, rows.size());
+  }
+
+  private List<GenericRecord> upsertSource(
+      List<GenericRecord> initializeData, RecordGenerator sourceGenerator,
+      PrimaryKeySpec keySpec, PartitionSpec partitionSpec,
+      int upsertCount, int insertCount) {
+    RecordGenerator generator = RecordGenerator.buildFor(schema)
+        .withSeed(System.currentTimeMillis())
+        .build();
+
+    List<GenericRecord> source = Lists.newArrayList();
+    List<GenericRecord> insertSource = sourceGenerator.records(insertCount);
+    source.addAll(insertSource);
+
+    List<GenericRecord> upsertSource = sourceGenerator.records(upsertCount);
+    Iterator<GenericRecord> it = initializeData.iterator();
+
+    Set<String> sourceCols = Sets.newHashSet();
+    sourceCols.addAll(keySpec.fieldNames());
+    // partitionSpec.fields().stream()
+    //     .map(f -> schema.findField(f.sourceId()))
+    //     .map(Types.NestedField::name)
+    //     .forEach(sourceCols::add);
+
+    for (GenericRecord r : upsertSource) {
+      GenericRecord t = it.next();
+      sourceCols.forEach(col -> t.setField(col, r.getField(col)));
+    }
+    return source;
+  }
+}


### PR DESCRIPTION

## Why are the changes needed?
To fix #1265 

Currently, the optimize write rule required open one parquet file at once. But in upsert mode, we have to write UPDATE_BEFORE and UPDATE_AFTER in one writer to get the right offset value. so we have to close optimize write for upsert and update/delete.

## Brief change log

- Disable optimize write for upsert

## How was this patch tested?
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
