### PR TITLE
[ARCTIC-1482][Flink]: When making a connection via ams in high availability mode, NoClassDefFoundError is encountered

### DIFF
--- a/flink/v1.12/flink-runtime/pom.xml
+++ b/flink/v1.12/flink-runtime/pom.xml
@@ -148,6 +148,7 @@
                                     <include>com.netease.arctic:*</include>
                                     <include>org.apache.parquet:*</include>
                                     <include>org.apache.commons:*</include>
+                                    <include>org.apache.zookeeper:*</include>
                                     <include>commons-lang:*</include>
                                     <include>com.fasterxml.jackson.core:*</include>
                                     <include>org.apache.thrift:*</include>
@@ -347,6 +348,11 @@
                                 <relocation>
                                     <pattern>org.apache.avro</pattern>
                                     <shadedPattern>com.netease.arctic.shaded.org.apache.avro</shadedPattern>
+                                </relocation>
+                                <!--               zookeeper                 -->
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/flink/v1.12/flink-runtime/pom.xml
+++ b/flink/v1.12/flink-runtime/pom.xml
@@ -149,6 +149,7 @@
                                     <include>org.apache.parquet:*</include>
                                     <include>org.apache.commons:*</include>
                                     <include>org.apache.zookeeper:*</include>
+                                    <include>org.apache.curator:*</include>
                                     <include>commons-lang:*</include>
                                     <include>com.fasterxml.jackson.core:*</include>
                                     <include>org.apache.thrift:*</include>
@@ -353,6 +354,11 @@
                                 <relocation>
                                     <pattern>org.apache.zookeeper</pattern>
                                     <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+                                <!--               curator                 -->
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/flink/v1.12/flink-runtime/pom.xml
+++ b/flink/v1.12/flink-runtime/pom.xml
@@ -353,12 +353,12 @@
                                 <!--               zookeeper                 -->
                                 <relocation>
                                     <pattern>org.apache.zookeeper</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shaded.org.apache.zookeeper</shadedPattern>
                                 </relocation>
                                 <!--               curator                 -->
                                 <relocation>
                                     <pattern>org.apache.curator</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shaded.org.apache.curator</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/flink/v1.14/flink-runtime/pom.xml
+++ b/flink/v1.14/flink-runtime/pom.xml
@@ -206,6 +206,7 @@
                             <include>org.apache.parquet:*</include>
                             <include>org.apache.commons:*</include>
                             <include>org.apache.zookeeper:*</include>
+                            <include>org.apache.curator:*</include>
                             <include>commons-lang:*</include>
                             <include>com.fasterxml.jackson.core:*</include>
                             <include>org.apache.thrift:*</include>
@@ -275,6 +276,11 @@
                                 <relocation>
                                     <pattern>org.apache.zookeeper</pattern>
                                     <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+                                <!--               curator                 -->
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/flink/v1.14/flink-runtime/pom.xml
+++ b/flink/v1.14/flink-runtime/pom.xml
@@ -275,12 +275,12 @@
                                 <!--               zookeeper                 -->
                                 <relocation>
                                     <pattern>org.apache.zookeeper</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shaded.org.apache.zookeeper</shadedPattern>
                                 </relocation>
                                 <!--               curator                 -->
                                 <relocation>
                                     <pattern>org.apache.curator</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shaded.org.apache.curator</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/flink/v1.14/flink-runtime/pom.xml
+++ b/flink/v1.14/flink-runtime/pom.xml
@@ -205,6 +205,7 @@
                             <include>com.netease.arctic:*</include>
                             <include>org.apache.parquet:*</include>
                             <include>org.apache.commons:*</include>
+                            <include>org.apache.zookeeper:*</include>
                             <include>commons-lang:*</include>
                             <include>com.fasterxml.jackson.core:*</include>
                             <include>org.apache.thrift:*</include>
