### PR TITLE
[ARCTIC-1330]jacoco-maven-plugin report EOFException in Flink Module CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,9 @@
                             <phase>test</phase>
                             <configuration>
                                 <outputDirectory>${project.build.directory}/codecov</outputDirectory>
+                                <includes>
+                                    <include>**/*.class</include>
+                                </includes>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
## Why are the changes needed?

fix #1330 

## Brief change log

  - *include only .class files in plugin configuration within report execution*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
