### PR TITLE
[ARCTIC-1423][FLINK]: OffsetOutOfRangeException is encountered when the arctic logstore failover.

### DIFF
--- a/flink/v1.12/flink/pom.xml
+++ b/flink/v1.12/flink/pom.xml
@@ -274,6 +274,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-hive-metastore</artifactId>
             <version>${iceberg.version}</version>

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceReader.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceReader.java
@@ -169,8 +169,7 @@ public class KafkaSourceReader<T>
 
   // ------------------------
 
-  @VisibleForTesting
-  SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> getOffsetsToCommit() {
+  public SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> getOffsetsToCommit() {
     return offsetsToCommit;
   }
 

--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
@@ -76,7 +76,7 @@ public class LogKafkaPartitionSplit extends KafkaPartitionSplit {
   }
 
   public LogKafkaPartitionSplit(LogKafkaPartitionSplitState splitState) {
-    super(splitState.getTopicPartition(), splitState.getStartingOffset(),
+    super(splitState.getTopicPartition(), splitState.getCurrentOffset(),
         splitState.getStoppingOffset().orElse(NO_STOPPING_OFFSET));
     retracting = splitState.isRetracting();
     retractStopOffset = splitState.getRetractStopOffset();

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
@@ -73,6 +73,7 @@ import static org.junit.Assert.assertEquals;
 public class TestKafkaSourceReader {
   private static final Logger LOG = LoggerFactory.getLogger(TestKafkaSourceReader.class);
   private static String topic;
+  private static final int KAFKA_PARTITION_NUMS = 1;
   private static final int NUM_SPLITS = 1;
   private static final int NUM_RECORDS_PER_SPLIT = 10;
   private static final int TOTAL_NUM_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
@@ -95,6 +96,7 @@ public class TestKafkaSourceReader {
   @Before
   public void initData() throws Exception {
     topic = TestUtil.getUtMethodName(testName);
+    KafkaContainerTest.createTopics(KAFKA_PARTITION_NUMS, topic);
     write(topic, TOTAL_NUM_RECORDS);
   }
 
@@ -120,7 +122,7 @@ public class TestKafkaSourceReader {
     // re-create and restore
     reader = (LogKafkaSourceReader) createReader(groupId);
     reader.addSplits(splitList);
-    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId++);
+    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId);
     currentSplitList.forEach(s -> assertEquals(TOTAL_NUM_RECORDS, s.getStartingOffset()));
   }
 

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.hidden.kafka;
+
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplit;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplitState;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceReader;
+import com.netease.arctic.flink.shuffle.LogRecordV1;
+import com.netease.arctic.flink.util.TestUtil;
+import com.netease.arctic.flink.util.kafka.KafkaContainerTest;
+import com.netease.arctic.log.FormatVersion;
+import com.netease.arctic.log.LogData;
+import com.netease.arctic.log.LogDataJsonDeserialization;
+import com.netease.arctic.log.LogDataJsonSerialization;
+import com.netease.arctic.utils.IdGenerator;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.table.data.RowData;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.netease.arctic.flink.shuffle.RowKindUtil.transformFromFlinkRowKind;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE;
+import static com.netease.arctic.flink.util.kafka.KafkaContainerTest.KAFKA_CONTAINER;
+import static com.netease.arctic.flink.util.kafka.KafkaContainerTest.getPropertiesByTopic;
+import static com.netease.arctic.flink.util.kafka.KafkaContainerTest.readRecordsBytes;
+import static com.netease.arctic.flink.write.hidden.TestBaseLog.createLogDataDeserialization;
+import static com.netease.arctic.flink.write.hidden.TestBaseLog.userSchema;
+import static com.netease.arctic.flink.write.hidden.TestHiddenLogOperators.createRowData;
+import static org.junit.Assert.assertEquals;
+
+public class TestKafkaSourceReader {
+  private static final Logger LOG = LoggerFactory.getLogger(TestKafkaSourceReader.class);
+  private static String topic;
+  private static final int NUM_SPLITS = 1;
+  private static final int NUM_RECORDS_PER_SPLIT = 10;
+  private static final int TOTAL_NUM_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  private static final byte[] JOB_ID = IdGenerator.generateUpstreamId();
+
+  @BeforeClass
+  public static void prepare() throws Exception {
+    KAFKA_CONTAINER.start();
+  }
+
+  @AfterClass
+  public static void shutdown() throws Exception {
+    KAFKA_CONTAINER.close();
+  }
+
+  @Before
+  public void initData() throws Exception {
+    topic = TestUtil.getUtMethodName(testName);
+    write(topic, TOTAL_NUM_RECORDS);
+  }
+
+  @Test
+  public void testSourceReaderFailover() throws Exception {
+    final String groupId = "testSourceReaderFailover";
+    LogKafkaSourceReader reader = (LogKafkaSourceReader) createReader(groupId);
+    reader.addSplits(getSplits(NUM_SPLITS));
+    ValidatingSourceOutput output = new ValidatingSourceOutput();
+    List<KafkaPartitionSplit> splitList;
+    long checkpointId = 0;
+    do {
+      checkpointId++;
+      reader.pollNext(output);
+      // Create a checkpoint for each message consumption, but not complete them.
+      splitList = reader.snapshotState(checkpointId);
+    } while (output.count() < TOTAL_NUM_RECORDS);
+
+    // The completion of the last checkpoint should subsume all the previous checkpoints.
+    assertEquals(checkpointId, reader.getOffsetsToCommit().size());
+    reader.notifyCheckpointComplete(checkpointId);
+
+    // re-create and restore
+    reader = (LogKafkaSourceReader) createReader(groupId);
+    reader.addSplits(splitList);
+    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId++);
+    currentSplitList.forEach(s -> assertEquals(TOTAL_NUM_RECORDS, s.getStartingOffset()));
+  }
+
+  private ProducerRecord<byte[], byte[]> createLogData(String topic, int i, int epicNo, boolean flip,
+                                                       LogDataJsonSerialization<RowData> serialization) {
+    RowData rowData = createRowData(i);
+    LogData<RowData> logData = new LogRecordV1(
+      FormatVersion.FORMAT_VERSION_V1,
+      JOB_ID,
+      epicNo,
+      flip,
+      transformFromFlinkRowKind(rowData.getRowKind()),
+      rowData
+    );
+    byte[] message = serialization.serialize(logData);
+    int partition = 0;
+    ProducerRecord<byte[], byte[]> producerRecord =
+      new ProducerRecord<>(topic, partition, null, null, message);
+    return producerRecord;
+  }
+
+  private void write(String topic, int numRecords) throws Exception {
+    KafkaProducer producer = KafkaContainerTest.getProducer();
+    LogDataJsonSerialization<RowData> serialization =
+      new LogDataJsonSerialization<>(userSchema, LogRecordV1.fieldGetterFactory);
+    for (int i = 0; i < numRecords; i++) {
+      producer.send(createLogData(topic, 0, 1, false, serialization));
+    }
+    printDataInTopic(topic);
+  }
+
+  public static void printDataInTopic(String topic) {
+    ConsumerRecords<byte[], byte[]> consumerRecords = readRecordsBytes(topic);
+    LogDataJsonDeserialization<RowData> deserialization = createLogDataDeserialization();
+    consumerRecords.forEach(consumerRecord -> {
+      try {
+        LOG.info("data in kafka: {}", deserialization.deserialize(consumerRecord.value()));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    });
+  }
+
+  private SourceReader<RowData, KafkaPartitionSplit> createReader(String groupId) {
+    List<String> topics = new ArrayList<>();
+    topics.add(topic);
+    LogKafkaSource kafkaSource = createKafkaSource(groupId, false, topics);
+    return kafkaSource.createReader(new TestingReaderContext());
+  }
+
+  private LogKafkaSource createKafkaSource(String groupId, boolean retract, List<String> topics) {
+    Properties properties = getPropertiesByTopic(topic);
+    properties.put("group.id", groupId);
+    properties.put("auto.offset.reset", "earliest");
+
+    Map<String, String> configuration = new HashMap<>();
+    configuration.put(ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.key(), String.valueOf(retract));
+
+    return LogKafkaSource.builder(userSchema, configuration)
+      .setTopics(topics)
+      .setStartingOffsets(OffsetsInitializer.earliest())
+      .setProperties(properties)
+      .build();
+  }
+
+  protected List<LogKafkaPartitionSplit> getSplits(int numRecordsPerSplit) {
+    List<LogKafkaPartitionSplit> splits = new ArrayList<>();
+    for (int i = 0; i < numRecordsPerSplit; i++) {
+      splits.add(getSplit(i, numRecordsPerSplit));
+    }
+    return splits;
+  }
+
+  protected LogKafkaPartitionSplit getSplit(int splitId, int numRecords) {
+    long stoppingOffset = KafkaPartitionSplit.NO_STOPPING_OFFSET;
+    KafkaPartitionSplit kafkaPartitionSplit = new KafkaPartitionSplit(new TopicPartition(topic, splitId), 0L, stoppingOffset);
+    return new LogKafkaPartitionSplit(new LogKafkaPartitionSplitState(kafkaPartitionSplit));
+  }
+
+  // ---------------- helper classes -----------------
+  /** A source output that validates the output. */
+  public static class ValidatingSourceOutput implements ReaderOutput<RowData> {
+    private final Set<RowData> consumedValues = new HashSet<>();
+    private int max = Integer.MIN_VALUE;
+    private int min = Integer.MAX_VALUE;
+
+    private int count = 0;
+
+    @Override
+    public void collect(RowData rowData) {
+      count++;
+      consumedValues.add(rowData);
+    }
+
+    @Override
+    public void collect(RowData rowData, long timestamp) {
+      collect(rowData);
+    }
+
+    @Override
+    public void emitWatermark(Watermark watermark) {
+    }
+
+    public void validate() {
+      assertEquals(
+        String.format("Should be %d distinct elements in total", TOTAL_NUM_RECORDS),
+        TOTAL_NUM_RECORDS,
+        consumedValues.size());
+      assertEquals(
+        String.format("Should be %d elements in total", TOTAL_NUM_RECORDS),
+        TOTAL_NUM_RECORDS,
+        count);
+      assertEquals("The min value should be 0", 0, min);
+      assertEquals(
+        "The max value should be " + (TOTAL_NUM_RECORDS - 1),
+        TOTAL_NUM_RECORDS - 1,
+        max);
+    }
+
+    public int count() {
+      return count;
+    }
+
+    @Override
+    public void markIdle() {}
+
+    @Override
+    public SourceOutput<RowData> createOutputForSplit(String splitId) {
+      return this;
+    }
+
+    @Override
+    public void releaseOutputForSplit(String splitId) {}
+  }
+}

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceFetcherManager.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceFetcherManager.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.internals;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherTask;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * The SplitFetcherManager for Kafka source. This class is needed to help commit the offsets to
+ * Kafka using the KafkaConsumer inside the {@link
+ * KafkaPartitionSplitReader}.
+ */
+public class KafkaSourceFetcherManager
+        extends SingleThreadFetcherManager<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSourceFetcherManager.class);
+
+    /**
+     * Creates a new SplitFetcherManager with a single I/O threads.
+     *
+     * @param elementsQueue The queue that is used to hand over data from the I/O thread (the
+     *     fetchers) to the reader (which emits the records and book-keeps the state. This must be
+     *     the same queue instance that is also passed to the {@link SourceReaderBase}.
+     * @param splitReaderSupplier The factory for the split reader that connects to the source
+     *     system.
+     * @param splitFinishedHook Hook for handling finished splits in split fetchers.
+     */
+    public KafkaSourceFetcherManager(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<ConsumerRecord<byte[], byte[]>>>
+                    elementsQueue,
+            Supplier<SplitReader<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit>>
+                    splitReaderSupplier,
+            Consumer<Collection<String>> splitFinishedHook) {
+        super(elementsQueue, splitReaderSupplier, splitFinishedHook);
+    }
+
+    public void commitOffsets(
+            Map<TopicPartition, OffsetAndMetadata> offsetsToCommit, OffsetCommitCallback callback) {
+        LOG.debug("Committing offsets {}", offsetsToCommit);
+        if (offsetsToCommit.isEmpty()) {
+            return;
+        }
+        SplitFetcher<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> splitFetcher =
+                fetchers.get(0);
+        if (splitFetcher != null) {
+            // The fetcher thread is still running. This should be the majority of the cases.
+            enqueueOffsetsCommitTask(splitFetcher, offsetsToCommit, callback);
+        } else {
+            splitFetcher = createSplitFetcher();
+            enqueueOffsetsCommitTask(splitFetcher, offsetsToCommit, callback);
+            startFetcher(splitFetcher);
+        }
+    }
+
+    private void enqueueOffsetsCommitTask(
+            SplitFetcher<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> splitFetcher,
+            Map<TopicPartition, OffsetAndMetadata> offsetsToCommit,
+            OffsetCommitCallback callback) {
+        KafkaPartitionSplitReader kafkaReader =
+                (KafkaPartitionSplitReader) splitFetcher.getSplitReader();
+
+        splitFetcher.enqueueTask(
+                new SplitFetcherTask() {
+                    @Override
+                    public boolean run() throws IOException {
+                        kafkaReader.notifyCheckpointComplete(offsetsToCommit, callback);
+                        return true;
+                    }
+
+                    @Override
+                    public void wakeUp() {}
+                });
+    }
+}

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceReader.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceReader.java
@@ -27,7 +27,6 @@ import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSource
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
 import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
-import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -184,8 +183,7 @@ public class KafkaSourceReader<T>
 
   // ------------------------
 
-  @VisibleForTesting
-  SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> getOffsetsToCommit() {
+  public SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> getOffsetsToCommit() {
     return offsetsToCommit;
   }
 

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
@@ -76,7 +76,7 @@ public class LogKafkaPartitionSplit extends KafkaPartitionSplit {
   }
 
   public LogKafkaPartitionSplit(LogKafkaPartitionSplitState splitState) {
-    super(splitState.getTopicPartition(), splitState.getStartingOffset(),
+    super(splitState.getTopicPartition(), splitState.getCurrentOffset(),
         splitState.getStoppingOffset().orElse(NO_STOPPING_OFFSET));
     retracting = splitState.isRetracting();
     retractStopOffset = splitState.getRetractStopOffset();

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaSource;
+import com.netease.arctic.flink.read.internals.KafkaSourceFetcherManager;
 import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -32,7 +33,6 @@ import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsIni
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
-import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.read.source.log.kafka;
 
+import com.netease.arctic.flink.read.internals.KafkaSourceFetcherManager;
 import com.netease.arctic.flink.read.internals.KafkaSourceReader;
 import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import org.apache.flink.api.connector.source.SourceReaderContext;
@@ -26,7 +27,6 @@ import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
-import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
@@ -73,6 +73,7 @@ import static org.junit.Assert.assertEquals;
 public class TestKafkaSourceReader {
   private static final Logger LOG = LoggerFactory.getLogger(TestKafkaSourceReader.class);
   private static String topic;
+  private static final int KAFKA_PARTITION_NUMS = 1;
   private static final int NUM_SPLITS = 1;
   private static final int NUM_RECORDS_PER_SPLIT = 10;
   private static final int TOTAL_NUM_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
@@ -95,6 +96,7 @@ public class TestKafkaSourceReader {
   @Before
   public void initData() throws Exception {
     topic = TestUtil.getUtMethodName(testName);
+    KafkaContainerTest.createTopics(KAFKA_PARTITION_NUMS, topic);
     write(topic, TOTAL_NUM_RECORDS);
   }
 
@@ -120,7 +122,7 @@ public class TestKafkaSourceReader {
     // re-create and restore
     reader = (LogKafkaSourceReader) createReader(groupId);
     reader.addSplits(splitList);
-    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId++);
+    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId);
     currentSplitList.forEach(s -> assertEquals(TOTAL_NUM_RECORDS, s.getStartingOffset()));
   }
 

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.hidden.kafka;
+
+import com.netease.arctic.flink.kafka.testutils.KafkaContainerTest;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplit;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplitState;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceReader;
+import com.netease.arctic.flink.shuffle.LogRecordV1;
+import com.netease.arctic.flink.util.TestUtil;
+import com.netease.arctic.log.FormatVersion;
+import com.netease.arctic.log.LogData;
+import com.netease.arctic.log.LogDataJsonDeserialization;
+import com.netease.arctic.log.LogDataJsonSerialization;
+import com.netease.arctic.utils.IdGenerator;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.table.data.RowData;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.netease.arctic.flink.shuffle.RowKindUtil.transformFromFlinkRowKind;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE;
+import static com.netease.arctic.flink.kafka.testutils.KafkaContainerTest.KAFKA_CONTAINER;
+import static com.netease.arctic.flink.kafka.testutils.KafkaContainerTest.getPropertiesByTopic;
+import static com.netease.arctic.flink.kafka.testutils.KafkaContainerTest.readRecordsBytes;
+import static com.netease.arctic.flink.write.hidden.kafka.TestBaseLog.createLogDataDeserialization;
+import static com.netease.arctic.flink.write.hidden.kafka.TestBaseLog.userSchema;
+import static com.netease.arctic.flink.write.hidden.kafka.TestHiddenLogOperators.createRowData;
+import static org.junit.Assert.assertEquals;
+
+public class TestKafkaSourceReader {
+  private static final Logger LOG = LoggerFactory.getLogger(TestKafkaSourceReader.class);
+  private static String topic;
+  private static final int NUM_SPLITS = 1;
+  private static final int NUM_RECORDS_PER_SPLIT = 10;
+  private static final int TOTAL_NUM_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  private static final byte[] JOB_ID = IdGenerator.generateUpstreamId();
+
+  @BeforeClass
+  public static void prepare() throws Exception {
+    KAFKA_CONTAINER.start();
+  }
+
+  @AfterClass
+  public static void shutdown() throws Exception {
+    KAFKA_CONTAINER.close();
+  }
+
+  @Before
+  public void initData() throws Exception {
+    topic = TestUtil.getUtMethodName(testName);
+    write(topic, TOTAL_NUM_RECORDS);
+  }
+
+  @Test
+  public void testSourceReaderFailover() throws Exception {
+    final String groupId = "testSourceReaderFailover";
+    LogKafkaSourceReader reader = (LogKafkaSourceReader) createReader(groupId);
+    reader.addSplits(getSplits(NUM_SPLITS));
+    ValidatingSourceOutput output = new ValidatingSourceOutput();
+    List<KafkaPartitionSplit> splitList;
+    long checkpointId = 0;
+    do {
+      checkpointId++;
+      reader.pollNext(output);
+      // Create a checkpoint for each message consumption, but not complete them.
+      splitList = reader.snapshotState(checkpointId);
+    } while (output.count() < TOTAL_NUM_RECORDS);
+
+    // The completion of the last checkpoint should subsume all the previous checkpoints.
+    assertEquals(checkpointId, reader.getOffsetsToCommit().size());
+    reader.notifyCheckpointComplete(checkpointId);
+
+    // re-create and restore
+    reader = (LogKafkaSourceReader) createReader(groupId);
+    reader.addSplits(splitList);
+    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId++);
+    currentSplitList.forEach(s -> assertEquals(TOTAL_NUM_RECORDS, s.getStartingOffset()));
+  }
+
+  private ProducerRecord<byte[], byte[]> createLogData(String topic, int i, int epicNo, boolean flip,
+                                                       LogDataJsonSerialization<RowData> serialization) {
+    RowData rowData = createRowData(i);
+    LogData<RowData> logData = new LogRecordV1(
+      FormatVersion.FORMAT_VERSION_V1,
+      JOB_ID,
+      epicNo,
+      flip,
+      transformFromFlinkRowKind(rowData.getRowKind()),
+      rowData
+    );
+    byte[] message = serialization.serialize(logData);
+    int partition = 0;
+    ProducerRecord<byte[], byte[]> producerRecord =
+      new ProducerRecord<>(topic, partition, null, null, message);
+    return producerRecord;
+  }
+
+  private void write(String topic, int numRecords) throws Exception {
+    KafkaProducer producer = KafkaContainerTest.getProducer();
+    LogDataJsonSerialization<RowData> serialization =
+      new LogDataJsonSerialization<>(userSchema, LogRecordV1.fieldGetterFactory);
+    for (int i = 0; i < numRecords; i++) {
+      producer.send(createLogData(topic, 0, 1, false, serialization));
+    }
+    printDataInTopic(topic);
+  }
+
+  public static void printDataInTopic(String topic) {
+    ConsumerRecords<byte[], byte[]> consumerRecords = readRecordsBytes(topic);
+    LogDataJsonDeserialization<RowData> deserialization = createLogDataDeserialization();
+    consumerRecords.forEach(consumerRecord -> {
+      try {
+        LOG.info("data in kafka: {}", deserialization.deserialize(consumerRecord.value()));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    });
+  }
+
+  private SourceReader<RowData, KafkaPartitionSplit> createReader(String groupId) {
+    List<String> topics = new ArrayList<>();
+    topics.add(topic);
+    LogKafkaSource kafkaSource = createKafkaSource(groupId, false, topics);
+    return kafkaSource.createReader(new TestingReaderContext());
+  }
+
+  private LogKafkaSource createKafkaSource(String groupId, boolean retract, List<String> topics) {
+    Properties properties = getPropertiesByTopic(topic);
+    properties.put("group.id", groupId);
+    properties.put("auto.offset.reset", "earliest");
+
+    Map<String, String> configuration = new HashMap<>();
+    configuration.put(ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.key(), String.valueOf(retract));
+
+    return LogKafkaSource.builder(userSchema, configuration)
+      .setTopics(topics)
+      .setStartingOffsets(OffsetsInitializer.earliest())
+      .setProperties(properties)
+      .build();
+  }
+
+  protected List<LogKafkaPartitionSplit> getSplits(int numRecordsPerSplit) {
+    List<LogKafkaPartitionSplit> splits = new ArrayList<>();
+    for (int i = 0; i < numRecordsPerSplit; i++) {
+      splits.add(getSplit(i, numRecordsPerSplit));
+    }
+    return splits;
+  }
+
+  protected LogKafkaPartitionSplit getSplit(int splitId, int numRecords) {
+    long stoppingOffset = KafkaPartitionSplit.NO_STOPPING_OFFSET;
+    KafkaPartitionSplit kafkaPartitionSplit = new KafkaPartitionSplit(new TopicPartition(topic, splitId), 0L, stoppingOffset);
+    return new LogKafkaPartitionSplit(new LogKafkaPartitionSplitState(kafkaPartitionSplit));
+  }
+
+  // ---------------- helper classes -----------------
+  /** A source output that validates the output. */
+  public static class ValidatingSourceOutput implements ReaderOutput<RowData> {
+    private final Set<RowData> consumedValues = new HashSet<>();
+    private int max = Integer.MIN_VALUE;
+    private int min = Integer.MAX_VALUE;
+
+    private int count = 0;
+
+    @Override
+    public void collect(RowData rowData) {
+      count++;
+      consumedValues.add(rowData);
+    }
+
+    @Override
+    public void collect(RowData rowData, long timestamp) {
+      collect(rowData);
+    }
+
+    @Override
+    public void emitWatermark(Watermark watermark) {
+    }
+
+    public void validate() {
+      assertEquals(
+        String.format("Should be %d distinct elements in total", TOTAL_NUM_RECORDS),
+        TOTAL_NUM_RECORDS,
+        consumedValues.size());
+      assertEquals(
+        String.format("Should be %d elements in total", TOTAL_NUM_RECORDS),
+        TOTAL_NUM_RECORDS,
+        count);
+      assertEquals("The min value should be 0", 0, min);
+      assertEquals(
+        "The max value should be " + (TOTAL_NUM_RECORDS - 1),
+        TOTAL_NUM_RECORDS - 1,
+        max);
+    }
+
+    public int count() {
+      return count;
+    }
+
+    @Override
+    public void markIdle() {}
+
+    @Override
+    public void markActive() {
+    }
+
+    @Override
+    public SourceOutput<RowData> createOutputForSplit(String splitId) {
+      return this;
+    }
+
+    @Override
+    public void releaseOutputForSplit(String splitId) {}
+  }
+}

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceFetcherManager.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceFetcherManager.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.internals;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherTask;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * The SplitFetcherManager for Kafka source. This class is needed to help commit the offsets to
+ * Kafka using the KafkaConsumer inside the {@link
+ * KafkaPartitionSplitReader}.
+ */
+public class KafkaSourceFetcherManager
+        extends SingleThreadFetcherManager<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSourceFetcherManager.class);
+
+    /**
+     * Creates a new SplitFetcherManager with a single I/O threads.
+     *
+     * @param elementsQueue The queue that is used to hand over data from the I/O thread (the
+     *     fetchers) to the reader (which emits the records and book-keeps the state. This must be
+     *     the same queue instance that is also passed to the {@link SourceReaderBase}.
+     * @param splitReaderSupplier The factory for the split reader that connects to the source
+     *     system.
+     * @param splitFinishedHook Hook for handling finished splits in split fetchers.
+     */
+    public KafkaSourceFetcherManager(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<ConsumerRecord<byte[], byte[]>>>
+                    elementsQueue,
+            Supplier<SplitReader<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit>>
+                    splitReaderSupplier,
+            Consumer<Collection<String>> splitFinishedHook) {
+        super(elementsQueue, splitReaderSupplier, splitFinishedHook);
+    }
+
+    public void commitOffsets(
+            Map<TopicPartition, OffsetAndMetadata> offsetsToCommit, OffsetCommitCallback callback) {
+        LOG.debug("Committing offsets {}", offsetsToCommit);
+        if (offsetsToCommit.isEmpty()) {
+            return;
+        }
+        SplitFetcher<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> splitFetcher =
+                fetchers.get(0);
+        if (splitFetcher != null) {
+            // The fetcher thread is still running. This should be the majority of the cases.
+            enqueueOffsetsCommitTask(splitFetcher, offsetsToCommit, callback);
+        } else {
+            splitFetcher = createSplitFetcher();
+            enqueueOffsetsCommitTask(splitFetcher, offsetsToCommit, callback);
+            startFetcher(splitFetcher);
+        }
+    }
+
+    private void enqueueOffsetsCommitTask(
+            SplitFetcher<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit> splitFetcher,
+            Map<TopicPartition, OffsetAndMetadata> offsetsToCommit,
+            OffsetCommitCallback callback) {
+        KafkaPartitionSplitReader kafkaReader =
+                (KafkaPartitionSplitReader) splitFetcher.getSplitReader();
+
+        splitFetcher.enqueueTask(
+                new SplitFetcherTask() {
+                    @Override
+                    public boolean run() throws IOException {
+                        kafkaReader.notifyCheckpointComplete(offsetsToCommit, callback);
+                        return true;
+                    }
+
+                    @Override
+                    public void wakeUp() {}
+                });
+    }
+}

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceReader.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/internals/KafkaSourceReader.java
@@ -28,7 +28,6 @@ import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSource
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
 import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
-import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -186,8 +185,7 @@ public class KafkaSourceReader<T>
 
   // ------------------------
 
-  @VisibleForTesting
-  SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> getOffsetsToCommit() {
+  public SortedMap<Long, Map<TopicPartition, OffsetAndMetadata>> getOffsetsToCommit() {
     return offsetsToCommit;
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaPartitionSplit.java
@@ -76,7 +76,7 @@ public class LogKafkaPartitionSplit extends KafkaPartitionSplit {
   }
 
   public LogKafkaPartitionSplit(LogKafkaPartitionSplitState splitState) {
-    super(splitState.getTopicPartition(), splitState.getStartingOffset(),
+    super(splitState.getTopicPartition(), splitState.getCurrentOffset(),
         splitState.getStoppingOffset().orElse(NO_STOPPING_OFFSET));
     retracting = splitState.isRetracting();
     retractStopOffset = splitState.getRetractStopOffset();

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSource.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.flink.read.source.log.kafka;
 
 import com.netease.arctic.flink.read.internals.KafkaSource;
+import com.netease.arctic.flink.read.internals.KafkaSourceFetcherManager;
 import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -32,7 +33,6 @@ import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsIni
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
-import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceReader.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.read.source.log.kafka;
 
+import com.netease.arctic.flink.read.internals.KafkaSourceFetcherManager;
 import com.netease.arctic.flink.read.internals.KafkaSourceReader;
 import com.netease.arctic.flink.read.source.log.LogSourceHelper;
 import org.apache.flink.api.connector.source.SourceReaderContext;
@@ -26,7 +27,6 @@ import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
-import org.apache.flink.connector.kafka.source.reader.fetcher.KafkaSourceFetcherManager;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitState;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.read.hidden.kafka;
+
+import com.netease.arctic.flink.kafka.testutils.KafkaContainerTest;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplit;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaPartitionSplitState;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSource;
+import com.netease.arctic.flink.read.source.log.kafka.LogKafkaSourceReader;
+import com.netease.arctic.flink.shuffle.LogRecordV1;
+import com.netease.arctic.flink.util.TestUtil;
+import com.netease.arctic.log.FormatVersion;
+import com.netease.arctic.log.LogData;
+import com.netease.arctic.log.LogDataJsonDeserialization;
+import com.netease.arctic.log.LogDataJsonSerialization;
+import com.netease.arctic.utils.IdGenerator;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.table.data.RowData;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.netease.arctic.flink.kafka.testutils.KafkaContainerTest.KAFKA_CONTAINER;
+import static com.netease.arctic.flink.kafka.testutils.KafkaContainerTest.getPropertiesByTopic;
+import static com.netease.arctic.flink.kafka.testutils.KafkaContainerTest.readRecordsBytes;
+import static com.netease.arctic.flink.shuffle.RowKindUtil.transformFromFlinkRowKind;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE;
+import static com.netease.arctic.flink.write.hidden.kafka.TestBaseLog.createLogDataDeserialization;
+import static com.netease.arctic.flink.write.hidden.kafka.TestBaseLog.userSchema;
+import static com.netease.arctic.flink.write.hidden.kafka.TestHiddenLogOperators.createRowData;
+import static org.junit.Assert.assertEquals;
+
+public class TestKafkaSourceReader {
+  private static final Logger LOG = LoggerFactory.getLogger(TestKafkaSourceReader.class);
+  private static String topic;
+  private static final int NUM_SPLITS = 1;
+  private static final int NUM_RECORDS_PER_SPLIT = 10;
+  private static final int TOTAL_NUM_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  private static final byte[] JOB_ID = IdGenerator.generateUpstreamId();
+
+  @BeforeClass
+  public static void prepare() throws Exception {
+    KAFKA_CONTAINER.start();
+  }
+
+  @AfterClass
+  public static void shutdown() throws Exception {
+    KAFKA_CONTAINER.close();
+  }
+
+  @Before
+  public void initData() throws Exception {
+    topic = TestUtil.getUtMethodName(testName);
+    write(topic, TOTAL_NUM_RECORDS);
+  }
+
+  @Test
+  public void testSourceReaderFailover() throws Exception {
+    final String groupId = "testSourceReaderFailover";
+    LogKafkaSourceReader reader = (LogKafkaSourceReader) createReader(groupId);
+    reader.addSplits(getSplits(NUM_SPLITS));
+    ValidatingSourceOutput output = new ValidatingSourceOutput();
+    List<KafkaPartitionSplit> splitList;
+    long checkpointId = 0;
+    do {
+      checkpointId++;
+      reader.pollNext(output);
+      // Create a checkpoint for each message consumption, but not complete them.
+      splitList = reader.snapshotState(checkpointId);
+    } while (output.count() < TOTAL_NUM_RECORDS);
+
+    // The completion of the last checkpoint should subsume all the previous checkpoints.
+    assertEquals(checkpointId, reader.getOffsetsToCommit().size());
+    reader.notifyCheckpointComplete(checkpointId);
+
+    // re-create and restore
+    reader = (LogKafkaSourceReader) createReader(groupId);
+    reader.addSplits(splitList);
+    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId++);
+    currentSplitList.forEach(s -> assertEquals(TOTAL_NUM_RECORDS, s.getStartingOffset()));
+  }
+
+  private ProducerRecord<byte[], byte[]> createLogData(String topic, int i, int epicNo, boolean flip,
+                                                       LogDataJsonSerialization<RowData> serialization) {
+    RowData rowData = createRowData(i);
+    LogData<RowData> logData = new LogRecordV1(
+      FormatVersion.FORMAT_VERSION_V1,
+      JOB_ID,
+      epicNo,
+      flip,
+      transformFromFlinkRowKind(rowData.getRowKind()),
+      rowData
+    );
+    byte[] message = serialization.serialize(logData);
+    int partition = 0;
+    ProducerRecord<byte[], byte[]> producerRecord =
+      new ProducerRecord<>(topic, partition, null, null, message);
+    return producerRecord;
+  }
+
+  private void write(String topic, int numRecords) throws Exception {
+    KafkaProducer producer = KafkaContainerTest.getProducer();
+    LogDataJsonSerialization<RowData> serialization =
+      new LogDataJsonSerialization<>(userSchema, LogRecordV1.fieldGetterFactory);
+    for (int i = 0; i < numRecords; i++) {
+      producer.send(createLogData(topic, 0, 1, false, serialization));
+    }
+    printDataInTopic(topic);
+  }
+
+  public static void printDataInTopic(String topic) {
+    ConsumerRecords<byte[], byte[]> consumerRecords = readRecordsBytes(topic);
+    LogDataJsonDeserialization<RowData> deserialization = createLogDataDeserialization();
+    consumerRecords.forEach(consumerRecord -> {
+      try {
+        LOG.info("data in kafka: {}", deserialization.deserialize(consumerRecord.value()));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    });
+  }
+
+  private SourceReader<RowData, KafkaPartitionSplit> createReader(String groupId) {
+    List<String> topics = new ArrayList<>();
+    topics.add(topic);
+    LogKafkaSource kafkaSource = createKafkaSource(groupId, false, topics);
+    return kafkaSource.createReader(new TestingReaderContext());
+  }
+
+  private LogKafkaSource createKafkaSource(String groupId, boolean retract, List<String> topics) {
+    Properties properties = getPropertiesByTopic(topic);
+    properties.put("group.id", groupId);
+    properties.put("auto.offset.reset", "earliest");
+
+    Map<String, String> configuration = new HashMap<>();
+    configuration.put(ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE.key(), String.valueOf(retract));
+
+    return LogKafkaSource.builder(userSchema, configuration)
+      .setTopics(topics)
+      .setStartingOffsets(OffsetsInitializer.earliest())
+      .setProperties(properties)
+      .build();
+  }
+
+  protected List<LogKafkaPartitionSplit> getSplits(int numRecordsPerSplit) {
+    List<LogKafkaPartitionSplit> splits = new ArrayList<>();
+    for (int i = 0; i < numRecordsPerSplit; i++) {
+      splits.add(getSplit(i, numRecordsPerSplit));
+    }
+    return splits;
+  }
+
+  protected LogKafkaPartitionSplit getSplit(int splitId, int numRecords) {
+    long stoppingOffset = KafkaPartitionSplit.NO_STOPPING_OFFSET;
+    KafkaPartitionSplit kafkaPartitionSplit = new KafkaPartitionSplit(new TopicPartition(topic, splitId), 0L, stoppingOffset);
+    return new LogKafkaPartitionSplit(new LogKafkaPartitionSplitState(kafkaPartitionSplit));
+  }
+
+  // ---------------- helper classes -----------------
+  /** A source output that validates the output. */
+  public static class ValidatingSourceOutput implements ReaderOutput<RowData> {
+    private final Set<RowData> consumedValues = new HashSet<>();
+    private int max = Integer.MIN_VALUE;
+    private int min = Integer.MAX_VALUE;
+
+    private int count = 0;
+
+    @Override
+    public void collect(RowData rowData) {
+      count++;
+      consumedValues.add(rowData);
+    }
+
+    @Override
+    public void collect(RowData rowData, long timestamp) {
+      collect(rowData);
+    }
+
+    @Override
+    public void emitWatermark(Watermark watermark) {
+    }
+
+    public void validate() {
+      assertEquals(
+        String.format("Should be %d distinct elements in total", TOTAL_NUM_RECORDS),
+        TOTAL_NUM_RECORDS,
+        consumedValues.size());
+      assertEquals(
+        String.format("Should be %d elements in total", TOTAL_NUM_RECORDS),
+        TOTAL_NUM_RECORDS,
+        count);
+      assertEquals("The min value should be 0", 0, min);
+      assertEquals(
+        "The max value should be " + (TOTAL_NUM_RECORDS - 1),
+        TOTAL_NUM_RECORDS - 1,
+        max);
+    }
+
+    public int count() {
+      return count;
+    }
+
+    @Override
+    public void markIdle() {}
+
+    @Override
+    public void markActive() {
+    }
+
+    @Override
+    public SourceOutput<RowData> createOutputForSplit(String splitId) {
+      return this;
+    }
+
+    @Override
+    public void releaseOutputForSplit(String splitId) {}
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/read/hidden/kafka/TestKafkaSourceReader.java
@@ -73,6 +73,7 @@ import static org.junit.Assert.assertEquals;
 public class TestKafkaSourceReader {
   private static final Logger LOG = LoggerFactory.getLogger(TestKafkaSourceReader.class);
   private static String topic;
+  private static final int KAFKA_PARTITION_NUMS = 1;
   private static final int NUM_SPLITS = 1;
   private static final int NUM_RECORDS_PER_SPLIT = 10;
   private static final int TOTAL_NUM_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
@@ -95,6 +96,7 @@ public class TestKafkaSourceReader {
   @Before
   public void initData() throws Exception {
     topic = TestUtil.getUtMethodName(testName);
+    KafkaContainerTest.createTopics(KAFKA_PARTITION_NUMS, topic);
     write(topic, TOTAL_NUM_RECORDS);
   }
 
@@ -120,7 +122,7 @@ public class TestKafkaSourceReader {
     // re-create and restore
     reader = (LogKafkaSourceReader) createReader(groupId);
     reader.addSplits(splitList);
-    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId++);
+    List<KafkaPartitionSplit> currentSplitList = reader.snapshotState(checkpointId);
     currentSplitList.forEach(s -> assertEquals(TOTAL_NUM_RECORDS, s.getStartingOffset()));
   }
 


### PR DESCRIPTION
## Why are the changes needed?
fix #1423 which results in OffsetOutOfRangeException.
fix #1431. When performing the unit test in 1.14 and 1.15 modules, ClassCastException related to #1431 was encountered and should be fixed.

## Brief change log

  - *Modified the parameters passed to the LogKafkaPartitionSplit constructor*
  - *Override the KafkaSourceFetcherManager class from flink-kafka-connector to fix ClassCastException*
  - *The flink 1.12, 1.14 and 1.15 versions are affected.*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
