### PR TITLE
[ARCTIC-1242][ams] Optimizing plan thread should only plan tables in pending status

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeService.java
@@ -133,7 +133,6 @@ public class OptimizeService extends IJDBCService implements IOptimizeService {
 
   @Override
   public boolean isInited() {
-    LOG.info("OptimizeService inited {}", inited);
     return inited;
   }
 

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/TableOptimizeItem.java
@@ -457,7 +457,12 @@ public class TableOptimizeItem extends IJDBCService {
       // if the table is planning, should not update the optimizing status 
       return;
     }
+    if (tableOptimizeRuntime.getOptimizeStatus() == TableOptimizeRuntime.OptimizeStatus.Pending) {
+      // if the table is Pending, should not plan again
+      return;
+    }
     if (com.netease.arctic.utils.TableTypeUtil.isIcebergTableFormat(getArcticTable())) {
+      arcticTable.asUnkeyedTable().refresh();
       Snapshot currentSnapshot = arcticTable.asUnkeyedTable().currentSnapshot();
       if (currentSnapshot == null) {
         tryUpdateOptimizeInfo(TableOptimizeRuntime.OptimizeStatus.Idle, Collections.emptyList(), null);

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
@@ -759,6 +759,11 @@ public class OptimizeQueueService extends IJDBCService {
             }
           }
 
+          if (tableItem.getTableOptimizeRuntime().getOptimizeStatus() != TableOptimizeRuntime.OptimizeStatus.Pending) {
+            // only table in pending should plan
+            continue;
+          }
+
           OptimizePlanResult optimizePlanResult = OptimizePlanResult.EMPTY;
           if (tableItem.startPlanIfNot()) {
             try {

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsEnvironment.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsEnvironment.java
@@ -144,9 +144,12 @@ public class AmsEnvironment {
       }
     }
   }
-  
+
   public List<TableIdentifier> refreshTables() {
-    return ServiceContainer.getOptimizeService().refreshAndListTables();
+    List<TableIdentifier> tableIdentifiers = ServiceContainer.getOptimizeService().refreshAndListTables();
+    ServiceContainer.getOptimizeService()
+        .checkOptimizeCheckTasks(ArcticMetaStore.conf.getLong(ArcticMetaStoreConf.OPTIMIZE_CHECK_STATUS_INTERVAL));
+    return tableIdentifiers;
   }
 
   public void syncTableFileCache(TableIdentifier tableIdentifier, String tableType) {
@@ -229,6 +232,7 @@ public class AmsEnvironment {
         "  arctic.ams.optimize.commit.thread.pool-size: 1\n" +
         "  arctic.ams.expire.thread.pool-size: 1\n" +
         "  arctic.ams.orphan.clean.thread.pool-size: 1\n" +
+        "  arctic.ams.optimize.check-status.interval: 3000\n" +
         "  arctic.ams.file.sync.thread.pool-size: 1\n" +
         "  arctic.ams.support.hive.sync.thread.pool-size: 1\n" +
         "  # derby config.sh\n" +


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix, #1242 

## Brief change log

  - optimizing-check thread pool skips `pending` tables and only changes optimizing status from `idle` to `pending`
  - optimizing-planner thread skips `idle` tables and only plans tables in `pending` 

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
