### PR TITLE
[ARCTIC-1474]: Self-Optimizing cached table list not fetched correctly 

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeService.java
@@ -275,7 +275,12 @@ public class OptimizeService extends IJDBCService implements IOptimizeService {
       refreshAndListTables();
       TableOptimizeItem reloadTableOptimizeItem = optimizeTables.get(tableIdentifier);
       if (reloadTableOptimizeItem == null) {
-        throw new NoSuchObjectException("can't find table " + tableIdentifier);
+        if (unOptimizeTables.contains(tableIdentifier)) {
+          throw new NoSuchObjectException(tableIdentifier + " not in optimizing tables, maybe property " +
+                  "self-optimizing.enabled is false!");
+        } else {
+          throw new NoSuchObjectException("can't find table " + tableIdentifier);
+        }
       }
       return reloadTableOptimizeItem;
     }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/RuntimeDataExpireService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/RuntimeDataExpireService.java
@@ -65,7 +65,7 @@ public class RuntimeDataExpireService {
 
   private void expire() {
     List<TableMetadata> tableMetadata = metaService.listTables();
-    List<TableIdentifier> optimizeTables = optimizeService.refreshAndListTables();
+    List<TableIdentifier> optimizeTables = optimizeService.listCachedTables();
     // expire and clear table_task_history table
     if (optimizeTables != null && optimizeTables.size() > 0) {
       tableMetadata.forEach(meta -> {


### PR DESCRIPTION
fix #1474 

## Why are the changes needed?

OptimizeService::getTableOptimizeItem  doesn't check the table in optimizeTables.  
RuntimeDataExpireService::expire  will trigger refreshAndListTables when can't get the TableOptimizeItem, i  think we should refresh first and then do expire logic.


## Brief change log

1. call   refreshAndListTables to get tables which need to expire optimize_history
2、Improve logging when TableOptimizeItem cannot be found.


## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
