### PR TITLE
[ARCTIC-1545][PICK-1546][Bug][Spark]: Adapt legacy hive properties in spark session catalog.

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/ArcticSparkSessionCatalog.java
@@ -18,6 +18,8 @@
 
 package com.netease.arctic.spark;
 
+import com.netease.arctic.hive.HiveTableProperties;
+import com.netease.arctic.hive.utils.CompatibleHivePropertyUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
@@ -221,7 +223,8 @@ public class ArcticSparkSessionCatalog<T extends TableCatalog & SupportsNamespac
   }
 
   private boolean isArcticTable(Table table) {
-    return table.properties().containsKey("arctic.enabled") &&
-        table.properties().get("arctic.enabled").equals("true");
+    return table.properties() != null &&
+        CompatibleHivePropertyUtil.propertyAsBoolean(
+            table.properties(), HiveTableProperties.ARCTIC_TABLE_FLAG, false);
   }
 }


### PR DESCRIPTION
 
## Why are the changes needed?

pick #1546 to fix #1545 

 
## Brief change log

Using CompatibleHivePropertyUtil to read hive table properties

## How was this patch tested?

- [X] Run test locally before making a pull request

## Documentation

Not documented
