### PR TITLE
[ARCTIC-1584] Fix Mysql init sql

### DIFF
--- a/ams/server/src/main/resources/mysql/ams-mysql-init.sql
+++ b/ams/server/src/main/resources/mysql/ams-mysql-init.sql
@@ -46,7 +46,7 @@ CREATE TABLE `optimizer`
 
 CREATE TABLE `resource`
 (
-    `resource_id`               varchar(100) DEFAULT NULL  COMMENT 'optimizer instance id',
+    `resource_id`               varchar(100) NOT NULL  COMMENT 'optimizer instance id',
     `resource_type`             tinyint(4) DEFAULT 0 COMMENT 'resource type like optimizer/ingestor',
     `container_name`            varchar(100) DEFAULT NULL  COMMENT 'container name',
     `group_name`                varchar(50) DEFAULT NULL COMMENT 'queue name',


### PR DESCRIPTION
## Why are the changes needed?
Fix #1584 .

## Brief change log

  - *Make `resource_id` not null in table `resource`.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
