### PR TITLE
[ARCTIC-1444] When executing the drop_metadata command with the repair tool, the Hive table was also deleted

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/maintainer/command/TableCall.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/maintainer/command/TableCall.java
@@ -21,6 +21,7 @@ package com.netease.arctic.ams.server.maintainer.command;
 import com.netease.arctic.ams.api.ArcticTableMetastore;
 import com.netease.arctic.catalog.ArcticCatalog;
 import com.netease.arctic.catalog.CatalogManager;
+import com.netease.arctic.hive.catalog.ArcticHiveCatalog;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
@@ -78,7 +79,12 @@ public class TableCall implements CallCommand {
       }
       case DROP_METADATA: {
         ArcticCatalog arcticCatalog = catalogManager.getArcticCatalog(identifier.getCatalog());
-        arcticCatalog.dropTable(identifier, false);
+        if (arcticCatalog instanceof ArcticHiveCatalog) {
+          ArcticHiveCatalog arcticHiveCatalog = (ArcticHiveCatalog)arcticCatalog;
+          arcticHiveCatalog.dropTableButNotDropHiveTable(identifier);
+        } else {
+          arcticCatalog.dropTable(identifier, false);
+        }
         return ok();
       }
       default: {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix #1444 

## Brief change log

When the catalog is found to be a Mixed-Hive catalog, only the Arctic table is deleted without deleting the Hive table

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
