### PR TITLE
[ARCTIC-1380] [core] fix NPE when scan entries of Iceberg table < 1.0.0

### DIFF
--- a/core/src/main/java/com/netease/arctic/IcebergFileEntry.java
+++ b/core/src/main/java/com/netease/arctic/IcebergFileEntry.java
@@ -20,6 +20,7 @@ package com.netease.arctic;
 
 import com.netease.arctic.utils.ManifestEntryFields;
 import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
 /**
  * Entry of Iceberg ContentFile, include status, ContentFile, snapshotId and sequenceNumber.
@@ -58,11 +59,11 @@ public class IcebergFileEntry {
 
   @Override
   public String toString() {
-    return "IcebergFileEntry{" +
-        "snapshotId=" + snapshotId +
-        ", sequenceNumber=" + sequenceNumber +
-        ", status=" + status +
-        ", file=" + (file == null ? "null" : String.valueOf(file.path())) +
-        '}';
+    return MoreObjects.toStringHelper(this)
+        .add("snapshotId", snapshotId)
+        .add("sequenceNumber", sequenceNumber)
+        .add("status", status)
+        .add("file", file == null ? "null" : file.path())
+        .toString();
   }
 }

--- a/core/src/main/java/com/netease/arctic/IcebergFileEntry.java
+++ b/core/src/main/java/com/netease/arctic/IcebergFileEntry.java
@@ -18,20 +18,25 @@
 
 package com.netease.arctic;
 
+import com.netease.arctic.utils.ManifestEntryFields;
 import org.apache.iceberg.ContentFile;
 
 /**
- * Entry of Iceberg ContentFile, include ContentFile, snapshotId and sequenceNumber.
- * The sequenceNumber is inherited from metadata, not the actual value in manifest file.
+ * Entry of Iceberg ContentFile, include status, ContentFile, snapshotId and sequenceNumber.
+ * If the actual sequenceNumber in manifest file is null, it will be inherited from metadata,
+ * and it may be null for DELETED entries with iceberg version < 1.0.0.
  */
 public class IcebergFileEntry {
-  private Long snapshotId;
-  private long sequenceNumber;
-  private ContentFile<?> file;
+  private final Long snapshotId;
+  private final Long sequenceNumber;
+  private final ManifestEntryFields.Status status;
+  private final ContentFile<?> file;
 
-  public IcebergFileEntry(Long snapshotId, long sequenceNumber, ContentFile<?> file) {
+  public IcebergFileEntry(Long snapshotId, Long sequenceNumber,
+                          ManifestEntryFields.Status status, ContentFile<?> file) {
     this.snapshotId = snapshotId;
     this.sequenceNumber = sequenceNumber;
+    this.status = status;
     this.file = file;
   }
 
@@ -39,24 +44,25 @@ public class IcebergFileEntry {
     return snapshotId;
   }
 
-  public void setSnapshotId(Long snapshotId) {
-    this.snapshotId = snapshotId;
-  }
-
-  public long getSequenceNumber() {
+  public Long getSequenceNumber() {
     return sequenceNumber;
-  }
-
-  public void setSequenceNumber(long sequenceNumber) {
-    this.sequenceNumber = sequenceNumber;
   }
 
   public ContentFile<?> getFile() {
     return file;
   }
 
-  public void setFile(ContentFile<?> file) {
-    this.file = file;
+  public ManifestEntryFields.Status getStatus() {
+    return status;
   }
-  
+
+  @Override
+  public String toString() {
+    return "IcebergFileEntry{" +
+        "snapshotId=" + snapshotId +
+        ", sequenceNumber=" + sequenceNumber +
+        ", status=" + status +
+        ", file=" + (file == null ? "null" : String.valueOf(file.path())) +
+        '}';
+  }
 }

--- a/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
+++ b/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -191,19 +192,19 @@ public class TableEntriesScan {
           ManifestEntryFields.Status status =
               ManifestEntryFields.Status.of(
                   entry.get(entryFieldIndex(ManifestEntryFields.STATUS.name()), Integer.class));
-          long sequence = entry.get(entryFieldIndex(ManifestEntryFields.SEQUENCE_NUMBER.name()), Long.class);
-          Long snapshotId = entry.get(entryFieldIndex(ManifestEntryFields.SNAPSHOT_ID.name()), Long.class);
           StructLike fileRecord =
               entry.get(entryFieldIndex(ManifestEntryFields.DATA_FILE_FIELD_NAME), StructLike.class);
           FileContent fileContent =
               getFileContent(fileRecord.get(dataFileFieldIndex(DataFile.CONTENT.name()), Integer.class));
           if (shouldKeep(status, fileContent)) {
+            Long sequence = entry.get(entryFieldIndex(ManifestEntryFields.SEQUENCE_NUMBER.name()), Long.class);
+            Long snapshotId = entry.get(entryFieldIndex(ManifestEntryFields.SNAPSHOT_ID.name()), Long.class);
             ContentFile<?> contentFile = buildContentFile(fileContent, fileRecord);
             if (metricsEvaluator().eval(contentFile)) {
               if (needMetrics() && !includeColumnStats) {
                 contentFile = (ContentFile<?>) contentFile.copyWithoutStats();
               }
-              return new IcebergFileEntry(snapshotId, sequence, contentFile);
+              return new IcebergFileEntry(snapshotId, sequence, status, contentFile);
             }
           }
           return null;

--- a/core/src/main/java/com/netease/arctic/utils/ManifestEntryFields.java
+++ b/core/src/main/java/com/netease/arctic/utils/ManifestEntryFields.java
@@ -27,7 +27,6 @@ public class ManifestEntryFields {
   public static final Types.NestedField STATUS = required(0, "status", Types.IntegerType.get());
   public static final Types.NestedField SNAPSHOT_ID = optional(1, "snapshot_id", Types.LongType.get());
   public static final Types.NestedField SEQUENCE_NUMBER = optional(3, "sequence_number", Types.LongType.get());
-  public static final int DATA_FILE_ID = 3;
   public static final String DATA_FILE_FIELD_NAME = "data_file";
 
   public enum Status {

--- a/core/src/test/java/com/netease/arctic/scan/TableEntriesScanTest.java
+++ b/core/src/test/java/com/netease/arctic/scan/TableEntriesScanTest.java
@@ -185,12 +185,13 @@ public class TableEntriesScanTest extends TableDataTestBase {
       }
       for (DataFile removedFile : snapshot.removedDataFiles(table.io())) {
         Entry entry = result.get(removedFile.path().toString());
-        // sequence for delete
+        // sequence for removed file is the sequence it added
         result.put(removedFile.path().toString(),
             new Entry(snapshotId, entry.getSequenceNumber(), removedFile.content(), false));
       }
       for (DeleteFile removedFile : snapshot.removedDeleteFiles(table.io())) {
         Entry entry = result.get(removedFile.path().toString());
+        // sequence for removed file is the sequence it added
         result.put(removedFile.path().toString(),
             new Entry(snapshotId, entry.getSequenceNumber(), removedFile.content(), false));
       }

--- a/core/src/test/java/com/netease/arctic/scan/TableEntriesScanTest.java
+++ b/core/src/test/java/com/netease/arctic/scan/TableEntriesScanTest.java
@@ -19,84 +19,111 @@
 package com.netease.arctic.scan;
 
 import com.netease.arctic.IcebergFileEntry;
-import com.netease.arctic.data.DataFileType;
-import com.netease.arctic.data.file.FileNameGenerator;
 import com.netease.arctic.io.TableDataTestBase;
-import org.apache.iceberg.ContentFile;
+import com.netease.arctic.io.writer.GenericBaseTaskWriter;
+import com.netease.arctic.io.writer.GenericTaskWriters;
+import com.netease.arctic.utils.ManifestEntryFields;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.FileContent;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class TableEntriesScanTest extends TableDataTestBase {
 
   @Test
-  public void testScanDataEntries() {
+  public void testScanEntriesForDataFile() {
     // change table commit 2 insert files, then commit 1 delete file
     Table changeTable = getArcticTable().asKeyedTable().changeTable();
+    Map<String, Entry> expectedEntries = getExpectedCurrentEntries(changeTable);
     TableEntriesScan dataFileScan = TableEntriesScan.builder(changeTable)
         .includeFileContent(FileContent.DATA)
         .build();
-    long currentSnapshotId = changeTable.currentSnapshot().snapshotId();
     int cnt = 0;
     for (IcebergFileEntry entry : dataFileScan.entries()) {
       cnt++;
-      DataFile file = (DataFile) entry.getFile();
-      DataFileType dataFileType = FileNameGenerator.parseFileTypeForChange(file.path().toString());
-      if (dataFileType == DataFileType.INSERT_FILE) {
-        Assert.assertEquals(1, entry.getSequenceNumber());
-      } else if (dataFileType == DataFileType.EQ_DELETE_FILE) {
-        Assert.assertEquals(2, entry.getSequenceNumber());
-        Assert.assertEquals(currentSnapshotId, (long) entry.getSnapshotId());
-      }
-      Assert.assertEquals(FileContent.DATA, file.content());
+      assertEntry(expectedEntries, entry);
     }
     Assert.assertEquals(3, cnt);
   }
 
   @Test
-  public void testScanDeleteEntries() {
+  public void testScanEntriesForPosDeleteFiles() {
     // base table commit 4 insert files, then commit 1 pos-delete file
     Table baseTable = getArcticTable().asKeyedTable().baseTable();
     TableEntriesScan deleteFileScan = TableEntriesScan.builder(baseTable)
         .includeFileContent(FileContent.POSITION_DELETES)
         .build();
-    long currentSnapshotId = baseTable.currentSnapshot().snapshotId();
+    Map<String, Entry> expectedEntries = getExpectedCurrentEntries(baseTable);
     int cnt = 0;
     for (IcebergFileEntry entry : deleteFileScan.entries()) {
       cnt++;
-      DeleteFile file = (DeleteFile) entry.getFile();
-      Assert.assertEquals(2, entry.getSequenceNumber());
-      Assert.assertEquals(currentSnapshotId, (long) entry.getSnapshotId());
-      Assert.assertEquals(FileContent.POSITION_DELETES, file.content());
+      assertEntry(expectedEntries, entry);
     }
     Assert.assertEquals(1, cnt);
   }
 
   @Test
-  public void testScanAllEntries() {
+  public void testScanAllEntries() throws IOException {
     // base table commit 4 insert files, then commit 1 pos-delete file
     Table baseTable = getArcticTable().asKeyedTable().baseTable();
-    TableEntriesScan deleteFileScan = TableEntriesScan.builder(baseTable)
+    Snapshot snapshot1 = baseTable.currentSnapshot();
+    Map<String, Entry> expectedEntries1 = getExpectedCurrentEntries(baseTable);
+
+    // add and delete 4 files
+    List<DataFile> dataFiles = writeIntoBase();
+    DeleteFiles deleteFiles = baseTable.newDelete();
+    dataFiles.forEach(deleteFiles::deleteFile);
+    deleteFiles.commit();
+
+    Map<String, Entry> expectedEntries2 = getExpectedCurrentEntries(baseTable);
+
+    // using snapshot
+    TableEntriesScan entryScan1 = TableEntriesScan.builder(baseTable)
         .includeFileContent(FileContent.POSITION_DELETES, FileContent.DATA, FileContent.EQUALITY_DELETES)
+        .useSnapshot(snapshot1.snapshotId())
+        .withAliveEntry(false)
         .build();
-    long currentSnapshotId = baseTable.currentSnapshot().snapshotId();
     int cnt = 0;
-    for (IcebergFileEntry entry : deleteFileScan.entries()) {
+    for (IcebergFileEntry entry : entryScan1.entries()) {
       cnt++;
-      ContentFile<?> file = entry.getFile();
-      if (file.content() == FileContent.DATA) {
-        Assert.assertEquals(1, entry.getSequenceNumber());
-      } else {
-        Assert.assertEquals(2, entry.getSequenceNumber());
-        Assert.assertEquals(currentSnapshotId, (long) entry.getSnapshotId());
-        Assert.assertEquals(FileContent.POSITION_DELETES, file.content());
-      }
+      assertEntry(expectedEntries1, entry);
     }
     Assert.assertEquals(5, cnt);
+
+    // current
+    TableEntriesScan entryScan2 = TableEntriesScan.builder(baseTable)
+        .includeFileContent(FileContent.POSITION_DELETES, FileContent.DATA, FileContent.EQUALITY_DELETES)
+        .withAliveEntry(false)
+        .build();
+    cnt = 0;
+    for (IcebergFileEntry entry : entryScan2.entries()) {
+      cnt++;
+      assertEntry(expectedEntries2, entry);
+    }
+    Assert.assertEquals(9, cnt);
+
+    // all entries (in all snapshots)
+    TableEntriesScan entryScan3 = TableEntriesScan.builder(baseTable)
+        .includeFileContent(FileContent.POSITION_DELETES, FileContent.DATA, FileContent.EQUALITY_DELETES)
+        .withAliveEntry(false)
+        .allEntries()
+        .build();
+    Assert.assertEquals(13, Iterables.size(entryScan3.entries()));
   }
 
   @Test
@@ -107,20 +134,106 @@ public class TableEntriesScanTest extends TableDataTestBase {
         .includeFileContent(FileContent.DATA)
         .withDataFilter(Expressions.equal("id", 5))
         .build();
-    long currentSnapshotId = changeTable.currentSnapshot().snapshotId();
+    Map<String, Entry> expectedEntries = getExpectedCurrentEntries(changeTable);
     int cnt = 0;
     for (IcebergFileEntry entry : dataFileScan.entries()) {
       cnt++;
-      DataFile file = (DataFile) entry.getFile();
-      DataFileType dataFileType = FileNameGenerator.parseFileTypeForChange(file.path().toString());
-      if (dataFileType == DataFileType.INSERT_FILE) {
-        Assert.assertEquals(1, entry.getSequenceNumber());
-      } else if (dataFileType == DataFileType.EQ_DELETE_FILE) {
-        Assert.assertEquals(2, entry.getSequenceNumber());
-        Assert.assertEquals(currentSnapshotId, (long) entry.getSnapshotId());
-      }
-      Assert.assertEquals(FileContent.DATA, file.content());
+      assertEntry(expectedEntries, entry);
     }
     Assert.assertEquals(2, cnt);
+  }
+
+  private List<DataFile> writeIntoBase() throws IOException {
+    long transactionId = getArcticTable().asKeyedTable().beginTransaction("");
+    GenericBaseTaskWriter writer = GenericTaskWriters.builderFor(getArcticTable().asKeyedTable())
+        .withTransactionId(transactionId).buildBaseWriter();
+
+    for (Record record : BASE_RECORDS) {
+      writer.write(record);
+    }
+    WriteResult result = writer.complete();
+    AppendFiles baseAppend = getArcticTable().asKeyedTable().baseTable().newAppend();
+    Arrays.stream(result.dataFiles()).forEach(baseAppend::appendFile);
+    baseAppend.commit();
+    return Arrays.asList(result.dataFiles());
+  }
+
+  private void assertEntry(Map<String, Entry> expected, IcebergFileEntry entry) {
+    Entry expectEntry = expected.get(entry.getFile().path().toString());
+    Assert.assertNotNull(expectEntry);
+    Assert.assertEquals("fail file " + entry, expectEntry.getSequenceNumber(), entry.getSequenceNumber());
+    Assert.assertEquals("fail file " + entry, expectEntry.getSnapshotId(), entry.getSnapshotId());
+    Assert.assertEquals("fail file " + entry, expectEntry.getFileContent(), entry.getFile().content());
+    if (expectEntry.isAliveEntry()) {
+      assertAliveEntry(entry);
+    } else {
+      assertDeletedEntry(entry);
+    }
+  }
+
+  private Map<String, Entry> getExpectedCurrentEntries(Table table) {
+    Iterable<Snapshot> snapshots = table.snapshots();
+    Map<String, Entry> result = new HashMap<>();
+    for (Snapshot snapshot : snapshots) {
+      long snapshotId = snapshot.snapshotId();
+      long sequenceNumber = snapshot.sequenceNumber();
+      for (DataFile addFile : snapshot.addedDataFiles(table.io())) {
+        result.put(addFile.path().toString(), new Entry(snapshotId, sequenceNumber, addFile.content(), true));
+      }
+      for (DeleteFile addFile : snapshot.addedDeleteFiles(table.io())) {
+        result.put(addFile.path().toString(), new Entry(snapshotId, sequenceNumber, addFile.content(), true));
+      }
+      for (DataFile removedFile : snapshot.removedDataFiles(table.io())) {
+        Entry entry = result.get(removedFile.path().toString());
+        // sequence for delete
+        result.put(removedFile.path().toString(),
+            new Entry(snapshotId, entry.getSequenceNumber(), removedFile.content(), false));
+      }
+      for (DeleteFile removedFile : snapshot.removedDeleteFiles(table.io())) {
+        Entry entry = result.get(removedFile.path().toString());
+        result.put(removedFile.path().toString(),
+            new Entry(snapshotId, entry.getSequenceNumber(), removedFile.content(), false));
+      }
+    }
+    return result;
+  }
+
+  private static class Entry {
+    private final Long snapshotId;
+    private final Long sequenceNumber;
+    private final boolean aliveEntry;
+    private final FileContent fileContent;
+
+    public Entry(Long snapshotId, Long sequenceNumber, FileContent fileContent, boolean aliveEntry) {
+      this.snapshotId = snapshotId;
+      this.sequenceNumber = sequenceNumber;
+      this.fileContent = fileContent;
+      this.aliveEntry = aliveEntry;
+    }
+
+    public Long getSnapshotId() {
+      return snapshotId;
+    }
+
+    public Long getSequenceNumber() {
+      return sequenceNumber;
+    }
+
+    public boolean isAliveEntry() {
+      return aliveEntry;
+    }
+
+    public FileContent getFileContent() {
+      return fileContent;
+    }
+  }
+
+  private void assertAliveEntry(IcebergFileEntry entry) {
+    Assert.assertTrue("fail file " + entry, entry.getStatus() == ManifestEntryFields.Status.ADDED ||
+        entry.getStatus() == ManifestEntryFields.Status.EXISTING);
+  }
+
+  private void assertDeletedEntry(IcebergFileEntry entry) {
+    Assert.assertSame("fail file " + entry, entry.getStatus(), ManifestEntryFields.Status.DELETED);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1380 

## Brief change log

  - support sequence number from entry to be null


## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
