### PR TITLE
[ARCTIC-1545][Bug][Spark]: Adapt legacy hive properties in spark session catalog.

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
@@ -18,6 +18,8 @@
 
 package com.netease.arctic.spark;
 
+import com.netease.arctic.hive.HiveTableProperties;
+import com.netease.arctic.hive.utils.CompatibleHivePropertyUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
@@ -221,7 +223,8 @@ public class ArcticSparkSessionCatalog<T extends TableCatalog & SupportsNamespac
   }
 
   private boolean isArcticTable(Table table) {
-    return table.properties().containsKey("arctic.enabled") &&
-        table.properties().get("arctic.enabled").equals("true");
+    return table.properties() != null &&
+        CompatibleHivePropertyUtil.propertyAsBoolean(
+            table.properties(), HiveTableProperties.ARCTIC_TABLE_FLAG, false);
   }
 }

--- a/spark/v3.2/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
@@ -18,6 +18,8 @@
 
 package com.netease.arctic.spark;
 
+import com.netease.arctic.hive.HiveTableProperties;
+import com.netease.arctic.hive.utils.CompatibleHivePropertyUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
@@ -218,7 +220,8 @@ public class ArcticSparkSessionCatalog<T extends TableCatalog & SupportsNamespac
   }
 
   private boolean isArcticTable(Table table) {
-    return table.properties().containsKey("arctic.enabled") &&
-        table.properties().get("arctic.enabled").equals("true");
+    return table.properties() != null &&
+        CompatibleHivePropertyUtil.propertyAsBoolean(
+            table.properties(), HiveTableProperties.ARCTIC_TABLE_FLAG, false);
   }
 }

--- a/spark/v3.2/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
@@ -120,7 +120,7 @@ public class ArcticSparkSessionCatalog<T extends TableCatalog & SupportsNamespac
   public Table loadTable(Identifier ident) throws NoSuchTableException {
     Table table = getSessionCatalog().loadTable(ident);
     if (isArcticTable(table)) {
-      return arcticCatalog.loadTable(ident);
+      return getArcticCatalog().loadTable(ident);
     }
     return table;
   }

--- a/spark/v3.2/spark/src/test/java/com/netease/arctic/spark/test/suites/sql/TestArcticSessionCatalog.java
+++ b/spark/v3.2/spark/src/test/java/com/netease/arctic/spark/test/suites/sql/TestArcticSessionCatalog.java
@@ -18,9 +18,14 @@
 
 package com.netease.arctic.spark.test.suites.sql;
 
+import com.google.common.collect.Maps;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.spark.SparkSQLProperties;
 import com.netease.arctic.spark.test.SparkTableTestBase;
 import com.netease.arctic.spark.test.helper.RecordGenerator;
+import com.netease.arctic.spark.test.helper.TestTableHelper;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.PrimaryKeySpec;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
@@ -28,13 +33,16 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.platform.commons.util.StringUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public class TestArcticSessionCatalog extends SparkTableTestBase {
@@ -140,5 +148,27 @@ public class TestArcticSessionCatalog extends SparkTableTestBase {
 
     Table hiveTable = loadHiveTable();
     Assertions.assertNotNull(hiveTable);
+  }
+
+  @Test
+  public void testLoadLegacyTable() {
+    createTarget(schema,
+        c -> c.withPrimaryKeySpec(PrimaryKeySpec.builderFor(schema).addColumn("id").build()));
+    createViewSource(schema, source);
+    Table hiveTable = loadHiveTable();
+    Map<String, String> properties = Maps.newHashMap(hiveTable.getParameters());
+    properties.remove(HiveTableProperties.ARCTIC_TABLE_FLAG);
+    properties.put(HiveTableProperties.ARCTIC_TABLE_FLAG_LEGACY, "true");
+    hiveTable.setParameters(properties);
+    try {
+      context.getHiveClient().alter_table(hiveTable.getDbName(), hiveTable.getTableName(), hiveTable);
+    } catch (TException e) {
+      throw new RuntimeException(e);
+    }
+
+    sql("insert into " + target() + " select * from " + source());
+    ArcticTable table = loadTable();
+    List<Record> changes = TestTableHelper.changeRecordsWithAction(table.asKeyedTable());
+    Assertions.assertTrue(changes.size() > 0);
   }
 }

