### PR TITLE
[ARCTIC-1346][AMS]Fix bug: When AMS is deployed HA, use Kerberos to access non-Kerberos zookeeper will throw an exception

### DIFF
--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ArcticZookeeperFactory.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ArcticZookeeperFactory.java
@@ -1,0 +1,21 @@
+package com.netease.arctic.ams.api.client;
+
+import org.apache.curator.utils.ZookeeperFactory;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+public class ArcticZookeeperFactory implements ZookeeperFactory {
+
+  private final ZKClientConfig config;
+
+  public ArcticZookeeperFactory(ZKClientConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, boolean canBeReadOnly) throws Exception {
+    return new ZooKeeperAdmin(connectString, sessionTimeout, watcher, canBeReadOnly, config);
+  }
+}

--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ZookeeperService.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ZookeeperService.java
@@ -22,6 +22,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.data.Stat;
 
 import java.nio.charset.StandardCharsets;
@@ -41,12 +42,15 @@ public class ZookeeperService {
   }
 
   private CuratorFramework newClient() {
+    ZKClientConfig zkClientConfig = new ZKClientConfig();
+    zkClientConfig.setProperty(ZKClientConfig.ENABLE_CLIENT_SASL_KEY, "false");
     ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(1000, 3, 5000);
     CuratorFramework client = CuratorFrameworkFactory.builder()
         .connectString(zkServerAddress)
         .sessionTimeoutMs(5000)
         .connectionTimeoutMs(5000)
         .retryPolicy(retryPolicy)
+        .zookeeperFactory(new ArcticZookeeperFactory(zkClientConfig))
         .build();
     client.start();
     return client;

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -141,11 +141,6 @@
                                 </relocation>
 
                                 <relocation>
-                                    <pattern>com.alibaba.fastjson</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.com.alibaba.fastjson</shadedPattern>
-                                </relocation>
-
-                                <relocation>
                                     <pattern>org.apache.curator</pattern>
                                     <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
                                 </relocation>

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -63,6 +63,12 @@
                                     <include>com.netease.arctic:arctic-ams-api</include>
                                     <incluede>com.netease.arctic:arctic-hive</incluede>
                                     <include>com.alibaba:fastjson</include>
+                                    <incluede>org.apache.curator:curator-framework</incluede>
+                                    <incluede>org.apache.curator:curator-client</incluede>
+                                    <incluede>org.apache.curator:curator-recipes</incluede>
+                                    <include>org.apache.iceberg:iceberg-core</include>
+                                    <include>org.apache.zookeeper:zookeeper</include>
+                                    <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>
                                     <include>org.apache.iceberg:iceberg-api</include>
                                     <include>org.apache.iceberg:iceberg-spark-3.1_2.12</include>
@@ -128,6 +134,21 @@
                                     <includes>
                                         <include>org.apache.spark.sql.execution.datasources.v2.Arctic*</include>
                                     </includes>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>com.alibaba.fastjson</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.com.alibaba.fastjson</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
                                 </relocation>
 
                                 <!-- relocation required dependencies -->

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -66,7 +66,6 @@
                                     <incluede>org.apache.curator:curator-framework</incluede>
                                     <incluede>org.apache.curator:curator-client</incluede>
                                     <incluede>org.apache.curator:curator-recipes</incluede>
-                                    <include>org.apache.iceberg:iceberg-core</include>
                                     <include>org.apache.zookeeper:zookeeper</include>
                                     <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>

--- a/spark/v3.2/spark-runtime/pom.xml
+++ b/spark/v3.2/spark-runtime/pom.xml
@@ -65,6 +65,11 @@
                                     <include>com.netease.arctic:arctic-ams-api</include>
                                     <incluede>com.netease.arctic:arctic-hive</incluede>
                                     <include>com.alibaba:fastjson</include>
+                                    <incluede>org.apache.curator:curator-framework</incluede>
+                                    <incluede>org.apache.curator:curator-client</incluede>
+                                    <incluede>org.apache.curator:curator-recipes</incluede>
+                                    <include>org.apache.zookeeper:zookeeper</include>
+                                    <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>
                                     <include>org.apache.iceberg:iceberg-api</include>
                                     <include>org.apache.iceberg:iceberg-spark-3.2_2.12</include>
@@ -139,6 +144,16 @@
                                 <relocation>
                                   <pattern>com.alibaba.fastjson</pattern>
                                   <shadedPattern>com.netease.arctic.shade.com.alibaba.fastjson</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
                                 </relocation>
 
 

--- a/spark/v3.3/spark-runtime/pom.xml
+++ b/spark/v3.3/spark-runtime/pom.xml
@@ -65,6 +65,11 @@
                                     <include>com.netease.arctic:arctic-ams-api</include>
                                     <incluede>com.netease.arctic:arctic-hive</incluede>
                                     <include>com.alibaba:fastjson</include>
+                                    <incluede>org.apache.curator:curator-framework</incluede>
+                                    <incluede>org.apache.curator:curator-client</incluede>
+                                    <incluede>org.apache.curator:curator-recipes</incluede>
+                                    <include>org.apache.zookeeper:zookeeper</include>
+                                    <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>
                                     <include>org.apache.iceberg:iceberg-api</include>
                                     <include>org.apache.iceberg:iceberg-spark-3.3_2.12</include>
@@ -139,6 +144,16 @@
                                 <relocation>
                                   <pattern>com.alibaba.fastjson</pattern>
                                   <shadedPattern>com.netease.arctic.shade.com.alibaba.fastjson</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
                                 </relocation>
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1346 

When AMS is deployed HA, use Kerberos to access non-Kerberos zookeeper will throw an exception.

Now the access to zk with or without Kerberos authentication information is controlled by turning off the parameter `zookeeper.sasl.client`.



## Brief change log
Change in com.netease.arctic.ams.api.client.ZookeeperService#newClient
Add property `ZKClientConfig.ENABLE_CLIENT_SASL_KEK = false` into ZKClientConfig.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
