### PR TITLE
[Arctic-1397]: Fix bug: Hive function can't be used when using ArcticSparkSessionCat…

### DIFF
--- a/spark/v3.3/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
+++ b/spark/v3.3/spark/src/test/java/com/netease/arctic/spark/delegate/TestArcticSessionCatalog.java
@@ -207,4 +207,16 @@ public class TestArcticSessionCatalog extends SparkTestContext {
     sql("drop table {0}.{1}", database, table);
   }
 
+  @Test
+  public void testLoadFunction(){
+    String funcClass = "org.apache.hadoop.hive.ql.udf.generic.GenericUDFLength";
+
+    // create permanent function
+    sql("CREATE FUNCTION permanent_len as '"+funcClass+"'");
+    assertEquals("load permanent function in Hive",
+            sql("select length('abc')"),
+            sql("select permanent_len('abc')"));
+
+  }
+
 }


### PR DESCRIPTION
…alog under spark 3.3

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix: https://github.com/NetEase/arctic/issues/1397

## Brief change log

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
