### PR TITLE
[ARCTIC-1306][FLINK] Arctic Define watermark on unkeyed table encounters FieldNotFound Exception

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -193,7 +193,7 @@ public class FlinkSource {
           .flinkConf(flinkConf)
           .limit(limit)
           .build();
-      return wrapKrb(origin);
+      return wrapKrb(origin).assignTimestampsAndWatermarks(watermarkStrategy);
     }
 
     /**

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -186,7 +186,7 @@ public class FlinkSource {
     public DataStream<RowData> buildUnkeyedTableSource() {
       DataStream<RowData> origin = org.apache.iceberg.flink.source.FlinkSource.forRowData()
           .env(env)
-          .project(projectedSchema)
+          .project(filterWatermark(projectedSchema))
           .tableLoader(tableLoader)
           .filters(filters)
           .properties(properties)

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/table/TestUnkeyed.java
@@ -229,6 +229,61 @@ public class TestUnkeyed extends FlinkTestBase {
   }
 
   @Test
+  public void testUnkeyedWatermarkSet() throws Exception {
+    List<Object[]> data = new LinkedList<>();
+
+    data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+    data.add(new Object[]{1000015, "b", LocalDateTime.parse("2022-06-17T10:08:11.0")});
+    data.add(new Object[]{1000011, "c", LocalDateTime.parse("2022-06-18T10:10:11.0")});
+    data.add(new Object[]{1000014, "d", LocalDateTime.parse("2022-06-17T10:11:11.0")});
+    data.add(new Object[]{1000021, "d", LocalDateTime.parse("2022-06-17T16:10:11.0")});
+    data.add(new Object[]{1000007, "e", LocalDateTime.parse("2022-06-17T10:10:11.0")});
+
+    List<ApiExpression> rows = DataUtil.toRows(data);
+
+    Table input = getTableEnv().fromValues(DataTypes.ROW(
+        DataTypes.FIELD("id", DataTypes.INT()),
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("ts", DataTypes.TIMESTAMP())
+      ),
+      rows
+    );
+    getTableEnv().createTemporaryView("input", input);
+
+    sql("CREATE CATALOG arcticCatalog WITH %s", toWithClause(props));
+
+    sql("CREATE TABLE IF NOT EXISTS arcticCatalog." + db + "." + TABLE + "(" +
+      " id INT, name STRING, ts TIMESTAMP)" +
+      " WITH (" +
+      " 'location' = '" + tableDir.getAbsolutePath() + "/" + TABLE + "'" +
+      ")");
+
+    sql("create table user_tb (" +
+      "    rtime as cast(ts as timestamp(3))," +
+      "    WATERMARK FOR rtime as rtime" +
+      "  ) LIKE arcticCatalog." + db + "." + TABLE);
+
+    sql("insert into arcticCatalog." + db + "." + TABLE + " select * from input");
+
+    TableResult result = exec("select id, name, ts from user_tb" +
+      "/*+ OPTIONS(" +
+      "'arctic.read.mode'='file'" +
+      ", 'scan.startup.mode'='earliest'" +
+      ")*/" +
+      "");
+
+    Set<Row> actual = new HashSet<>();
+    try (CloseableIterator<Row> iterator = result.collect()) {
+      for (Object[] datum : data) {
+        actual.add(iterator.next());
+      }
+    }
+    Assert.assertEquals(DataUtil.toRowSet(data), actual);
+
+    result.getJobClient().ifPresent(TestUtil::cancelJob);
+  }
+
+  @Test
   public void testSinkBatchRead() throws IOException {
     List<Object[]> data = new LinkedList<>();
     data.add(new Object[]{1000004, "a", LocalDateTime.parse("2022-06-17T10:10:11.0")});

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -194,7 +194,7 @@ public class FlinkSource {
           .flinkConf(flinkConf)
           .limit(limit)
           .build();
-      return wrapKrb(origin);
+      return wrapKrb(origin).assignTimestampsAndWatermarks(watermarkStrategy);
     }
 
     /**

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -187,7 +187,7 @@ public class FlinkSource {
     public DataStream<RowData> buildUnkeyedTableSource() {
       DataStream<RowData> origin = org.apache.iceberg.flink.source.FlinkSource.forRowData()
           .env(env)
-          .project(projectedSchema)
+          .project(filterWatermark(projectedSchema))
           .tableLoader(tableLoader)
           .filters(filters)
           .properties(properties)

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -199,7 +199,7 @@ public class FlinkSource {
     public DataStream<RowData> buildUnkeyedTableSource() {
       DataStream<RowData> origin = org.apache.iceberg.flink.source.FlinkSource.forRowData()
           .env(env)
-          .project(projectedSchema)
+          .project(filterWatermark(projectedSchema))
           .tableLoader(tableLoader)
           .filters(filters)
           .properties(properties)

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/FlinkSource.java
@@ -206,7 +206,7 @@ public class FlinkSource {
           .flinkConf(flinkConf)
           .limit(limit)
           .build();
-      return wrapKrb(origin);
+      return wrapKrb(origin).assignTimestampsAndWatermarks(watermarkStrategy);
     }
 
     /**


### PR DESCRIPTION
## Why are the changes needed?

fix #1306  

*Currently watermark is a virtual field and is not in the physical schema of the arctic unkeyed table, so the watermark needs to be filtered out to avoid FieldNotFound Exception.*

## Brief change log

  - *Filter watermark related fields.*
  - *The flink 1.12, 1.14 and 1.15 versions are affected.*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
