### PR TITLE
Revert "[ARCTIC-1551]: Global Catalog configuration not valid for table build check"

### DIFF
--- a/core/src/main/java/com/netease/arctic/catalog/BasicArcticCatalog.java
+++ b/core/src/main/java/com/netease/arctic/catalog/BasicArcticCatalog.java
@@ -283,7 +283,6 @@ public class BasicArcticCatalog implements ArcticCatalog {
 
     @Override
     public ArcticTable create() {
-      properties = CatalogUtil.mergeCatalogPropertiesToTable(properties, catalogMeta.getCatalogProperties());
       ConvertStructUtil.TableMetaBuilder builder = createTableMataBuilder();
       doCreateCheck();
       TableMeta meta = builder.build();

--- a/core/src/test/java/com/netease/arctic/catalog/TestMixedCatalog.java
+++ b/core/src/test/java/com/netease/arctic/catalog/TestMixedCatalog.java
@@ -143,41 +143,6 @@ public class TestMixedCatalog extends CatalogTestBase {
   }
 
   @Test
-  public void testCreateTableWithNewCatalogLogProperties() throws TException {
-    UnkeyedTable createTable = getCatalog()
-        .newTableBuilder(TableTestHelper.TEST_TABLE_ID, getCreateTableSchema())
-        .withPartitionSpec(getCreateTableSpec())
-        .create()
-        .asUnkeyedTable();
-    Assert.assertTrue(PropertyUtil.propertyAsBoolean(createTable.properties(),
-        TableProperties.ENABLE_SELF_OPTIMIZING, TableProperties.ENABLE_SELF_OPTIMIZING_DEFAULT));
-    getCatalog().dropTable(TableTestHelper.TEST_TABLE_ID, true);
-
-    CatalogMeta testCatalogMeta = TEST_AMS.getAmsHandler().getCatalog(CatalogTestHelper.TEST_CATALOG_NAME);
-    TEST_AMS.getAmsHandler().updateMeta(
-        testCatalogMeta,
-        CatalogMetaProperties.TABLE_PROPERTIES_PREFIX + TableProperties.LOG_STORE_ADDRESS,
-        "1.1.1.1");
-    TEST_AMS.getAmsHandler().updateMeta(
-        testCatalogMeta,
-        CatalogMetaProperties.TABLE_PROPERTIES_PREFIX + TableProperties.LOG_STORE_MESSAGE_TOPIC,
-        "test-topic");
-    TEST_AMS.getAmsHandler().updateMeta(
-        testCatalogMeta,
-        CatalogMetaProperties.TABLE_PROPERTIES_PREFIX + TableProperties.ENABLE_SELF_OPTIMIZING,
-        "false");
-    getCatalog().refresh();
-    createTable = getCatalog()
-        .newTableBuilder(TableTestHelper.TEST_TABLE_ID, getCreateTableSchema())
-        .withPartitionSpec(getCreateTableSpec())
-        .withProperty(TableProperties.ENABLE_LOG_STORE, "true")
-        .create()
-        .asUnkeyedTable();
-    Assert.assertFalse(PropertyUtil.propertyAsBoolean(createTable.properties(),
-        TableProperties.ENABLE_SELF_OPTIMIZING, TableProperties.ENABLE_SELF_OPTIMIZING_DEFAULT));
-  }
-
-  @Test
   public void testUnkeyedRecoverableFileIO() throws TException {
     UnkeyedTable createTable = getCatalog()
         .newTableBuilder(TableTestHelper.TEST_TABLE_ID, getCreateTableSchema())


### PR DESCRIPTION
Reverts NetEase/arctic#1555.
 In offline discussions, it was suggested that the properties of the catalog should remain consistent with the existing logic. Only when reading, the properties of the catalog should be merged with the properties of the table, and not written into the table properties.