### PR TITLE
[ARCTIC-1280][Spark]Fix bug: When the AMS deployment of high availability, use ArcticsparkSessionCatalog loadTable will throw exception

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
@@ -177,6 +177,11 @@ public class ArcticSparkSessionCatalog<T extends TableCatalog & SupportsNamespac
   public final void initialize(String name, CaseInsensitiveStringMap options) {
     this.catalogName = name;
     this.options = options;
+    try {
+      this.arcticCatalog = buildSparkCatalog(name, options);
+    } catch (Exception e) {
+      this.arcticCatalog = null;
+    }
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1280 

Problem: When the AMS deployment of high availability, use ArcticsparkSessionCatalog load table will throw exception.

Cause: The cause of this problem is that load hive table requires Kerberos authentication. After the hive table is loaded, Kerberos authentication information is carried to access the non-Kerberos Zookeeper.

## Brief change log

Change initialize() in ArcticSparkSessionCatalog.class.
Change to load arctic catalog first

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