@@ -269,6 +270,11 @@
                                 <relocation>
                                     <pattern>org.apache.avro</pattern>
                                     <shadedPattern>com.netease.arctic.shaded.org.apache.avro</shadedPattern>
+                                </relocation>
+                                <!--               zookeeper                 -->
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/flink/v1.15/flink-runtime/pom.xml
+++ b/flink/v1.15/flink-runtime/pom.xml
@@ -206,6 +206,7 @@
                             <include>org.apache.parquet:*</include>
                             <include>org.apache.commons:*</include>
                             <include>org.apache.zookeeper:*</include>
+                            <include>org.apache.curator:*</include>
                             <include>commons-lang:*</include>
                             <include>com.fasterxml.jackson.core:*</include>
                             <include>org.apache.thrift:*</include>
@@ -275,6 +276,11 @@
                                 <relocation>
                                     <pattern>org.apache.zookeeper</pattern>
                                     <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                </relocation>
+                                <!--               curator                 -->
+                                <relocation>
+                                    <pattern>org.apache.curator</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/flink/v1.15/flink-runtime/pom.xml
+++ b/flink/v1.15/flink-runtime/pom.xml
@@ -275,12 +275,12 @@
                                 <!--               zookeeper                 -->
                                 <relocation>
                                     <pattern>org.apache.zookeeper</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shaded.org.apache.zookeeper</shadedPattern>
                                 </relocation>
                                 <!--               curator                 -->
                                 <relocation>
                                     <pattern>org.apache.curator</pattern>
-                                    <shadedPattern>com.netease.arctic.shade.org.apache.curator</shadedPattern>
+                                    <shadedPattern>com.netease.arctic.shaded.org.apache.curator</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/flink/v1.15/flink-runtime/pom.xml
+++ b/flink/v1.15/flink-runtime/pom.xml
@@ -205,6 +205,7 @@
                             <include>com.netease.arctic:*</include>
                             <include>org.apache.parquet:*</include>
                             <include>org.apache.commons:*</include>
+                            <include>org.apache.zookeeper:*</include>
                             <include>commons-lang:*</include>
                             <include>com.fasterxml.jackson.core:*</include>
                             <include>org.apache.thrift:*</include>
@@ -269,6 +270,11 @@
                                 <relocation>
                                     <pattern>org.apache.avro</pattern>
                                     <shadedPattern>com.netease.arctic.shaded.org.apache.avro</shadedPattern>
+                                </relocation>
+                                <!--               zookeeper                 -->
+                                <relocation>
+                                    <pattern>org.apache.zookeeper</pattern>
+                                    <shadedPattern>com.netease.arctic.shade.org.apache.zookeeper</shadedPattern>
                                 </relocation>
                                 <!--               orc                 -->
                                 <relocation>

