### PR TITLE
[ARCTIC-1388][Spark]Fix bug: The runtime jar of Spark 3.3 throws a NoClassDefFoundError when executing SQL.

### DIFF
--- a/spark/v3.3/spark-runtime/pom.xml
+++ b/spark/v3.3/spark-runtime/pom.xml
@@ -342,24 +342,30 @@
                                         </include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.Call*</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.DropPartitionField</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.DropIdentifierFields</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.DeleteFromIcebergTable</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilter*
                                         </include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.MergeInto</include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.MergeInto$</include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.MergeIntoParams*</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.MergeIntoContext</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.MergeIntoIcebergTable</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.MergeRows</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.NamedArgument*</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.PositionalArgument*
                                         </include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.ReplaceData*</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.NoStatsUnaryNode</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.ReplaceIcebergData*</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.UnresolvedMergeIntoIcebergTable</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.RowLevelCommand</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.WriteDelta</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.ReplacePartitionField*
                                         </include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.SetIdentifierFields*
                                         </include>
                                         <include>
-                                            org.apache.spark.sql.catalyst.plans.logical.SetWriteDistributionAndOrdering*
+                                            org.apache.spark.sql.catalyst.plans.logical.UpdateIcebergTable
                                         </include>
                                         <include>
-                                            org.apache.spark.sql.catalyst.plans.logical.SortOrderParserUtil*
+                                            org.apache.spark.sql.catalyst.plans.logical.V2WriteCommandLike
                                         </include>
                                     </includes>
                                 </relocation>

--- a/spark/v3.3/spark-runtime/pom.xml
+++ b/spark/v3.3/spark-runtime/pom.xml
@@ -341,7 +341,7 @@
                                         <include>org.apache.spark.sql.catalyst.plans.logical.AddPartitionField*
                                         </include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.Call*</include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.Drop*</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.DropPartitionField</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilter*
                                         </include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.MergeInto</include>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix #1388 
Fix bug: The runtime jar of Spark 3.3 throws a NoClassDefFoundError when executing SQL.
This bug is caused by mistakenly shading classes from Spark package when shading files in the pom file.

## Brief change log

change pom.xml in spark/v3.3

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
