### PR TITLE
[ARCTIC-1295] fix writing into an empty KeyedTable with flink/spark 0.3.x/0.4.0 and AMS 0.4.1

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/ArcticTransactionService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/ArcticTransactionService.java
@@ -68,8 +68,14 @@ public class ArcticTransactionService extends IJDBCService {
       throw new TException(tableIdentifier + " is not keyed table");
     }
   }
-  
+
   public void validTable(TableIdentifier tableIdentifier) {
     validTableIdentifiers.add(tableIdentifier);
+    LOG.info("{} is now valid for allocating transaction id", tableIdentifier);
+  }
+
+  public void inValidTable(TableIdentifier tableIdentifier) {
+    validTableIdentifiers.remove(tableIdentifier);
+    LOG.info("{} is now invalid for allocating transaction id", tableIdentifier);
   }
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/JDBCMetaService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/JDBCMetaService.java
@@ -78,6 +78,16 @@ public class JDBCMetaService extends IJDBCService implements IMetaService {
 
     TABLE_META_STORE_CACHE.put(new Key(tableMetadata.getTableIdentifier(), tableMetadata.getMetaStore()),
         tableMetadata.getMetaStore());
+
+    try {
+      if (StringUtils.isNotBlank(tableMetadata.getPrimaryKey())) {
+        ServiceContainer.getArcticTransactionService()
+            .validTable(tableMetadata.getTableIdentifier().buildTableIdentifier());
+      }
+    } catch (Exception e) {
+      LOG.warn("createTable success but failed to valid for allocating transaction id", e);
+    }
+
     try {
       ServiceContainer.getOptimizeService().addNewTable(tableMetadata.getTableIdentifier());
     } catch (Exception e) {
@@ -140,6 +150,16 @@ public class JDBCMetaService extends IJDBCService implements IMetaService {
     }
 
     TABLE_META_STORE_CACHE.remove(new Key(tableMetadata.getTableIdentifier(), tableMetadata.getMetaStore()));
+
+    try {
+      if (StringUtils.isNotBlank(tableMetadata.getPrimaryKey())) {
+        ServiceContainer.getArcticTransactionService()
+            .inValidTable(tableMetadata.getTableIdentifier().buildTableIdentifier());
+      }
+    } catch (Exception e) {
+      LOG.warn("dropTable success but failed to invalid for allocating transaction id", e);
+    }
+
     try {
       ServiceContainer.getOptimizeService().clearRemovedTable(tableMetadata.getTableIdentifier());
     } catch (Exception e) {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UpdateTool.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UpdateTool.java
@@ -58,6 +58,8 @@ public class UpdateTool extends IJDBCService {
                 TableCommitMeta tableCommitMeta = getTableCommitMeta(tableIdentifier, createSnapshot);
                 ServiceContainer.getFileInfoCacheService().commitCacheFileInfo(tableCommitMeta);
               }
+            } else {
+              ServiceContainer.getArcticTransactionService().validTable(tableIdentifier.buildTableIdentifier());
             }
           }
         } catch (Throwable t) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1295 

## Brief change log

  - table with currentTxId == 0 should be valid for allocating TxId from AMS

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
