### PR TITLE
[ARCTIC-1420] Fix optimize commit for 0.3.x when there are no target files

### DIFF
--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizeCommit.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizeCommit.java
@@ -129,7 +129,6 @@ public class TestMajorOptimizeCommit extends TestBaseOptimizeBase {
   }
 
   @Test
-  @Ignore
   public void testEmptyTargetFilesMajorOptimizeCommit() throws Exception {
     List<DataFile> baseDataFiles = insertTableBaseDataFiles(testKeyedTable, 1L);
     baseDataFilesInfo.addAll(baseDataFiles.stream()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1420.

This bug only exist with iceberg 0.12.x, so there is no need to cherry-pick to 0.4.x(iceberg 0.13.2) or master (iceberg 1.0+).

## Brief change log

  - for full/major optimize commit, when there are no added DataFiles and removed DeleteFiles, use Overwrite instead of Rewrite
  - don't split the commit process into two Rewrite operations

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
