### PR TITLE
[ARCTIC-1386][ams] fix Iceberg Format table's orphan files clean mistakenly delete the `equality-delete` files 

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
@@ -33,7 +33,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * It's better to refactor UnKeyedTableUtil to IcebergTableUtil.
+ * TODO: It's better to refactor UnKeyedTableUtil to IcebergTableUtil.
  */
 public class UnKeyedTableUtil {
   private static final Logger LOG = LoggerFactory.getLogger(UnKeyedTableUtil.class);

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
@@ -21,20 +21,24 @@ package com.netease.arctic.ams.server.utils;
 import com.netease.arctic.IcebergFileEntry;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.scan.TableEntriesScan;
-import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.TableFileUtils;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * It's better to refactor UnKeyedTableUtil to IcebergTableUtil.
+ */
 public class UnKeyedTableUtil {
   private static final Logger LOG = LoggerFactory.getLogger(UnKeyedTableUtil.class);
 
-  public static long getSnapshotId(UnkeyedTable internalTable) {
+  public static long getSnapshotId(Table internalTable) {
     internalTable.refresh();
     Snapshot currentSnapshot = internalTable.currentSnapshot();
     if (currentSnapshot == null) {
@@ -44,16 +48,16 @@ public class UnKeyedTableUtil {
     }
   }
 
-  public static Snapshot getCurrentSnapshot(UnkeyedTable internalTable) {
+  public static Snapshot getCurrentSnapshot(Table internalTable) {
     internalTable.refresh();
     return internalTable.currentSnapshot();
   }
 
-  public static Set<String> getAllContentFilePath(UnkeyedTable internalTable) {
+  public static Set<String> getAllContentFilePath(Table internalTable) {
     Set<String> validFilesPath = new HashSet<>();
 
     TableEntriesScan manifestReader = TableEntriesScan.builder(internalTable)
-        .includeFileContent(FileContent.DATA, FileContent.POSITION_DELETES)
+        .includeFileContent(FileContent.DATA, FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES)
         .allEntries().build();
     for (IcebergFileEntry entry : manifestReader.entries()) {
       validFilesPath.add(TableFileUtils.getUriPath(entry.getFile().path().toString()));

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtilTest.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtilTest.java
@@ -25,22 +25,50 @@ import com.netease.arctic.io.writer.GenericBaseTaskWriter;
 import com.netease.arctic.io.writer.GenericTaskWriters;
 import com.netease.arctic.io.writer.SortedPosDeleteWriter;
 import com.netease.arctic.utils.TableFileUtils;
+import jline.internal.Log;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.DeleteFiles;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.Tables;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimap;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static com.netease.arctic.TableTestBase.newGenericRecord;
+import static com.netease.arctic.TableTestBase.partitionData;
+import static com.netease.arctic.TableTestBase.writeEqDeleteFile;
+import static com.netease.arctic.TableTestBase.writeNewDataFile;
+import static com.netease.arctic.TableTestBase.writePosDeleteFile;
+
 public class UnKeyedTableUtilTest extends TableTestBase {
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
   public UnKeyedTableUtilTest() {
     super(TableFormat.MIXED_ICEBERG, true, true);
   }
@@ -134,6 +162,72 @@ public class UnKeyedTableUtilTest extends TableTestBase {
         .retainLast(1).expireOlderThan(System.currentTimeMillis()).cleanExpiredFiles(true).commit();
     s1FilePath.remove(TableFileUtils.getUriPath(result.dataFiles()[0].path().toString()));
     Assert.assertEquals(s1FilePath, UnKeyedTableUtil.getAllContentFilePath(getArcticTable().asKeyedTable().baseTable()));
+  }
+
+  @Test
+  public void testGetAllContentFilesForIcebergFormat() throws IOException {
+    Tables hadoopTables = new HadoopTables(new Configuration());
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(TableProperties.FORMAT_VERSION, "2");
+
+    String path = tempFolder.getRoot().getPath();
+    Table table = hadoopTables.create(com.netease.arctic.TableTestBase.TABLE_SCHEMA, PartitionSpec.unpartitioned(),
+        tableProperties, path + "/test/table1");
+    List<DataFile> dataFiles = insertDataFiles(table, 10);
+    List<DeleteFile> eqDeleteFiles = insertEqDeleteFiles(table, 1);
+    List<DeleteFile> posDeleteFiles = insertPosDeleteFiles(table, dataFiles);
+    Set<String> realPaths = new HashSet<>();
+    dataFiles.stream().map(DataFile::path).map(CharSequence::toString).forEach(realPaths::add);
+    eqDeleteFiles.stream().map(DeleteFile::path).map(CharSequence::toString).forEach(realPaths::add);
+    posDeleteFiles.stream().map(DeleteFile::path).map(CharSequence::toString).forEach(realPaths::add);
+    Set<String> allContentFilePath = UnKeyedTableUtil.getAllContentFilePath(table);
+    Assert.assertEquals(realPaths, allContentFilePath);
+  }
+
+  private static List<DataFile> insertDataFiles(Table table, int length) throws IOException {
+    StructLike partitionData = partitionData(table.schema(), table.spec(), getOpTime());
+    DataFile result = writeNewDataFile(table, records(0, length, table.schema()), partitionData);
+
+    AppendFiles baseAppend = table.newAppend();
+    baseAppend.appendFile(result);
+    baseAppend.commit();
+
+    return Collections.singletonList(result);
+  }
+
+  private static List<Record> records(int start, int length, Schema tableSchema) {
+    List<Record> records = Lists.newArrayList();
+    for (int i = start; i < start + length; i++) {
+      records.add(newGenericRecord(tableSchema, i, "name", getOpTime()));
+    }
+    return records;
+  }
+
+  private static LocalDateTime getOpTime() {
+    return LocalDateTime.of(2022, 1, 1, 12, 0, 0);
+  }
+
+  private List<DeleteFile> insertPosDeleteFiles(Table table, List<DataFile> dataFiles) throws IOException {
+    Multimap<String, Long> file2Positions = Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
+    for (DataFile dataFile : dataFiles) {
+      file2Positions.put(dataFile.path().toString(), 0L);
+    }
+    StructLike partitionData = partitionData(table.schema(), table.spec(), getOpTime());
+    DeleteFile result = writePosDeleteFile(table, file2Positions, partitionData);
+    RowDelta rowDelta = table.newRowDelta();
+    rowDelta.addDeletes(result);
+    rowDelta.commit();
+    return Collections.singletonList(result);
+  }
+
+  private List<DeleteFile> insertEqDeleteFiles(Table table, int length) throws IOException {
+    StructLike partitionData = partitionData(table.schema(), table.spec(), getOpTime());
+    DeleteFile result = writeEqDeleteFile(table, records(0, length, table.schema()), partitionData);
+
+    RowDelta rowDelta = table.newRowDelta();
+    rowDelta.addDeletes(result);
+    rowDelta.commit();
+    return Collections.singletonList(result);
   }
 
   private List<Record> writeRecords() {

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtilTest.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtilTest.java
@@ -25,7 +25,6 @@ import com.netease.arctic.io.writer.GenericBaseTaskWriter;
 import com.netease.arctic.io.writer.GenericTaskWriters;
 import com.netease.arctic.io.writer.SortedPosDeleteWriter;
 import com.netease.arctic.utils.TableFileUtils;
-import jline.internal.Log;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1386

## Brief change log

  - add equality-delete files when get all valid content files

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
