### PR TITLE
[ARCTIC-1300] The ams installation should have the engine runtime package in the plugin directory

### DIFF
--- a/dist/src/main/assemblies/bin.xml
+++ b/dist/src/main/assemblies/bin.xml
@@ -35,6 +35,31 @@
             <fileMode>0644</fileMode>
         </file>
         <file>
+            <source>../flink/v1.12/flink-runtime/target/arctic-flink-runtime-1.12-${project.version}.jar</source>
+            <outputDirectory>plugin/flink</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>../flink/v1.14/flink-runtime/target/arctic-flink-runtime-1.14-${project.version}.jar</source>
+            <outputDirectory>plugin/flink</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>../flink/v1.15/flink-runtime/target/arctic-flink-runtime-1.15-${project.version}.jar</source>
+            <outputDirectory>plugin/flink</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>../spark/v2.3/spark-runtime/target/arctic-spark-2.3-runtime-${project.version}.jar</source>
+            <outputDirectory>plugin/spark</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
+            <source>../spark/v3.1/spark-runtime/target/arctic-spark-3.1-runtime-${project.version}.jar</source>
+            <outputDirectory>plugin/spark</outputDirectory>
+            <fileMode>0644</fileMode>
+        </file>
+        <file>
             <source>../ams/ams-server/target/arctic-ams-server-${project.version}.jar</source>
             <outputDirectory>lib/</outputDirectory>
             <destName>arctic-ams-server-${project.version}.jar</destName>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
resolve #1300 

## Brief change log

add engine runtime package in the plugin directory in dist module assemblies logic

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
