### PR TITLE
[ARCTIC-1346][AMS]Fix bug: When AMS is deployed HA, use Kerberos to a…ccess non-Kerberos zookeeper will throw an exception. cherry-pick from #1414

### DIFF
--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ArcticZookeeperFactory.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ArcticZookeeperFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.ams.api.client;
+
+import org.apache.curator.utils.ZookeeperFactory;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.admin.ZooKeeperAdmin;
+import org.apache.zookeeper.client.ZKClientConfig;
+
+public class ArcticZookeeperFactory implements ZookeeperFactory {
+
+  private final ZKClientConfig config;
+
+  public ArcticZookeeperFactory(ZKClientConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, boolean canBeReadOnly) throws Exception {
+    return new ZooKeeperAdmin(connectString, sessionTimeout, watcher, canBeReadOnly, config);
+  }
+}

--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ZookeeperService.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/client/ZookeeperService.java
@@ -22,6 +22,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.data.Stat;
 
 import java.nio.charset.StandardCharsets;
@@ -41,12 +42,15 @@ public class ZookeeperService {
   }
 
   private CuratorFramework newClient() {
+    ZKClientConfig zkClientConfig = new ZKClientConfig();
+    zkClientConfig.setProperty(ZKClientConfig.ENABLE_CLIENT_SASL_KEY, "false");
     ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(1000, 3, 5000);
     CuratorFramework client = CuratorFrameworkFactory.builder()
         .connectString(zkServerAddress)
         .sessionTimeoutMs(5000)
         .connectionTimeoutMs(5000)
         .retryPolicy(retryPolicy)
+        .zookeeperFactory(new ArcticZookeeperFactory(zkClientConfig))
         .build();
     client.start();
     return client;

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -70,7 +70,7 @@
                                     <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>
                                     <include>org.apache.iceberg:iceberg-api</include>
-                                    <include>org.apache.iceberg:iceberg-spark-3</include>
+                                    <include>org.apache.iceberg:iceberg-spark3</include>
                                     <include>org.apache.iceberg:iceberg-common</include>
                                     <include>org.apache.iceberg:iceberg-data</include>
                                     <include>org.apache.iceberg:iceberg-orc</include>

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -16,17 +16,15 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>arctic-spark</artifactId>
         <groupId>com.netease.arctic</groupId>
-        <version>0.4.2-SNAPSHOT</version>
+        <artifactId>arctic-spark</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>arctic-spark-3.1-runtime</artifactId>
     <packaging>jar</packaging>
@@ -65,9 +63,14 @@
                                     <include>com.netease.arctic:arctic-ams-api</include>
                                     <incluede>com.netease.arctic:arctic-hive</incluede>
                                     <include>com.alibaba:fastjson</include>
+                                    <incluede>org.apache.curator:curator-framework</incluede>
+                                    <incluede>org.apache.curator:curator-client</incluede>
+                                    <incluede>org.apache.curator:curator-recipes</incluede>
+                                    <include>org.apache.zookeeper:zookeeper</include>
+                                    <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>
                                     <include>org.apache.iceberg:iceberg-api</include>
-                                    <include>org.apache.iceberg:iceberg-spark3</include>
+                                    <include>org.apache.iceberg:iceberg-spark-3.1_2.12</include>
                                     <include>org.apache.iceberg:iceberg-common</include>
                                     <include>org.apache.iceberg:iceberg-data</include>
                                     <include>org.apache.iceberg:iceberg-orc</include>
@@ -82,7 +85,7 @@
                                     <include>org.apache.iceberg:iceberg-arrow</include>
                                     <include>org.apache.iceberg:iceberg-hive-metastore</include>
                                     <include>org.apache.iceberg:iceberg-spark</include>
-                                    <include>org.apache.iceberg:iceberg-spark3-extensions</include>
+                                    <include>org.apache.iceberg:iceberg-spark-extensions-3.1_2.12</include>
                                     <include>org.apache.iceberg:iceberg-bundled-guava</include>
 
                                     <include>org.apache.thrift:libthrift</include>
@@ -112,12 +115,8 @@
                                         <exclude>org/codehaus/mojo/animal_sniffer/**</exclude>
                                         <exclude>org/apache/iceberg/spark/extensions/**</exclude>
                                         <exclude>org/apache/spark/sql/catalyst/analysis/ResolveProcedures**</exclude>
-                                        <exclude>
-                                            org/apache/hadoop/hive/ql/optimizer/ppr/PartitionExpressionForMetastore**
-                                        </exclude>
-                                        <exclude>
-                                            org/apache/hadoop/hive/ql/security/authorization/AuthorizationPreEventListener**
-                                        </exclude>
+                                        <exclude>org/apache/hadoop/hive/ql/optimizer/ppr/PartitionExpressionForMetastore**</exclude>
+                                        <exclude>org/apache/hadoop/hive/ql/security/authorization/AuthorizationPreEventListener**</exclude>
                                     </excludes>
                                 </filter>
 
@@ -130,13 +129,21 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.catalyst</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.catalyst
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.catalyst</shadedPattern>
                                     <includes>
                                         <include>org.apache.spark.sql.execution.datasources.v2.Arctic*</include>
                                     </includes>
                                 </relocation>
 
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
+                                </relocation>
 
                                 <!-- relocation required dependencies -->
                                 <relocation>
@@ -197,8 +204,8 @@
                                     <shadedPattern>com.netease.arctic.shade.org.apache.commons.lang3</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                  <pattern>com.alibaba.fastjson</pattern>
-                                  <shadedPattern>com.netease.arctic.shade.com.alibaba.fastjson</shadedPattern>
+                                    <pattern>com.alibaba.fastjson</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.com.alibaba.fastjson</shadedPattern>
                                 </relocation>
 
                                 <!-- relocation iceberg -->
@@ -208,97 +215,58 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.connector.iceberg</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.connector.iceberg
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.connector.iceberg</shadedPattern>
                                     <excludes>
-                                        <exclude>org.apache.spark.sql.connector.iceberg.catalog.ProcedureCatalog
-                                        </exclude>
+                                        <exclude>org.apache.spark.sql.connector.iceberg.catalog.ProcedureCatalog</exclude>
                                         <exclude>org.apache.spark.sql.connector.iceberg.catalog.Procedure</exclude>
-                                        <exclude>org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter
-                                        </exclude>
-                                        <exclude>org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameterImpl
-                                        </exclude>
+                                        <exclude>org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter</exclude>
+                                        <exclude>org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameterImpl</exclude>
                                     </excludes>
                                 </relocation>
 
                                 <!-- relocation iceberg-spark3-extensions -->
                                 <relocation>
                                     <pattern>org.apache.spark.sql.execution.datasources.v2</pattern>
-                                    <shadedPattern>
-                                        com.netease.arctic.shade.org.apache.spark.sql.execution.datasources.v2
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.execution.datasources.v2</shadedPattern>
                                     <includes>
-                                        <include>org.apache.spark.sql.execution.datasources.v2.AddPartitionFieldExec*
-                                        </include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.AddPartitionFieldExec*</include>
                                         <include>org.apache.spark.sql.execution.datasources.v2.CallExec*</include>
-                                        <include>org.apache.spark.sql.execution.datasources.v2.DropIdentifierFields*
-                                        </include>
-                                        <include>org.apache.spark.sql.execution.datasources.v2.DropPartitionFieldExec*
-                                        </include>
-                                        <include>org.apache.spark.sql.execution.datasources.v2.DynamicFileFilterExec*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.execution.datasources.v2.DynamicFileFilterWithCardinalityCheckExec*
-                                        </include>
-                                        <include>org.apache.spark.sql.execution.datasources.v2.ExtendedBatchScanExec*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy*
-                                        </include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.DropIdentifierFields*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.DropPartitionFieldExec*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.DynamicFileFilterExec*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.DynamicFileFilterWithCardinalityCheckExec*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.ExtendedBatchScanExec*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy*</include>
                                         <include>org.apache.spark.sql.execution.datasources.v2.MergeIntoExec*</include>
-                                        <include>org.apache.spark.sql.execution.datasources.v2.ReplaceDataExec*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.execution.datasources.v2.ReplacePartitionFieldExec*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.execution.datasources.v2.SetIdentifierFieldsExec*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.execution.datasources.v2.SetWriteDistributionAndOrderingExec*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.execution.datasources.v2.ArcticTableWriteExec*
-                                        </include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.ReplaceDataExec*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.ReplacePartitionFieldExec*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.SetIdentifierFieldsExec*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.SetWriteDistributionAndOrderingExec*</include>
+                                        <include>org.apache.spark.sql.execution.datasources.v2.ArcticTableWriteExec*</include>
                                     </includes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.execution.datasources</pattern>
-                                    <shadedPattern>
-                                        com.netease.arctic.shade.org.apache.spark.sql.execution.datasources
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.execution.datasources</shadedPattern>
                                     <includes>
-                                        <include>
-                                            org.apache.spark.sql.execution.datasources.SparkExpressionConverter*
-                                        </include>
+                                        <include>org.apache.spark.sql.execution.datasources.SparkExpressionConverter*</include>
                                     </includes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.catalyst.analysis</pattern>
-                                    <shadedPattern>
-                                        com.netease.arctic.shade.org.apache.spark.sql.catalyst.analysis
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.catalyst.analysis</shadedPattern>
                                     <includes>
-                                        <include>org.apache.spark.sql.catalyst.analysis.AlignRowLevelOperations*
-                                        </include>
-                                        <include>org.apache.spark.sql.catalyst.analysis.AssignmentAlignmentSupport*
-                                        </include>
-                                        <include>org.apache.spark.sql.catalyst.analysis.ProcedureArgumentCoercion*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.analysis.AlignRowLevelOperations*</include>
+                                        <include>org.apache.spark.sql.catalyst.analysis.AssignmentAlignmentSupport*</include>
+                                        <include>org.apache.spark.sql.catalyst.analysis.ProcedureArgumentCoercion*</include>
                                         <include>org.apache.spark.sql.catalyst.analysis.ResolveProcedures*</include>
-                                        <include>
-                                            org.apache.spark.sql.catalyst.analysis.RowLevelOperationsPredicateCheck*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.analysis.RowLevelOperationsPredicateCheck*</include>
                                     </includes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.catalyst.expressions</pattern>
-                                    <shadedPattern>
-                                        com.netease.arctic.shade.org.apache.spark.sql.catalyst.expressions
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.catalyst.expressions</shadedPattern>
                                     <includes>
                                         <include>org.apache.spark.sql.catalyst.expressions.AccumulateFiles*</include>
                                         <include>org.apache.spark.sql.catalyst.expressions.Iceberg*</include>
@@ -306,16 +274,10 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.catalyst.optimizer</pattern>
-                                    <shadedPattern>
-                                        com.netease.arctic.shade.org.apache.spark.sql.catalyst.optimizer
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.catalyst.optimizer</shadedPattern>
                                     <includes>
-                                        <include>
-                                            org.apache.spark.sql.catalyst.optimizer.OptimizeConditionsInRowLevelOperations*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.catalyst.optimizer.PullupCorrelatedPredicatesInRowLevelOperations*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.optimizer.OptimizeConditionsInRowLevelOperations*</include>
+                                        <include>org.apache.spark.sql.catalyst.optimizer.PullupCorrelatedPredicatesInRowLevelOperations*</include>
                                         <include>org.apache.spark.sql.catalyst.optimizer.RewriteDelete*</include>
                                         <include>org.apache.spark.sql.catalyst.optimizer.RewriteMergeInto*</include>
                                         <include>org.apache.spark.sql.catalyst.optimizer.RewriteUpdate*</include>
@@ -323,57 +285,39 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.catalyst.parser.extensions</pattern>
-                                    <shadedPattern>
-                                        com.netease.arctic.shade.org.apache.spark.sql.catalyst.parser.extensions
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.catalyst.parser.extensions</shadedPattern>
                                     <includes>
                                         <include>org.apache.spark.sql.catalyst.parser.extensions.Iceberg*</include>
-                                        <include>org.apache.spark.sql.catalyst.parser.extensions.UpperCaseCharStream*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.parser.extensions.UpperCaseCharStream*</include>
                                     </includes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.catalyst.plans.logical</pattern>
-                                    <shadedPattern>
-                                        com.netease.arctic.shade.org.apache.spark.sql.catalyst.plans.logical
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.catalyst.plans.logical</shadedPattern>
                                     <includes>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.AddPartitionField*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.AddPartitionField*</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.Call*</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.Drop*</include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilter*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilter*</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.MergeInto</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.MergeInto$</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.MergeIntoParams*</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.NamedArgument*</include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.PositionalArgument*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.PositionalArgument*</include>
                                         <include>org.apache.spark.sql.catalyst.plans.logical.ReplaceData*</include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.ReplacePartitionField*
-                                        </include>
-                                        <include>org.apache.spark.sql.catalyst.plans.logical.SetIdentifierFields*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.catalyst.plans.logical.SetWriteDistributionAndOrdering*
-                                        </include>
-                                        <include>
-                                            org.apache.spark.sql.catalyst.plans.logical.SortOrderParserUtil*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.ReplacePartitionField*</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.SetIdentifierFields*</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.SetWriteDistributionAndOrdering*</include>
+                                        <include>org.apache.spark.sql.catalyst.plans.logical.SortOrderParserUtil*</include>
                                     </includes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.spark.sql.catalyst.utils</pattern>
-                                    <shadedPattern>
-                                        com.netease.arctic.shade.org.apache.spark.sql.catalyst.utils
-                                    </shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.spark.sql.catalyst.utils</shadedPattern>
                                     <includes>
-                                        <include>org.apache.spark.sql.catalyst.utils.DistributionAndOrderingUtils*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.utils.DistributionAndOrderingUtils*</include>
                                         <include>org.apache.spark.sql.catalyst.utils.PlanUtils*</include>
-                                        <include>org.apache.spark.sql.catalyst.utils.RewriteRowLevelOperationHelper*
-                                        </include>
+                                        <include>org.apache.spark.sql.catalyst.utils.RewriteRowLevelOperationHelper*</include>
                                         <include>org.apache.spark.sql.catalyst.utils.SetAccumulator*</include>
                                     </includes>
                                 </relocation>
@@ -399,10 +343,10 @@
                         <executions>
                             <execution>
                                 <id>empty-javadoc-jar</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
+                                <phase>package</phase>
                                 <configuration>
                                     <classifier>javadoc</classifier>
                                     <classesDirectory>${basedir}/javadoc</classesDirectory>

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.netease.arctic</groupId>
         <artifactId>arctic-spark</artifactId>
-        <version>0.5.0-SNAPSHOT</version>
+        <version>0.4.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -70,7 +70,7 @@
                                     <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>
                                     <include>org.apache.iceberg:iceberg-api</include>
-                                    <include>org.apache.iceberg:iceberg-spark-3.1_2.12</include>
+                                    <include>org.apache.iceberg:iceberg-spark-3</include>
                                     <include>org.apache.iceberg:iceberg-common</include>
                                     <include>org.apache.iceberg:iceberg-data</include>
                                     <include>org.apache.iceberg:iceberg-orc</include>
@@ -85,7 +85,7 @@
                                     <include>org.apache.iceberg:iceberg-arrow</include>
                                     <include>org.apache.iceberg:iceberg-hive-metastore</include>
                                     <include>org.apache.iceberg:iceberg-spark</include>
-                                    <include>org.apache.iceberg:iceberg-spark-extensions-3.1_2.12</include>
+                                    <include>org.apache.iceberg:iceberg-spark3-extensions</include>
                                     <include>org.apache.iceberg:iceberg-bundled-guava</include>
 
                                     <include>org.apache.thrift:libthrift</include>


### PR DESCRIPTION
 

## Why are the changes needed?
 
cherry-pick #1414 to 0.4.x
 
 

When AMS is deployed HA, use Kerberos to access non-Kerberos zookeeper will throw an exception.

Now the access to zk with or without Kerberos authentication information is controlled by turning off the parameter `zookeeper.sasl.client`.

## Brief change log
Change in com.netease.arctic.ams.api.client.ZookeeperService#newClient
Add property `ZKClientConfig.ENABLE_CLIENT_SASL_KEK = false` into ZKClientConfig.

## How was this patch tested?
 
- [x] Run test locally before making a pull request
 