### PR TITLE
[ARCTIC-1308] The front-end ams Settings page should not display quotes

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/controller/SettingController.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/controller/SettingController.java
@@ -66,7 +66,9 @@ public class SettingController extends RestBaseController {
       }
 
       config.forEach((k, v) -> {
-        result.put(k, JSON.toJSONString(v));
+        if (!(v instanceof String)) {
+          result.put(k, JSON.toJSONString(v));
+        }
       });
       ctx.json(OkResponse.of(result));
     } catch (Exception e) {

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsTestBase.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/AmsTestBase.java
@@ -214,7 +214,10 @@ public class AmsTestBase {
     when(ArcticMetaStore.getSystemSettingFromYaml()).thenAnswer((Answer<LinkedHashMap<String,Object>>) x ->
             new LinkedHashMap<String, Object>(){{
               put("a", "b");
-              put("a", "b");
+              put("b", true);
+              Map<String, String> mapType = new HashMap<>();
+              mapType.put("c1", "v1");
+              put("c", mapType);
             }});
     mockStatic(ServiceContainer.class);
     mockStatic(CatalogMetadataService.class);

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/controller/SettingControllerTest.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/controller/SettingControllerTest.java
@@ -19,20 +19,45 @@
 package com.netease.arctic.ams.server.controller;
 
 import com.alibaba.fastjson.JSONObject;
+import com.netease.arctic.ams.server.ArcticMetaStore;
 import com.netease.arctic.ams.server.controller.response.Response;
 import io.javalin.testtools.JavalinTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ArcticMetaStore.class})
+@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*"})
 public class SettingControllerTest {
   private final Logger LOG = LoggerFactory.getLogger(SettingController.class);
 
   @Test
   public void testGetVersion() {
+    mockStatic(ArcticMetaStore.class);
+    when(ArcticMetaStore.getSystemSettingFromYaml()).thenAnswer((Answer<LinkedHashMap<String,Object>>) x ->
+        new LinkedHashMap<String, Object>(){{
+          put("arctic.ams.database.type", "derby");
+          put("b", true);
+          Map<String, String> mapType = new HashMap<>();
+          mapType.put("c1", "v1");
+          put("c", mapType);
+        }});
     JavalinTest.test((app, client) -> {
-      app.get("/", ctx -> SettingController.getSystemSetting(ctx));
-      final okhttp3.Response resp = client.get("/", x -> {
+      app.get("/settings/system", ctx -> SettingController.getSystemSetting(ctx));
+      final okhttp3.Response resp = client.get("/settings/system", x -> {
       });
       assert resp.code() == 200;
       Response result = JSONObject.parseObject(resp.body().string(), Response.class);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
fix #1308 

## Brief change log

The front-end ams Settings page should not display quotes

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