--- a/site/docs/ch/flink/flink-ddl.md
+++ b/site/docs/ch/flink/flink-ddl.md
@@ -11,17 +11,17 @@ CREATE CATALOG <catalog_name> WITH (
 
 其中 `<catalog_name>` 为用户自定义的 flink catalog 名称， `<config_key>`=`<config_value>` 有如下配置：
 
-|Key|默认值|类型|是否必填|描述|
-|--- |--- |--- |--- |--- |
-|metastore.url|(none)|String|是|Arctic Metastore 的 URL，thrift://`<ip>`:`<port>`/`<catalog_name_in_metastore>`|
-|default-database<img width=100/>|default|String|否|默认使用的数据库|
-|property-version|1|Integer|否|Catalog properties 版本，此选项是为了将来的向后兼容性|
-| properties.auth.load-from-ams | True | BOOLEAN | 否 |是否从 AMS 加载安全校验的配置。 true:从AMS加载；false:不使用AMS的配置。注意：不管该参数是否配置，只要用户配置了下述 auth.*** 相关参数，就会使用该配置进行访问|
-| properties.auth.type | (none) | String | 否 | 表安全校验类型，有效值：simple、kerberos 或不配置。默认不配置，无需权限检验。simple：使用 hadoop 用户名，搭配参数'properties.auth.simple.hadoop_username'使用； kerberos：配置 kerberos 权限校验，搭配参数'properties.auth.kerberos.principal','properties.auth.kerberos.keytab','properties.auth.kerberos.krb'使用 |
-| properties.auth.simple.hadoop_username | (none) | String | 否 | 使用该 hadoop username 访问，'properties.auth.type'='simple'时必填。|
-| properties.auth.kerberos.principal | (none) | String | 否 | kerberos 的 principal 配置，'properties.auth.type'='kerberos'时必填。|
-| properties.auth.kerberos.krb.path | (none) | String | 否 | kerberos 的 krb5.conf 配置文件的绝对路径（Flink SQL提交机器的本地文件路径，如用 Flink SQL Client提交SQL任务，该路径为同节点的本地路径，如 /XXX/XXX/krb5.conf）。'properties.auth.type'='kerberos'时必填。|
-| properties.auth.kerberos.keytab.path | (none) | String | 否 | kerberos 的 XXX.keytab 配置文件的绝对路径（Flink SQL提交机器的本地文件路径，如用 Flink SQL Client提交SQL任务，该路径为同节点的本地路径，如 /XXX/XXX/XXX.keytab）。'properties.auth.type'='kerberos'时必填。|
+| Key                                    | 默认值     | 类型      | 是否必填 | 描述                                                                                                                                                                                                                                                       |
+|----------------------------------------|---------|---------|------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| metastore.url                          | (none)  | String  | 是    | Arctic Metastore 的 URL，thrift://`<ip>`:`<port>`/`<catalog_name_in_metastore>`；如果 AMS 开启了[高可用](../guides/deployment.md#_6)，也可以通过 zookeeper://{zookeeper-server}/{cluster-name}/{catalog-name} 的形式进行指定                                                     |
+| default-database<img width=100/>       | default | String  | 否    | 默认使用的数据库                                                                                                                                                                                                                                                 |
+| property-version                       | 1       | Integer | 否    | Catalog properties 版本，此选项是为了将来的向后兼容性                                                                                                                                                                                                                     |
+| properties.auth.load-from-ams          | True    | BOOLEAN | 否    | 是否从 AMS 加载安全校验的配置。 true:从AMS加载；false:不使用AMS的配置。注意：不管该参数是否配置，只要用户配置了下述 auth.*** 相关参数，就会使用该配置进行访问                                                                                                                                                          |
+| properties.auth.type                   | (none)  | String  | 否    | 表安全校验类型，有效值：simple、kerberos 或不配置。默认不配置，无需权限检验。simple：使用 hadoop 用户名，搭配参数'properties.auth.simple.hadoop_username'使用； kerberos：配置 kerberos 权限校验，搭配参数'properties.auth.kerberos.principal','properties.auth.kerberos.keytab','properties.auth.kerberos.krb'使用 |
+| properties.auth.simple.hadoop_username | (none)  | String  | 否    | 使用该 hadoop username 访问，'properties.auth.type'='simple'时必填。                                                                                                                                                                                               |
+| properties.auth.kerberos.principal     | (none)  | String  | 否    | kerberos 的 principal 配置，'properties.auth.type'='kerberos'时必填。                                                                                                                                                                                            |
+| properties.auth.kerberos.krb.path      | (none)  | String  | 否    | kerberos 的 krb5.conf 配置文件的绝对路径（Flink SQL提交机器的本地文件路径，如用 Flink SQL Client提交SQL任务，该路径为同节点的本地路径，如 /XXX/XXX/krb5.conf）。'properties.auth.type'='kerberos'时必填。                                                                                                  |
+| properties.auth.kerberos.keytab.path   | (none)  | String  | 否    | kerberos 的 XXX.keytab 配置文件的绝对路径（Flink SQL提交机器的本地文件路径，如用 Flink SQL Client提交SQL任务，该路径为同节点的本地路径，如 /XXX/XXX/XXX.keytab）。'properties.auth.type'='kerberos'时必填。                                                                                                |
 
 ### 通过 YAML 配置
 参考 Flink Sql Client [官方配置](https://nightlies.apache.org/flink/flink-docs-release-1.12/dev/table/sqlClient.html#environment-files)。

--- a/spark/v3.1/spark-runtime/pom.xml
+++ b/spark/v3.1/spark-runtime/pom.xml
@@ -61,11 +61,11 @@
                                     <include>com.netease.arctic:arctic-spark-3.1</include>
                                     <include>com.netease.arctic:arctic-core</include>
                                     <include>com.netease.arctic:arctic-ams-api</include>
-                                    <incluede>com.netease.arctic:arctic-hive</incluede>
+                                    <include>com.netease.arctic:arctic-hive</include>
                                     <include>com.alibaba:fastjson</include>
-                                    <incluede>org.apache.curator:curator-framework</incluede>
-                                    <incluede>org.apache.curator:curator-client</incluede>
-                                    <incluede>org.apache.curator:curator-recipes</incluede>
+                                    <include>org.apache.curator:curator-framework</include>
+                                    <include>org.apache.curator:curator-client</include>
+                                    <include>org.apache.curator:curator-recipes</include>
                                     <include>org.apache.zookeeper:zookeeper</include>
                                     <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>

--- a/spark/v3.2/spark-runtime/pom.xml
+++ b/spark/v3.2/spark-runtime/pom.xml
@@ -63,11 +63,11 @@
                                     <include>com.netease.arctic:arctic-spark-3.2</include>
                                     <include>com.netease.arctic:arctic-core</include>
                                     <include>com.netease.arctic:arctic-ams-api</include>
-                                    <incluede>com.netease.arctic:arctic-hive</incluede>
+                                    <include>com.netease.arctic:arctic-hive</include>
                                     <include>com.alibaba:fastjson</include>
-                                    <incluede>org.apache.curator:curator-framework</incluede>
-                                    <incluede>org.apache.curator:curator-client</incluede>
-                                    <incluede>org.apache.curator:curator-recipes</incluede>
+                                    <include>org.apache.curator:curator-framework</include>
+                                    <include>org.apache.curator:curator-client</include>
+                                    <include>org.apache.curator:curator-recipes</include>
                                     <include>org.apache.zookeeper:zookeeper</include>
                                     <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>

--- a/spark/v3.3/spark-runtime/pom.xml
+++ b/spark/v3.3/spark-runtime/pom.xml
@@ -63,11 +63,11 @@
                                     <include>com.netease.arctic:arctic-spark-3.3</include>
                                     <include>com.netease.arctic:arctic-core</include>
                                     <include>com.netease.arctic:arctic-ams-api</include>
-                                    <incluede>com.netease.arctic:arctic-hive</incluede>
+                                    <include>com.netease.arctic:arctic-hive</include>
                                     <include>com.alibaba:fastjson</include>
-                                    <incluede>org.apache.curator:curator-framework</incluede>
-                                    <incluede>org.apache.curator:curator-client</incluede>
-                                    <incluede>org.apache.curator:curator-recipes</incluede>
+                                    <include>org.apache.curator:curator-framework</include>
+                                    <include>org.apache.curator:curator-client</include>
+                                    <include>org.apache.curator:curator-recipes</include>
                                     <include>org.apache.zookeeper:zookeeper</include>
                                     <include>org.apache.zookeeper:zookeeper-jute</include>
                                     <include>org.apache.iceberg:iceberg-core</include>


### PR DESCRIPTION
## Why are the changes needed?

fix #1482.
In the same way as pr #1414, the Flink engine needs to include zookeeper and curator-related dependencies when packaging.

## Brief change log

  - *Add zookeeper and curator dependency in flink-runtime pom file*
  - *The flink 1.12 ,1.14 and 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
