### PR TITLE
[ARCTIC-1283][FLINK]when source is a kafka with canal-json format, the task can't run with a exception thrown

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -173,7 +173,7 @@ public class FlinkSink {
       Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkSchema), table.schema());
 
       int writeOperatorParallelism = PropertyUtil.propertyAsInt(table.properties(), SINK_PARALLELISM.key(),
-          rowDataInput.getParallelism());
+          rowDataInput.getExecutionEnvironment().getParallelism());
 
       DistributionHashMode distributionMode = getDistributionHashMode();
       LOG.info("take effect distribute mode: {}", distributionMode);

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -173,7 +173,7 @@ public class FlinkSink {
       Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkSchema), table.schema());
 
       int writeOperatorParallelism = PropertyUtil.propertyAsInt(table.properties(), SINK_PARALLELISM.key(),
-          rowDataInput.getParallelism());
+          rowDataInput.getExecutionEnvironment().getParallelism());
 
       DistributionHashMode distributionMode = getDistributionHashMode();
       LOG.info("take effect distribute mode: {}", distributionMode);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkSink.java
@@ -180,7 +180,7 @@ public class FlinkSink {
       Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkSchema), table.schema());
 
       int writeOperatorParallelism = PropertyUtil.propertyAsInt(table.properties(), SINK_PARALLELISM.key(),
-          rowDataInput.getParallelism());
+          rowDataInput.getExecutionEnvironment().getParallelism());
 
       DistributionHashMode distributionMode = getDistributionHashMode();
       LOG.info("take effect distribute mode: {}", distributionMode);


### PR DESCRIPTION
## Why are the changes needed?

fix #1283 

*In some scenarios rowDataInput's parallelism may be negative (e.g. if cdc-event-duplicate is enabled) which needs to be changed to get the parallelism from the ExecutionEnvironment.*

## Brief change log

  - *Change the way to obtain the parallelism of the write operator*
  - *The flink 1.12, 1.14 and 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
