### PR TITLE
[Arctic-1364]: Disable jacoco in github CI

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache: maven
 
       - name: Build all module with Maven
-        run: mvn clean install -pl '!trino' -Djacoco.skip=true -B
+        run: mvn clean install -pl '!trino' -Djacoco.skip=true -B -ntp
 
       - name: Code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache: maven
 
       - name: Build all module with Maven
-        run: mvn clean install -pl '!trino' -Djacoco.skip=true -B -q
+        run: mvn clean install -pl '!trino' -Djacoco.skip=true -B
 
       - name: Code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache: maven
 
       - name: Build all module with Maven
-        run: mvn clean install -pl '!trino'
+        run: mvn clean install -pl '!trino' -Djacoco.skip=true -B -q
 
       - name: Code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/trino-ci.yml
+++ b/.github/workflows/trino-ci.yml
@@ -47,10 +47,10 @@ jobs:
           cache: maven
 
       - name: Install dependency with Maven
-        run: mvn clean install -DskipTests -pl 'ams/ams-api,core,hive' -am
+        run: mvn clean install -DskipTests -pl 'ams/ams-api,core,hive' -am -B
 
       - name: Build with Maven
-        run: mvn clean test -pl 'trino'
+        run: mvn clean test -pl 'trino' -B
 
       - name: Code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/trino-ci.yml
+++ b/.github/workflows/trino-ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: mvn clean install -DskipTests -pl 'ams/ams-api,core,hive' -am -B
 
       - name: Build with Maven
-        run: mvn clean test -pl 'trino' -B
+        run: mvn clean test -pl 'trino' -B -ntp
 
       - name: Code coverage
         uses: codecov/codecov-action@v3

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,6 @@
         <maven.scalastyle.skip>false</maven.scalastyle.skip>
         <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>
         <spotless.scala.scalafmt.version>3.6.1</spotless.scala.scalafmt.version>
-        <spotless.python.includes></spotless.python.includes>
-        <spotless.python.black.version>22.3.0</spotless.python.black.version>
         <maven.plugin.spotless.version>2.27.2</maven.plugin.spotless.version>
     </properties>
 


### PR DESCRIPTION
 

## Why are the changes needed?
disable jacoco when run github ci for not blocking code development.

This PR releated to #1364 but not fixed it totally, so this PR will not close the issue. In the future we should find out the reason of the EOFException and enable the test cover check.


 
## Brief change log

- Add `-Djacoco.skip=true` for core ci
- Add `-B ` for core ci to diable print colorful code.
- Add `--no-transfer-progress` to not print download process



 