### PR TITLE
[ARCTIC-1408][Ams]Disable authentication for ZooKeeper client.

### DIFF
--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ArcticThriftUrl.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ArcticThriftUrl.java
@@ -143,16 +143,7 @@ public class ArcticThriftUrl {
           retryCount++;
           logger.error(String.format("Caught exception, retrying... (retry count: %s)", retryCount),
               authFailedException);
-          try {
-            Subject subject = Subject.getSubject(java.security.AccessController.getContext());
-
-            if (subject != null) {
-              LoginContext loginContext = new LoginContext("", subject);
-              loginContext.logout();
-            }
-          } catch (LoginException e) {
-            logger.error("Failed to logout", e);
-          }
+          System.setProperty("zookeeper.sasl.client", "false");
         } catch (Exception e) {
           retryCount++;
           logger.error(String.format("Caught exception, retrying... (retry count: %s)", retryCount), e);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
resolve #1408 
The previous approach was to solve the problem by clearing the Kerberos authentication information, but now a more user-friendly and convenient way has been found, which is to disable authentication for the ZooKeeper client to solve the problem.

## Brief change log

System.setProperty("zookeeper.sasl.client", "false");

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
