### PR TITLE
[AMS-Refactor] Optimizing trigger support hive/base max delay for each partition

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
@@ -2,8 +2,10 @@ package com.netease.arctic.server.optimizing;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Objects;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.utils.CompatiblePropertyUtil;
+import org.apache.iceberg.util.PropertyUtil;
 
 import java.util.Map;
 
@@ -55,11 +57,11 @@ public class OptimizingConfig {
   //base.file-index.hash-bucket
   private int baseHashBucket;
 
-  //self-optimizing.trigger.max-base-delay
-  private long baseMaxDelay;
+  //base.refresh-interval
+  private long baseRefreshInterval;
 
-  //self-optimizing.trigger.max-hive-delay
-  private long hiveMaxDelay;
+  //base.hive.refresh-interval
+  private long hiveRefreshInterval;
 
   public OptimizingConfig() {
   }
@@ -207,21 +209,21 @@ public class OptimizingConfig {
     return this;
   }
 
-  public long getBaseMaxDelay() {
-    return baseMaxDelay;
+  public long getBaseRefreshInterval() {
+    return baseRefreshInterval;
   }
 
-  public OptimizingConfig setBaseMaxDelay(long baseMaxDelay) {
-    this.baseMaxDelay = baseMaxDelay;
+  public OptimizingConfig setBaseRefreshInterval(long baseRefreshInterval) {
+    this.baseRefreshInterval = baseRefreshInterval;
     return this;
   }
 
-  public long getHiveMaxDelay() {
-    return hiveMaxDelay;
+  public long getHiveRefreshInterval() {
+    return hiveRefreshInterval;
   }
 
-  public OptimizingConfig setHiveMaxDelay(long hiveMaxDelay) {
-    this.hiveMaxDelay = hiveMaxDelay;
+  public OptimizingConfig setHiveRefreshInterval(long hiveRefreshInterval) {
+    this.hiveRefreshInterval = hiveRefreshInterval;
     return this;
   }
 
@@ -237,8 +239,8 @@ public class OptimizingConfig {
         minorLeastInterval == that.minorLeastInterval &&
         Double.compare(that.majorDuplicateRatio, majorDuplicateRatio) == 0 &&
         fullTriggerInterval == that.fullTriggerInterval && fullRewriteAllFiles == that.fullRewriteAllFiles &&
-        baseHashBucket == that.baseHashBucket && baseMaxDelay == that.baseMaxDelay &&
-        hiveMaxDelay == that.hiveMaxDelay &&
+        baseHashBucket == that.baseHashBucket && baseRefreshInterval == that.baseRefreshInterval &&
+        hiveRefreshInterval == that.hiveRefreshInterval &&
         Objects.equal(optimizerGroup, that.optimizerGroup);
   }
 
@@ -246,7 +248,7 @@ public class OptimizingConfig {
   public int hashCode() {
     return Objects.hashCode(enabled, targetQuota, optimizerGroup, maxExecuteRetryCount, maxCommitRetryCount, targetSize,
         maxFileCount, openFileCost, fragmentRatio, minorLeastFileCount, minorLeastInterval, majorDuplicateRatio,
-        fullTriggerInterval, fullRewriteAllFiles, baseHashBucket, baseMaxDelay, hiveMaxDelay);
+        fullTriggerInterval, fullRewriteAllFiles, baseHashBucket, baseRefreshInterval, hiveRefreshInterval);
   }
 
   public static OptimizingConfig parseOptimizingConfig(Map<String, String> properties) {
@@ -310,13 +312,13 @@ public class OptimizingConfig {
             properties,
             TableProperties.BASE_FILE_INDEX_HASH_BUCKET,
             TableProperties.BASE_FILE_INDEX_HASH_BUCKET_DEFAULT))
-        .setBaseMaxDelay(CompatiblePropertyUtil.propertyAsLong(
+        .setBaseRefreshInterval(PropertyUtil.propertyAsLong(
             properties,
-            TableProperties.SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY,
-            TableProperties.SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY_DEFAULT))
-        .setHiveMaxDelay(CompatiblePropertyUtil.propertyAsLong(
+            TableProperties.BASE_REFRESH_INTERVAL,
+            TableProperties.BASE_REFRESH_INTERVAL_DEFAULT))
+        .setHiveRefreshInterval(PropertyUtil.propertyAsLong(
             properties,
-            TableProperties.SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY,
-            TableProperties.SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY_DEFAULT));
+            HiveTableProperties.REFRESH_HIVE_INTERVAL,
+            HiveTableProperties.REFRESH_HIVE_INTERVAL_DEFAULT));
   }
 }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
@@ -55,6 +55,12 @@ public class OptimizingConfig {
   //base.file-index.hash-bucket
   private int baseHashBucket;
 
+  //self-optimizing.trigger.base-max-delay
+  private long baseMaxDelay;
+
+  //self-optimizing.trigger.hive-max-delay
+  private long hiveMaxDelay;
+
   public OptimizingConfig() {
   }
 
@@ -201,6 +207,24 @@ public class OptimizingConfig {
     return this;
   }
 
+  public long getBaseMaxDelay() {
+    return baseMaxDelay;
+  }
+
+  public OptimizingConfig setBaseMaxDelay(long baseMaxDelay) {
+    this.baseMaxDelay = baseMaxDelay;
+    return this;
+  }
+
+  public long getHiveMaxDelay() {
+    return hiveMaxDelay;
+  }
+
+  public OptimizingConfig setHiveMaxDelay(long hiveMaxDelay) {
+    this.hiveMaxDelay = hiveMaxDelay;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -213,7 +237,8 @@ public class OptimizingConfig {
         minorLeastInterval == that.minorLeastInterval &&
         Double.compare(that.majorDuplicateRatio, majorDuplicateRatio) == 0 &&
         fullTriggerInterval == that.fullTriggerInterval && fullRewriteAllFiles == that.fullRewriteAllFiles &&
-        baseHashBucket == that.baseHashBucket &&
+        baseHashBucket == that.baseHashBucket && baseMaxDelay == that.baseMaxDelay &&
+        hiveMaxDelay == that.hiveMaxDelay &&
         Objects.equal(optimizerGroup, that.optimizerGroup);
   }
 
@@ -221,7 +246,7 @@ public class OptimizingConfig {
   public int hashCode() {
     return Objects.hashCode(enabled, targetQuota, optimizerGroup, maxExecuteRetryCount, maxCommitRetryCount, targetSize,
         maxFileCount, openFileCost, fragmentRatio, minorLeastFileCount, minorLeastInterval, majorDuplicateRatio,
-        fullTriggerInterval, fullRewriteAllFiles, baseHashBucket);
+        fullTriggerInterval, fullRewriteAllFiles, baseHashBucket, baseMaxDelay, hiveMaxDelay);
   }
 
   public static OptimizingConfig parseOptimizingConfig(Map<String, String> properties) {
@@ -284,6 +309,14 @@ public class OptimizingConfig {
         .setBaseHashBucket(CompatiblePropertyUtil.propertyAsInt(
             properties,
             TableProperties.BASE_FILE_INDEX_HASH_BUCKET,
-            TableProperties.BASE_FILE_INDEX_HASH_BUCKET_DEFAULT));
+            TableProperties.BASE_FILE_INDEX_HASH_BUCKET_DEFAULT))
+        .setBaseMaxDelay(CompatiblePropertyUtil.propertyAsLong(
+            properties,
+            TableProperties.SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY,
+            TableProperties.SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY_DEFAULT))
+        .setHiveMaxDelay(CompatiblePropertyUtil.propertyAsLong(
+            properties,
+            TableProperties.SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY,
+            TableProperties.SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY_DEFAULT));
   }
 }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
@@ -55,10 +55,10 @@ public class OptimizingConfig {
   //base.file-index.hash-bucket
   private int baseHashBucket;
 
-  //self-optimizing.trigger.base-max-delay
+  //self-optimizing.trigger.max-base-delay
   private long baseMaxDelay;
 
-  //self-optimizing.trigger.hive-max-delay
+  //self-optimizing.trigger.max-hive-delay
   private long hiveMaxDelay;
 
   public OptimizingConfig() {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -119,7 +119,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
 
   @Override
   public void addPartitionProperties(Map<String, String> properties) {
-    
+    evaluator().addPartitionProperties(properties);
   }
 
   public List<TaskDescriptor> splitTasks(int targetTaskCount) {
@@ -214,6 +214,11 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
   @Override
   public long getPosDeleteFileSize() {
     return evaluator().getPosDeleteFileSize();
+  }
+
+  @Override
+  public Weight getWeight() {
+    return evaluator().getWeight();
   }
 
   protected class SplitTask {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -117,6 +117,11 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
     }
   }
 
+  @Override
+  public void addPartitionProperties(Map<String, String> properties) {
+    
+  }
+
   public List<TaskDescriptor> splitTasks(int targetTaskCount) {
     if (taskSplitter == null) {
       taskSplitter = buildTaskSplitter();

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.FileContent;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class CommonPartitionEvaluator implements PartitionEvaluator {
@@ -82,6 +83,10 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
     } else {
       addSegmentFile(dataFile, deletes);
     }
+  }
+
+  @Override
+  public void addPartitionProperties(Map<String, String> properties) {
   }
 
   private boolean isDuplicateDelete(IcebergContentFile<?> delete) {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
@@ -26,7 +26,6 @@ import com.netease.arctic.server.table.TableRuntime;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Map;
@@ -285,7 +284,7 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
     }
 
     @Override
-    public int compareTo(@NotNull PartitionEvaluator.Weight o) {
+    public int compareTo(PartitionEvaluator.Weight o) {
       return Long.compare(this.cost, ((Weight) o).cost);
     }
   }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
@@ -59,6 +59,8 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   protected long posDeleteFileSize = 0L;
 
   private long cost = -1;
+  private Boolean necessary = null;
+  private OptimizingType optimizingType = null;
 
   public CommonPartitionEvaluator(TableRuntime tableRuntime, String partition, long planTime) {
     this.partition = partition;
@@ -156,7 +158,10 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
 
   @Override
   public boolean isNecessary() {
-    return isFullNecessary() || isMajorNecessary() || isMinorNecessary();
+    if (necessary == null) {
+      necessary = isFullNecessary() || isMajorNecessary() || isMinorNecessary();
+    }
+    return necessary;
   }
 
   @Override
@@ -178,8 +183,11 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
 
   @Override
   public OptimizingType getOptimizingType() {
-    return isFullNecessary() ? OptimizingType.FULL_MAJOR :
-        isMajorNecessary() ? OptimizingType.MAJOR : OptimizingType.MINOR;
+    if (optimizingType == null) {
+      optimizingType = isFullNecessary() ? OptimizingType.FULL_MAJOR :
+          isMajorNecessary() ? OptimizingType.MAJOR : OptimizingType.MINOR;
+    }
+    return optimizingType;
   }
 
   public boolean isMajorNecessary() {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
@@ -26,6 +26,7 @@ import com.netease.arctic.server.table.TableRuntime;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Map;
@@ -171,6 +172,11 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   }
 
   @Override
+  public PartitionEvaluator.Weight getWeight() {
+    return new Weight(getCost());
+  }
+
+  @Override
   public OptimizingType getOptimizingType() {
     return isFullNecessary() ? OptimizingType.FULL_MAJOR :
         isMajorNecessary() ? OptimizingType.MAJOR : OptimizingType.MINOR;
@@ -260,5 +266,19 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   @Override
   public long getPosDeleteFileSize() {
     return posDeleteFileSize;
+  }
+
+  public static class Weight implements PartitionEvaluator.Weight {
+
+    private final long cost;
+
+    public Weight(long cost) {
+      this.cost = cost;
+    }
+
+    @Override
+    public int compareTo(@NotNull PartitionEvaluator.Weight o) {
+      return Long.compare(this.cost, ((Weight) o).cost);
+    }
   }
 }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -22,12 +22,14 @@ import com.netease.arctic.data.DataFileType;
 import com.netease.arctic.data.IcebergContentFile;
 import com.netease.arctic.data.IcebergDataFile;
 import com.netease.arctic.data.PrimaryKeyedFile;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.utils.HiveTableUtil;
 import com.netease.arctic.optimizing.OptimizingInputProperties;
 import com.netease.arctic.server.table.TableRuntime;
 import com.netease.arctic.table.ArcticTable;
 
 import java.util.List;
+import java.util.Map;
 
 public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
   private final String hiveLocation;
@@ -108,7 +110,9 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
 
   protected static class MixedHivePartitionEvaluator extends MixedIcebergPartitionEvaluator {
     private final String hiveLocation;
-    private boolean hasNotInHiveLocationFile = false;
+    private boolean hasNotInHiveLocationDataFile = false;
+    // partition property
+    protected long lastHiveOptimizedTime;
 
     public MixedHivePartitionEvaluator(TableRuntime tableRuntime, String partition, String hiveLocation,
                                        long planTime, boolean keyedTable) {
@@ -119,8 +123,18 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
     @Override
     public void addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
       super.addFile(dataFile, deletes);
-      if (!hasNotInHiveLocationFile && notInHiveLocation(dataFile)) {
-        hasNotInHiveLocationFile = true;
+      if (!hasNotInHiveLocationDataFile && notInHiveLocation(dataFile)) {
+        hasNotInHiveLocationDataFile = true;
+      }
+    }
+
+    @Override
+    public void addPartitionProperties(Map<String, String> properties) {
+      super.addPartitionProperties(properties);
+      String optimizedTime = properties.get(HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME);
+      if (optimizedTime != null) {
+        // the unit of transient-time is seconds
+        this.lastHiveOptimizedTime = Integer.parseInt(optimizedTime) * 1000L;
       }
     }
 
@@ -140,10 +154,21 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
 
     @Override
     public boolean isFullNecessary() {
+      if (reachHiveOptimizedDelay() && hasNewHiveData()) {
+        return true;
+      }
       if (!reachFullInterval()) {
         return false;
       }
-      return anyDeleteExist() || fragmentFileCount > getBaseSplitCount() || hasChangeFiles || hasNotInHiveLocationFile;
+      return fragmentFileCount > getBaseSplitCount() || hasNewHiveData();
+    }
+
+    protected boolean hasNewHiveData() {
+      return anyDeleteExist() || hasChangeFiles || hasNotInHiveLocationDataFile;
+    }
+
+    protected boolean reachHiveOptimizedDelay() {
+      return config.getHiveMaxDelay() >= 0 && planTime - lastHiveOptimizedTime > config.getHiveMaxDelay();
     }
 
     @Override

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -110,7 +110,7 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
 
   protected static class MixedHivePartitionEvaluator extends MixedIcebergPartitionEvaluator {
     private final String hiveLocation;
-    private boolean hasNotInHiveLocationDataFile = false;
+    private boolean filesNotInHiveLocation = false;
     // partition property
     protected long lastHiveOptimizedTime;
 
@@ -123,8 +123,8 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
     @Override
     public void addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
       super.addFile(dataFile, deletes);
-      if (!hasNotInHiveLocationDataFile && notInHiveLocation(dataFile)) {
-        hasNotInHiveLocationDataFile = true;
+      if (!filesNotInHiveLocation && notInHiveLocation(dataFile)) {
+        filesNotInHiveLocation = true;
       }
     }
 
@@ -164,7 +164,7 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
     }
 
     protected boolean hasNewHiveData() {
-      return anyDeleteExist() || hasChangeFiles || hasNotInHiveLocationDataFile;
+      return anyDeleteExist() || hasChangeFiles || filesNotInHiveLocation;
     }
 
     protected boolean reachHiveRefreshInterval() {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -176,6 +176,12 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
       return super.shouldRewriteSegmentFile(dataFile, deletes) && notInHiveLocation(dataFile);
     }
 
+    @Override
+    public PartitionEvaluator.Weight getWeight() {
+      return new Weight(getCost(),
+          hasChangeFiles && reachBaseOptimizedDelay() || hasNewHiveData() && reachHiveOptimizedDelay());
+    }
+
     private boolean notInHiveLocation(IcebergContentFile<?> file) {
       return !file.path().toString().contains(hiveLocation);
     }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -154,7 +154,7 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
 
     @Override
     public boolean isFullNecessary() {
-      if (reachHiveOptimizedDelay() && hasNewHiveData()) {
+      if (reachHiveRefreshInterval() && hasNewHiveData()) {
         return true;
       }
       if (!reachFullInterval()) {
@@ -167,8 +167,8 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
       return anyDeleteExist() || hasChangeFiles || hasNotInHiveLocationDataFile;
     }
 
-    protected boolean reachHiveOptimizedDelay() {
-      return config.getHiveMaxDelay() >= 0 && planTime - lastHiveOptimizedTime > config.getHiveMaxDelay();
+    protected boolean reachHiveRefreshInterval() {
+      return config.getHiveRefreshInterval() >= 0 && planTime - lastHiveOptimizedTime > config.getHiveRefreshInterval();
     }
 
     @Override
@@ -179,7 +179,7 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
     @Override
     public PartitionEvaluator.Weight getWeight() {
       return new Weight(getCost(),
-          hasChangeFiles && reachBaseOptimizedDelay() || hasNewHiveData() && reachHiveOptimizedDelay());
+          hasChangeFiles && reachBaseRefreshInterval() || hasNewHiveData() && reachHiveRefreshInterval());
     }
 
     private boolean notInHiveLocation(IcebergContentFile<?> file) {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedIcebergPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedIcebergPartitionPlan.java
@@ -157,7 +157,7 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
           return true;
         } else if ((smallFileCount > baseSplitCount || hasChangeFiles) && reachMinorInterval()) {
           return true;
-        } else if (hasChangeFiles && reachBaseOptimizedDelay()) {
+        } else if (hasChangeFiles && reachBaseRefreshInterval()) {
           return true;
         } else {
           return false;
@@ -167,8 +167,8 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
       }
     }
 
-    protected boolean reachBaseOptimizedDelay() {
-      return config.getBaseMaxDelay() >= 0 && planTime - lastBaseOptimizedTime > config.getBaseMaxDelay();
+    protected boolean reachBaseRefreshInterval() {
+      return config.getBaseRefreshInterval() >= 0 && planTime - lastBaseOptimizedTime > config.getBaseRefreshInterval();
     }
 
     protected int getBaseSplitCount() {
@@ -189,7 +189,7 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
 
     @Override
     public PartitionEvaluator.Weight getWeight() {
-      return new Weight(getCost(), hasChangeFiles && reachBaseOptimizedDelay());
+      return new Weight(getCost(), hasChangeFiles && reachBaseRefreshInterval());
     }
 
     protected static class Weight implements PartitionEvaluator.Weight {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedIcebergPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedIcebergPartitionPlan.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.FileContent;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.BinPacking;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -202,7 +201,7 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
       }
 
       @Override
-      public int compareTo(@NotNull PartitionEvaluator.Weight o) {
+      public int compareTo(PartitionEvaluator.Weight o) {
         Weight that = (Weight) o;
         int compare = Boolean.compare(this.reachDelay, that.reachDelay);
         if (compare != 0) {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedIcebergPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedIcebergPartitionPlan.java
@@ -27,6 +27,7 @@ import com.netease.arctic.hive.optimizing.MixFormatRewriteExecutorFactory;
 import com.netease.arctic.optimizing.OptimizingInputProperties;
 import com.netease.arctic.server.table.TableRuntime;
 import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.TableProperties;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -99,6 +100,8 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
   protected static class MixedIcebergPartitionEvaluator extends CommonPartitionEvaluator {
     protected final boolean keyedTable;
     protected boolean hasChangeFiles = false;
+    // partition property
+    protected long lastBaseOptimizedTime;
 
     public MixedIcebergPartitionEvaluator(TableRuntime tableRuntime, String partition, long planTime,
                                           boolean keyedTable) {
@@ -111,6 +114,15 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
       super.addFile(dataFile, deletes);
       if (!hasChangeFiles && isChangeFile(dataFile)) {
         hasChangeFiles = true;
+      }
+    }
+
+    @Override
+    public void addPartitionProperties(Map<String, String> properties) {
+      super.addPartitionProperties(properties);
+      String optimizedTime = properties.get(TableProperties.PARTITION_BASE_OPTIMIZED_TIME);
+      if (optimizedTime != null) {
+        this.lastBaseOptimizedTime = Long.parseLong(optimizedTime);
       }
     }
 
@@ -144,12 +156,18 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
           return true;
         } else if ((smallFileCount > baseSplitCount || hasChangeFiles) && reachMinorInterval()) {
           return true;
+        } else if (hasChangeFiles && reachBaseOptimizedDelay()) {
+          return true;
         } else {
           return false;
         }
       } else {
         return super.isMinorNecessary();
       }
+    }
+
+    protected boolean reachBaseOptimizedDelay() {
+      return config.getBaseMaxDelay() >= 0 && planTime - lastBaseOptimizedTime > config.getBaseMaxDelay();
     }
 
     protected int getBaseSplitCount() {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
@@ -40,8 +40,7 @@ import java.util.stream.Collectors;
 public class OptimizingPlanner extends OptimizingEvaluator {
   private static final Logger LOG = LoggerFactory.getLogger(OptimizingPlanner.class);
 
-  private static final int MAX_INPUT_FILE_COUNT_PER_THREAD = 5000;
-  private static final long MAX_INPUT_FILE_SIZE_PER_THREAD = 5 * 1024 * 1024 * 1024;
+  private static final long MAX_INPUT_FILE_SIZE_PER_THREAD = 5L * 1024 * 1024 * 1024;
 
   private final TableFileScanHelper.PartitionFilter partitionFilter;
 

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
@@ -119,7 +119,8 @@ public class OptimizingPlanner extends OptimizingEvaluator {
     }
 
     List<PartitionEvaluator> evaluators = new ArrayList<>(partitionPlanMap.values());
-    Collections.sort(evaluators, Comparator.comparing(evaluator -> evaluator.getCost() * -1));
+    evaluators.sort(Comparator.comparing(PartitionEvaluator::getWeight));
+    Collections.reverse(evaluators);
 
     double maxInputSize = MAX_INPUT_FILE_SIZE_PER_THREAD * availableCore;
     List<PartitionEvaluator> inputPartitions = Lists.newArrayList();

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
@@ -27,6 +27,13 @@ import java.util.Map;
 
 public interface PartitionEvaluator {
 
+  /**
+   * Weight determines the priority of partition execution, with higher weights having higher priority.
+   */
+  interface Weight extends Comparable<Weight> {
+
+  }
+
   String getPartition();
 
   void addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes);
@@ -36,6 +43,8 @@ public interface PartitionEvaluator {
   boolean isNecessary();
 
   long getCost();
+  
+  Weight getWeight();
 
   OptimizingType getOptimizingType();
 

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
@@ -23,12 +23,15 @@ import com.netease.arctic.data.IcebergDataFile;
 import com.netease.arctic.server.optimizing.OptimizingType;
 
 import java.util.List;
+import java.util.Map;
 
 public interface PartitionEvaluator {
 
   String getPartition();
 
   void addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes);
+  
+  void addPartitionProperties(Map<String, String> properties);
 
   boolean isNecessary();
 

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestHiveKeyedPartitionPlan.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestHiveKeyedPartitionPlan.java
@@ -30,7 +30,6 @@ import com.netease.arctic.hive.catalog.HiveTableTestHelper;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.optimizing.OptimizingInputProperties;
 import com.netease.arctic.server.optimizing.OptimizingTestHelpers;
-import com.netease.arctic.table.TableProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.data.Record;
@@ -101,7 +100,7 @@ public class TestHiveKeyedPartitionPlan extends TestKeyedPartitionPlan {
     Assert.assertEquals(0, planWithCurrentFiles().size());
 
     // update hive delay
-    updateTableProperty(TableProperties.SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY, 1 + "");
+    updateTableProperty(HiveTableProperties.REFRESH_HIVE_INTERVAL, 1 + "");
     Assert.assertEquals(4, planWithCurrentFiles().size());
     updatePartitionProperty(partition, HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME,
         (System.currentTimeMillis() / 1000 - 10) + "");

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestHiveOptimizingEvaluator.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestHiveOptimizingEvaluator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.server.optimizing.plan;
+
+import com.netease.arctic.TableTestHelper;
+import com.netease.arctic.ams.api.TableFormat;
+import com.netease.arctic.catalog.CatalogTestHelper;
+import com.netease.arctic.hive.TestHMS;
+import com.netease.arctic.hive.catalog.HiveCatalogTestHelper;
+import com.netease.arctic.hive.catalog.HiveTableTestHelper;
+import org.junit.ClassRule;
+import org.junit.runners.Parameterized;
+
+public class TestHiveOptimizingEvaluator extends TestOptimizingEvaluator {
+  @ClassRule
+  public static TestHMS TEST_HMS = new TestHMS();
+
+  public TestHiveOptimizingEvaluator(CatalogTestHelper catalogTestHelper,
+                                     TableTestHelper tableTestHelper) {
+    super(catalogTestHelper, tableTestHelper);
+  }
+
+  @Parameterized.Parameters(name = "{0}, {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        {new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()),
+            new HiveTableTestHelper(true, true)},
+        {new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()),
+            new HiveTableTestHelper(true, false)},
+        {new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()),
+            new HiveTableTestHelper(false, true)},
+        {new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()),
+            new HiveTableTestHelper(false, false)}};
+  }
+}

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestHiveUnkeyedPartitionPlan.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestHiveUnkeyedPartitionPlan.java
@@ -29,7 +29,6 @@ import com.netease.arctic.hive.catalog.HiveTableTestHelper;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.optimizing.OptimizingInputProperties;
 import com.netease.arctic.server.optimizing.OptimizingTestHelpers;
-import com.netease.arctic.table.TableProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.data.Record;
@@ -98,7 +97,7 @@ public class TestHiveUnkeyedPartitionPlan extends TestUnkeyedPartitionPlan {
     Assert.assertEquals(0, planWithCurrentFiles().size());
 
     // update hive delay
-    updateTableProperty(TableProperties.SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY, 1 + "");
+    updateTableProperty(HiveTableProperties.REFRESH_HIVE_INTERVAL, 1 + "");
     Assert.assertEquals(1, planWithCurrentFiles().size());
     updatePartitionProperty(partition, HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME,
         (System.currentTimeMillis() / 1000 - 10) + "");

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestHiveUnkeyedPartitionPlan.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestHiveUnkeyedPartitionPlan.java
@@ -22,16 +22,25 @@ import com.google.common.collect.Maps;
 import com.netease.arctic.TableTestHelper;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.catalog.CatalogTestHelper;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.TestHMS;
 import com.netease.arctic.hive.catalog.HiveCatalogTestHelper;
 import com.netease.arctic.hive.catalog.HiveTableTestHelper;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.optimizing.OptimizingInputProperties;
+import com.netease.arctic.server.optimizing.OptimizingTestHelpers;
+import com.netease.arctic.table.TableProperties;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.List;
 import java.util.Map;
 
 @RunWith(Parameterized.class)
@@ -69,5 +78,33 @@ public class TestHiveUnkeyedPartitionPlan extends TestUnkeyedPartitionPlan {
     String hiveLocation = hiveTable.hiveLocation();
     return new MixedHivePartitionPlan(getTableRuntime(), getArcticTable(), getPartition(), hiveLocation,
         System.currentTimeMillis());
+  }
+
+  @Test
+  public void testFullOptimizingWithHiveDelay() {
+    closeFullOptimizingInterval();
+    closeMinorOptimizingInterval();
+    List<Record> newRecords;
+    long transactionId;
+    List<DataFile> dataFiles = Lists.newArrayList();
+    // write fragment file
+    newRecords = OptimizingTestHelpers.generateRecord(tableTestHelper(), 1, 4, "2022-01-01T12:00:00");
+    transactionId = beginTransaction();
+    dataFiles.addAll(OptimizingTestHelpers.appendBase(getArcticTable(),
+        tableTestHelper().writeBaseStore(getArcticTable(), transactionId, newRecords, false)));
+    StructLike partition = dataFiles.get(0).partition();
+
+    // not trigger optimize
+    Assert.assertEquals(0, planWithCurrentFiles().size());
+
+    // update hive delay
+    updateTableProperty(TableProperties.SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY, 1 + "");
+    Assert.assertEquals(1, planWithCurrentFiles().size());
+    updatePartitionProperty(partition, HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME,
+        (System.currentTimeMillis() / 1000 - 10) + "");
+    Assert.assertEquals(1, planWithCurrentFiles().size());
+    updatePartitionProperty(partition, HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME,
+        (System.currentTimeMillis() / 1000 + 1000) + "");
+    Assert.assertEquals(0, planWithCurrentFiles().size());
   }
 }

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestKeyedPartitionPlan.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestKeyedPartitionPlan.java
@@ -160,7 +160,7 @@ public class TestKeyedPartitionPlan extends MixedTablePlanTestBase {
     Assert.assertEquals(0, planWithCurrentFiles().size());
 
     // update base delay
-    updateTableProperty(TableProperties.SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY, 1 + "");
+    updateTableProperty(TableProperties.BASE_REFRESH_INTERVAL, 1 + "");
     Assert.assertEquals(4, planWithCurrentFiles().size());
     updatePartitionProperty(partition, TableProperties.PARTITION_BASE_OPTIMIZED_TIME,
         (System.currentTimeMillis() - 10) + "");

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestKeyedPartitionPlan.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestKeyedPartitionPlan.java
@@ -28,8 +28,10 @@ import com.netease.arctic.server.optimizing.OptimizingTestHelpers;
 import com.netease.arctic.server.optimizing.scan.KeyedTableFileScanHelper;
 import com.netease.arctic.server.optimizing.scan.TableFileScanHelper;
 import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
@@ -82,7 +84,7 @@ public class TestKeyedPartitionPlan extends MixedTablePlanTestBase {
   @Test
   public void testOnlyOneChangeFiles() {
     updateChangeHashBucket(1);
-    closeFullOptimizing();
+    closeFullOptimizingInterval();
     // write fragment file
     List<Record> newRecords = OptimizingTestHelpers.generateRecord(tableTestHelper(), 1, 4, "2022-01-01T12:00:00");
     long transactionId = beginTransaction();
@@ -101,7 +103,7 @@ public class TestKeyedPartitionPlan extends MixedTablePlanTestBase {
   @Test
   public void testChangeFilesWithDelete() {
     updateChangeHashBucket(1);
-    closeFullOptimizing();
+    closeFullOptimizingInterval();
     List<Record> newRecords;
     long transactionId;
     List<DataFile> dataFiles = Lists.newArrayList();
@@ -136,6 +138,36 @@ public class TestKeyedPartitionPlan extends MixedTablePlanTestBase {
 
     assertTask(taskDescriptors.get(0), dataFiles, Collections.emptyList(), Collections.emptyList(),
         deleteFiles);
+  }
+
+  @Test
+  public void testMinorOptimizingWithBaseDelay() {
+    updateChangeHashBucket(4);
+    closeFullOptimizingInterval();
+    closeMinorOptimizingInterval();
+    List<Record> newRecords;
+    long transactionId;
+    List<DataFile> dataFiles = Lists.newArrayList();
+    // write fragment file
+    newRecords = OptimizingTestHelpers.generateRecord(tableTestHelper(), 1, 4, "2022-01-01T12:00:00");
+    transactionId = beginTransaction();
+    dataFiles.addAll(OptimizingTestHelpers.appendChange(getArcticTable(),
+        tableTestHelper().writeChangeStore(getArcticTable(), transactionId, ChangeAction.INSERT,
+            newRecords, false)));
+    StructLike partition = dataFiles.get(0).partition();
+
+    // not trigger optimize
+    Assert.assertEquals(0, planWithCurrentFiles().size());
+
+    // update base delay
+    updateTableProperty(TableProperties.SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY, 1 + "");
+    Assert.assertEquals(4, planWithCurrentFiles().size());
+    updatePartitionProperty(partition, TableProperties.PARTITION_BASE_OPTIMIZED_TIME,
+        (System.currentTimeMillis() - 10) + "");
+    Assert.assertEquals(4, planWithCurrentFiles().size());
+    updatePartitionProperty(partition, TableProperties.PARTITION_BASE_OPTIMIZED_TIME,
+        (System.currentTimeMillis() + 1000000) + "");
+    Assert.assertEquals(0, planWithCurrentFiles().size());
   }
 
   @Override

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestOptimizingEvaluator.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/TestOptimizingEvaluator.java
@@ -71,7 +71,7 @@ public class TestOptimizingEvaluator extends MixedTablePlanTestBase {
 
   @Test
   public void testFragmentFiles() {
-    closeFullOptimizing();
+    closeFullOptimizingInterval();
     updateBaseHashBucket(1);
     List<DataFile> dataFiles = Lists.newArrayList();
     List<Record> newRecords = OptimizingTestHelpers.generateRecord(tableTestHelper(), 1, 4, "2022-01-01T12:00:00");

--- a/core/src/main/java/com/netease/arctic/op/OverwriteBaseFiles.java
+++ b/core/src/main/java/com/netease/arctic/op/OverwriteBaseFiles.java
@@ -20,12 +20,14 @@ package com.netease.arctic.op;
 
 import com.netease.arctic.scan.CombinedScanTask;
 import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.StructLike;
@@ -35,12 +37,14 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.StructLikeMap;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Overwrite {@link com.netease.arctic.table.BaseTable} and change max transaction id map
@@ -148,7 +152,7 @@ public class OverwriteBaseFiles extends PartitionTransactionOperation {
   }
 
   @Override
-  protected StructLikeMap<Long> apply(Transaction transaction, StructLikeMap<Long> partitionOptimizedSequence) {
+  protected StructLikeMap<Map<String, String>> apply(Transaction transaction) {
     Preconditions.checkState(this.dynamic != null,
         "updateOptimizedSequence() or updateOptimizedSequenceDynamically() must be invoked");
     applyDeleteExpression();
@@ -231,13 +235,19 @@ public class OverwriteBaseFiles extends PartitionTransactionOperation {
     }
 
     // step3: set optimized sequence id
+    PartitionSpec spec = transaction.table().spec();
+    StructLikeMap<Map<String, String>> partitionProperties = StructLikeMap.create(spec.partitionType());
     if (this.dynamic) {
-      partitionOptimizedSequence.putAll(sequenceForChangedPartitions);
+      sequenceForChangedPartitions.forEach((partition, sequence) ->
+          partitionProperties.computeIfAbsent(partition, k -> Maps.newHashMap())
+              .put(TableProperties.PARTITION_OPTIMIZED_SEQUENCE, String.valueOf(sequence)));
     } else {
-      partitionOptimizedSequence.putAll(this.partitionOptimizedSequence);
+      this.partitionOptimizedSequence.forEach((partition, sequence) ->
+          partitionProperties.computeIfAbsent(partition, k -> Maps.newHashMap())
+              .put(TableProperties.PARTITION_OPTIMIZED_SEQUENCE, String.valueOf(sequence)));
     }
 
-    return partitionOptimizedSequence;
+    return partitionProperties;
   }
 
   private void applyDeleteExpression() {

--- a/core/src/main/java/com/netease/arctic/op/RewritePartitions.java
+++ b/core/src/main/java/com/netease/arctic/op/RewritePartitions.java
@@ -5,7 +5,9 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.PendingUpdate;
 import org.apache.iceberg.util.StructLikeMap;
 
-public interface RewritePartitions extends PendingUpdate<StructLikeMap<Long>> {
+import java.util.Map;
+
+public interface RewritePartitions extends PendingUpdate<StructLikeMap<Map<String, String>>> {
 
   /**
    * Add a {@link DataFile} to the table.

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -109,14 +109,6 @@ public class TableProperties {
   public static final String SELF_OPTIMIZING_FULL_TRIGGER_INTERVAL = "self-optimizing.full.trigger.interval";
   public static final int SELF_OPTIMIZING_FULL_TRIGGER_INTERVAL_DEFAULT = -1; // not trigger
 
-  public static final String SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY =
-      "self-optimizing.trigger.max-base-delay";
-  public static final long SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY_DEFAULT = -1L;
-
-  public static final String SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY =
-      "self-optimizing.trigger.max-hive-delay";
-  public static final long SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY_DEFAULT = -1L;
-
   public static final String SELF_OPTIMIZING_FULL_REWRITE_ALL_FILES = "self-optimizing.full.rewrite-all-files";
   public static final boolean SELF_OPTIMIZING_FULL_REWRITE_ALL_FILES_DEFAULT = true;
 
@@ -229,6 +221,9 @@ public class TableProperties {
   public static final String WRITE_DISTRIBUTION_HASH_PRIMARY_PARTITION = "primary-partition-key";
   public static final String WRITE_DISTRIBUTION_HASH_AUTO = "auto";
   public static final String WRITE_DISTRIBUTION_HASH_MODE_DEFAULT = WRITE_DISTRIBUTION_HASH_AUTO;
+
+  public static final String BASE_REFRESH_INTERVAL = "base.refresh-interval";
+  public static final long BASE_REFRESH_INTERVAL_DEFAULT = -1L;
 
   /**
    * table read related properties

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -39,6 +39,7 @@ public class TableProperties {
   public static final String BASE_TABLE_MAX_TRANSACTION_ID = "base.table.max-transaction-id";
 
   public static final String PARTITION_OPTIMIZED_SEQUENCE = "max-txId";
+  public static final String PARTITION_BASE_OPTIMIZED_TIME = "base-op-time";
 
   public static final String LOCATION = "location";
 
@@ -107,6 +108,14 @@ public class TableProperties {
 
   public static final String SELF_OPTIMIZING_FULL_TRIGGER_INTERVAL = "self-optimizing.full.trigger.interval";
   public static final int SELF_OPTIMIZING_FULL_TRIGGER_INTERVAL_DEFAULT = -1; // not trigger
+
+  public static final String SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY =
+      "self-optimizing.trigger.base-max-delay";
+  public static final long SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY_DEFAULT = -1L;
+
+  public static final String SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY =
+      "self-optimizing.trigger.hive-max-delay";
+  public static final long SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY_DEFAULT = -1L;
 
   public static final String SELF_OPTIMIZING_FULL_REWRITE_ALL_FILES = "self-optimizing.full.rewrite-all-files";
   public static final boolean SELF_OPTIMIZING_FULL_REWRITE_ALL_FILES_DEFAULT = true;
@@ -273,7 +282,7 @@ public class TableProperties {
 
   public static final String LOG_STORE_DATA_VERSION = "log-store.data-version";
   public static final String LOG_STORE_DATA_VERSION_DEFAULT = "v1";
-  
+
   public static final String LOG_STORE_PROPERTIES_PREFIX = "properties.";
 
   public static final String OWNER = "owner";

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -110,11 +110,11 @@ public class TableProperties {
   public static final int SELF_OPTIMIZING_FULL_TRIGGER_INTERVAL_DEFAULT = -1; // not trigger
 
   public static final String SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY =
-      "self-optimizing.trigger.base-max-delay";
+      "self-optimizing.trigger.max-base-delay";
   public static final long SELF_OPTIMIZING_TRIGGER_BASE_MAX_DELAY_DEFAULT = -1L;
 
   public static final String SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY =
-      "self-optimizing.trigger.hive-max-delay";
+      "self-optimizing.trigger.max-hive-delay";
   public static final long SELF_OPTIMIZING_TRIGGER_HIVE_MAX_DELAY_DEFAULT = -1L;
 
   public static final String SELF_OPTIMIZING_FULL_REWRITE_ALL_FILES = "self-optimizing.full.rewrite-all-files";

--- a/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
+++ b/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
@@ -48,6 +48,9 @@ public class HiveTableProperties {
   public static final String AUTO_SYNC_HIVE_DATA_WRITE = "base.hive.auto-sync-data-write";
   public static final boolean AUTO_SYNC_HIVE_DATA_WRITE_DEFAULT = false;
 
+  public static final String REFRESH_HIVE_INTERVAL = "base.hive.refresh-interval";
+  public static final long REFRESH_HIVE_INTERVAL_DEFAULT = -1L;
+
   public static final String ALLOW_HIVE_TABLE_EXISTED = "allow-hive-table-existed";
 
   public static final String WATERMARK_HIVE = "watermark.hive";


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->



## Brief change log

  - refactor PartitionTransactionOperation: apply() return partition properties
  - support table partition property `base-op-time` as base partition last optimized time
  - use HiveTableProperties `transient-time` as hive partition last optimized time
  - optimizing support base max delay and hive max delay
  - add partition evaluator weight

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
