### PR TITLE
[ARCTIC-1521] [Improvement]: Add hive location to table properties of Mixed hive format

### DIFF
--- a/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
+++ b/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
@@ -36,6 +36,9 @@ public class HiveTableProperties {
 
   public static final String ARCTIC_TABLE_PRIMARY_KEYS = "arctic.table.primary-keys";
 
+  // save the location of arctic table. ranger can
+  public static final String ARCTIC_TABLE_ROOT_LOCATION = "arctic.table.root-location";
+
   public static final String PARTITION_PROPERTIES_KEY_HIVE_LOCATION = "hive-location";
 
   public static final String PARTITION_PROPERTIES_KEY_TRANSIENT_TIME = "transient-time";

--- a/hive/src/test/java/com/netease/arctic/hive/op/TestHiveSchemaUpdate.java
+++ b/hive/src/test/java/com/netease/arctic/hive/op/TestHiveSchemaUpdate.java
@@ -19,7 +19,10 @@
 package com.netease.arctic.hive.op;
 
 import com.netease.arctic.hive.HiveTableTestBase;
+import com.netease.arctic.hive.table.KeyedHiveTable;
+import com.netease.arctic.hive.table.UnkeyedHiveTable;
 import com.netease.arctic.hive.utils.HiveSchemaUtil;
+import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.UnkeyedTable;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.iceberg.PartitionSpec;
@@ -40,21 +43,45 @@ public class TestHiveSchemaUpdate extends HiveTableTestBase {
 
   @Test
   public void testHiveParameterFromArctic() throws TException {
-    String database = testHiveTable.id().getDatabase();
-    String table = testHiveTable.id().getTableName();
+
+    String unkeyedTable = "unkeyed_test_hive_table";
+    String keyedTable = "keyed_test_hive_table";
+
+    final TableIdentifier unKeyedHiveTableIdentifier =
+            TableIdentifier.of(HIVE_CATALOG_NAME, HIVE_DB_NAME, unkeyedTable);
+
+    final TableIdentifier keyedHiveTableIdentifier =
+            TableIdentifier.of(HIVE_CATALOG_NAME, HIVE_DB_NAME, keyedTable);
+
+    UnkeyedHiveTable testUnKeyedTable = (UnkeyedHiveTable) hiveCatalog
+            .newTableBuilder(unKeyedHiveTableIdentifier, HIVE_TABLE_SCHEMA)
+            .withPartitionSpec(HIVE_SPEC)
+            .create().asUnkeyedTable();
+
     Map<String,String> tableParameter =  hms.getClient()
-            .getTable(database,table).getParameters();
+            .getTable(HIVE_DB_NAME,unkeyedTable).getParameters();
     Assert.assertTrue(tableParameter.containsKey(ARCTIC_TABLE_ROOT_LOCATION));
-    Assert.assertTrue(tableParameter.get(ARCTIC_TABLE_ROOT_LOCATION).endsWith(table));
+    Assert.assertTrue(tableParameter.get(ARCTIC_TABLE_ROOT_LOCATION).endsWith(unkeyedTable));
     Assert.assertTrue(tableParameter.containsKey(ARCTIC_TABLE_FLAG));
 
+    hiveCatalog.dropTable(unKeyedHiveTableIdentifier, true);
+    AMS.handler().getTableCommitMetas().remove(unKeyedHiveTableIdentifier.buildTableIdentifier());
+    
+    KeyedHiveTable testKeyedTable = (KeyedHiveTable) hiveCatalog
+            .newTableBuilder(keyedHiveTableIdentifier, HIVE_TABLE_SCHEMA)
+            .withPartitionSpec(HIVE_SPEC)
+            .withPrimaryKeySpec(PRIMARY_KEY_SPEC)
+            .create().asKeyedTable();
+
     Map<String,String> keyedTableParameter =  hms.getClient()
-            .getTable(testKeyedHiveTable.id().getDatabase(),testKeyedHiveTable.id().getTableName()).getParameters();
+            .getTable(HIVE_DB_NAME, keyedTable).getParameters();
     Assert.assertTrue(keyedTableParameter.containsKey(ARCTIC_TABLE_ROOT_LOCATION));
     Assert.assertTrue(keyedTableParameter.get(ARCTIC_TABLE_ROOT_LOCATION)
-            .endsWith(testKeyedHiveTable.id().getTableName()));
+            .endsWith(keyedTable));
     Assert.assertTrue(keyedTableParameter.containsKey(ARCTIC_TABLE_FLAG));
 
+    hiveCatalog.dropTable(keyedHiveTableIdentifier, true);
+    AMS.handler().getTableCommitMetas().remove(keyedHiveTableIdentifier.buildTableIdentifier());
   }
 
   @Test

--- a/hive/src/test/java/com/netease/arctic/hive/op/TestHiveSchemaUpdate.java
+++ b/hive/src/test/java/com/netease/arctic/hive/op/TestHiveSchemaUpdate.java
@@ -31,8 +31,31 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
+
+import static com.netease.arctic.hive.HiveTableProperties.ARCTIC_TABLE_FLAG;
+import static com.netease.arctic.hive.HiveTableProperties.ARCTIC_TABLE_ROOT_LOCATION;
 
 public class TestHiveSchemaUpdate extends HiveTableTestBase {
+
+  @Test
+  public void testHiveParameterFromArctic() throws TException {
+    String database = testHiveTable.id().getDatabase();
+    String table = testHiveTable.id().getTableName();
+    Map<String,String> tableParameter =  hms.getClient()
+            .getTable(database,table).getParameters();
+    Assert.assertTrue(tableParameter.containsKey(ARCTIC_TABLE_ROOT_LOCATION));
+    Assert.assertTrue(tableParameter.get(ARCTIC_TABLE_ROOT_LOCATION).endsWith(table));
+    Assert.assertTrue(tableParameter.containsKey(ARCTIC_TABLE_FLAG));
+
+    Map<String,String> keyedTableParameter =  hms.getClient()
+            .getTable(testKeyedHiveTable.id().getDatabase(),testKeyedHiveTable.id().getTableName()).getParameters();
+    Assert.assertTrue(keyedTableParameter.containsKey(ARCTIC_TABLE_ROOT_LOCATION));
+    Assert.assertTrue(keyedTableParameter.get(ARCTIC_TABLE_ROOT_LOCATION)
+            .endsWith(testKeyedHiveTable.id().getTableName()));
+    Assert.assertTrue(keyedTableParameter.containsKey(ARCTIC_TABLE_FLAG));
+
+  }
 
   @Test
   public void testKeyedAdd() throws TException {


### PR DESCRIPTION
## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix #1521 
*(For example: The Arctic Flink dataStream API has already supported this configuration: 'scan.startup.mode', but it is not available with Flink SQL. We should expose this configuration to users when they are using Flink SQL.)*

## Brief change log

- affect 0.4.x master
- affect table format: mixed hive
- add a new parameter named  `arctic.table.root-location`  to hive table to specify the root directory for storing Arctic table when creating it.


## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