--- a/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
+++ b/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
@@ -18,6 +18,8 @@
 
 package com.netease.arctic.spark;
 
+import com.netease.arctic.hive.HiveTableProperties;
+import com.netease.arctic.hive.utils.CompatibleHivePropertyUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchFunctionException;
@@ -223,8 +225,9 @@ public class ArcticSparkSessionCatalog<T extends TableCatalog & SupportsNamespac
   }
 
   private boolean isArcticTable(Table table) {
-    return table.properties().containsKey("arctic.enabled") &&
-        table.properties().get("arctic.enabled").equals("true");
+    return table.properties() != null &&
+        CompatibleHivePropertyUtil.propertyAsBoolean(
+            table.properties(), HiveTableProperties.ARCTIC_TABLE_FLAG, false);
   }
 
   @Override

--- a/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
+++ b/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
@@ -123,7 +123,7 @@ public class ArcticSparkSessionCatalog<T extends TableCatalog & SupportsNamespac
   public Table loadTable(Identifier ident) throws NoSuchTableException {
     Table table = getSessionCatalog().loadTable(ident);
     if (isArcticTable(table)) {
-      return arcticCatalog.loadTable(ident);
+      return getArcticCatalog().loadTable(ident);
     }
     return table;
   }

--- a/spark/v3.3/spark/src/test/java/com/netease/arctic/spark/test/suites/sql/TestArcticSessionCatalog.java
+++ b/spark/v3.3/spark/src/test/java/com/netease/arctic/spark/test/suites/sql/TestArcticSessionCatalog.java
@@ -18,9 +18,14 @@
 
 package com.netease.arctic.spark.test.suites.sql;
 
+import com.google.common.collect.Maps;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.spark.SparkSQLProperties;
 import com.netease.arctic.spark.test.SparkTableTestBase;
 import com.netease.arctic.spark.test.helper.RecordGenerator;
+import com.netease.arctic.spark.test.helper.TestTableHelper;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.PrimaryKeySpec;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
@@ -28,13 +33,16 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.platform.commons.util.StringUtils;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public class TestArcticSessionCatalog extends SparkTableTestBase {
@@ -133,5 +141,27 @@ public class TestArcticSessionCatalog extends SparkTableTestBase {
 
     Table hiveTable = loadHiveTable();
     Assertions.assertNotNull(hiveTable);
+  }
+
+  @Test
+  public void testLoadLegacyTable() {
+    createTarget(schema,
+        c -> c.withPrimaryKeySpec(PrimaryKeySpec.builderFor(schema).addColumn("id").build()));
+    createViewSource(schema, source);
+    Table hiveTable = loadHiveTable();
+    Map<String, String> properties = Maps.newHashMap(hiveTable.getParameters());
+    properties.remove(HiveTableProperties.ARCTIC_TABLE_FLAG);
+    properties.put(HiveTableProperties.ARCTIC_TABLE_FLAG_LEGACY, "true");
+    hiveTable.setParameters(properties);
+    try {
+      context.getHiveClient().alter_table(hiveTable.getDbName(), hiveTable.getTableName(), hiveTable);
+    } catch (TException e) {
+      throw new RuntimeException(e);
+    }
+
+    sql("insert into " + target() + " select * from " + source());
+    ArcticTable table = loadTable();
+    List<Record> changes = TestTableHelper.changeRecordsWithAction(table.asKeyedTable());
+    Assertions.assertTrue(changes.size() > 0);
   }
 }


### PR DESCRIPTION
 

## Why are the changes needed?

fix #1545 


## Brief change log

- Using CompatibleHivePropertyUtil to read hive table properties 

## How was this patch tested?

- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Run test locally before making a pull request

