### PR TITLE
[ARCTIC-1378] Incorrect data synchronization caused the data of the arctic base table to be overwritten

### DIFF
--- a/ams/server/src/main/resources/mysql/ams-mysql-init.sql
+++ b/ams/server/src/main/resources/mysql/ams-mysql-init.sql
@@ -46,7 +46,7 @@ CREATE TABLE `optimizer`
 
 CREATE TABLE `resource`
 (
-    `resource_id`               varchar(100) DEFAULT NULL  COMMENT 'optimizer instance id',
+    `resource_id`               varchar(100) NOT NULL  COMMENT 'optimizer instance id',
     `resource_type`             tinyint(4) DEFAULT 0 COMMENT 'resource type like optimizer/ingestor',
     `container_name`            varchar(100) DEFAULT NULL  COMMENT 'container name',
     `group_name`                varchar(50) DEFAULT NULL COMMENT 'queue name',

--- a/hive/src/main/java/com/netease/arctic/hive/utils/HiveMetaSynchronizer.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/HiveMetaSynchronizer.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.hive.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.netease.arctic.hive.HMSClientPool;
 import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.op.OverwriteHiveFiles;
@@ -221,7 +222,8 @@ public class HiveMetaSynchronizer {
     }
   }
 
-  private static boolean partitionHasModified(
+  @VisibleForTesting
+  static boolean partitionHasModified(
       UnkeyedTable arcticTable, Partition hivePartition,
       StructLike partitionData) {
     String hiveTransientTime = hivePartition.getParameters().get("transient_lastDdlTime");
@@ -248,7 +250,8 @@ public class HiveMetaSynchronizer {
     return false;
   }
 
-  private static boolean tableHasModified(UnkeyedTable arcticTable, Table table) {
+  @VisibleForTesting
+  static boolean tableHasModified(UnkeyedTable arcticTable, Table table) {
     String hiveTransientTime = table.getParameters().get("transient_lastDdlTime");
     StructLikeMap<Map<String, String>> structLikeMap = arcticTable.partitionProperty();
     String arcticTransientTime = null;

--- a/hive/src/main/java/com/netease/arctic/hive/utils/HivePartitionUtil.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/HivePartitionUtil.java
@@ -136,7 +136,7 @@ public class HivePartitionUtil {
    * @param tableIdentifier A table identifier
    * @return A List of Hive partition objects
    */
-  public List<Partition> getHiveAllPartitions(HMSClientPool hiveClient, TableIdentifier tableIdentifier) {
+  public static List<Partition> getHiveAllPartitions(HMSClientPool hiveClient, TableIdentifier tableIdentifier) {
     try {
       return hiveClient.run(client ->
           client.listPartitions(tableIdentifier.getDatabase(), tableIdentifier.getTableName(), Short.MAX_VALUE));

--- a/hive/src/main/java/com/netease/arctic/hive/utils/UpgradeHiveTableUtil.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/UpgradeHiveTableUtil.java
@@ -18,18 +18,24 @@
 
 package com.netease.arctic.hive.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.netease.arctic.hive.HMSClientPool;
 import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.catalog.ArcticHiveCatalog;
 import com.netease.arctic.hive.table.SupportHive;
+import com.netease.arctic.hive.table.UnkeyedHiveTable;
 import com.netease.arctic.io.ArcticHadoopFileIO;
+import com.netease.arctic.op.UpdatePartitionProperties;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.PrimaryKeySpec;
 import com.netease.arctic.table.TableIdentifier;
+import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.slf4j.Logger;
@@ -82,6 +88,7 @@ public class UpgradeHiveTableUtil {
           .withProperty(HiveTableProperties.ALLOW_HIVE_TABLE_EXISTED, "true")
           .create();
       upgradeHive = true;
+      initPartitionProperties(arcticTable, arcticHiveCatalog, hiveTable);
       UpgradeHiveTableUtil.hiveDataMigration((SupportHive) arcticTable, arcticHiveCatalog, tableIdentifier);
     } catch (Throwable t) {
       if (upgradeHive) {
@@ -171,5 +178,39 @@ public class UpgradeHiveTableUtil {
       throw new IOException(e);
     }
     return isSupport.get();
+  }
+
+  @VisibleForTesting
+  static void initPartitionProperties(ArcticTable table, ArcticHiveCatalog arcticHiveCatalog, Table hiveTable) {
+    UnkeyedHiveTable baseTable;
+    if (table.isKeyedTable()) {
+      baseTable = (UnkeyedHiveTable) table.asKeyedTable().baseTable();
+    } else {
+      baseTable = (UnkeyedHiveTable) table.asUnkeyedTable();
+    }
+    UpdatePartitionProperties updatePartitionProperties =
+        baseTable.updatePartitionProperties(null);
+    if (table.spec().isUnpartitioned()) {
+      updatePartitionProperties.set(
+          TablePropertyUtil.EMPTY_STRUCT,
+          HiveTableProperties.PARTITION_PROPERTIES_KEY_HIVE_LOCATION, baseTable.hiveLocation());
+      updatePartitionProperties.set(TablePropertyUtil.EMPTY_STRUCT,
+          HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME,
+          hiveTable.getParameters().get("transient_lastDdlTime"));
+    } else {
+      List<Partition> partitions =
+          HivePartitionUtil.getHiveAllPartitions(arcticHiveCatalog.getHMSClient(), table.id());
+      partitions.forEach(partition -> {
+        updatePartitionProperties.set(
+            DataFiles.data(table.spec(), String.join("/", partition.getValues())),
+            HiveTableProperties.PARTITION_PROPERTIES_KEY_HIVE_LOCATION,
+            partition.getSd().getLocation());
+        updatePartitionProperties.set(
+            DataFiles.data(table.spec(), String.join("/", partition.getValues())),
+            HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME,
+            partition.getParameters().get("transient_lastDdlTime"));
+      });
+    }
+    updatePartitionProperties.commit();
   }
 }

--- a/hive/src/main/java/com/netease/arctic/hive/utils/UpgradeHiveTableUtil.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/UpgradeHiveTableUtil.java
@@ -143,6 +143,7 @@ public class UpgradeHiveTableUtil {
       }
     }
     HiveMetaSynchronizer.syncHiveDataToArctic(arcticTable, arcticHiveCatalog.getHMSClient());
+    hiveTable = HiveTableUtil.loadHmsTable(arcticHiveCatalog.getHMSClient(), tableIdentifier);
     fillPartitionProperties(arcticTable, arcticHiveCatalog, hiveTable);
   }
 

--- a/hive/src/test/java/com/netease/arctic/hive/utils/TestUpgradeHiveTableUtil.java
+++ b/hive/src/test/java/com/netease/arctic/hive/utils/TestUpgradeHiveTableUtil.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.hive.utils;
+
+import com.netease.arctic.ams.api.TableFormat;
+import com.netease.arctic.catalog.CatalogTestBase;
+import com.netease.arctic.catalog.CatalogTestHelper;
+import com.netease.arctic.hive.HiveTableProperties;
+import com.netease.arctic.hive.TestHMS;
+import com.netease.arctic.hive.catalog.ArcticHiveCatalog;
+import com.netease.arctic.hive.catalog.HiveCatalogTestHelper;
+import com.netease.arctic.hive.catalog.HiveTableTestHelper;
+import com.netease.arctic.hive.table.UnkeyedHiveTable;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.TableIdentifier;
+import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.utils.TablePropertyUtil;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.thrift.TException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@RunWith(Parameterized.class)
+public class TestUpgradeHiveTableUtil extends CatalogTestBase {
+
+  @ClassRule
+  public static TestHMS TEST_HMS = new TestHMS();
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private Table hiveTable;
+  private TableIdentifier identifier;
+  private String db = "testUpgradeHiveDb";
+  private String table = "testUpgradeHiveTable";
+  private boolean isPartitioned;
+  private Schema partitionSchema;
+  private String[] partitionNames = {"name", HiveTableTestHelper.COLUMN_NAME_OP_DAY};
+  private String[] partitionValues = {"Bob", "2020-01-01"};
+
+  public TestUpgradeHiveTableUtil(
+      CatalogTestHelper catalogTestHelper, boolean isPartitioned) throws IOException {
+    super(catalogTestHelper);
+    folder.create();
+    this.isPartitioned = isPartitioned;
+    this.partitionSchema = HiveTableTestHelper.HIVE_TABLE_SCHEMA.select(partitionNames);
+  }
+
+  @Before
+  public void setUp() throws TException, IOException {
+    Database database = new Database();
+    database.setName(db);
+    TEST_HMS.getHiveClient().createDatabase(database);
+    PartitionSpec spec = isPartitioned ? PartitionSpec.builderFor(HiveTableTestHelper.HIVE_TABLE_SCHEMA)
+        .identity("name").identity(HiveTableTestHelper.COLUMN_NAME_OP_DAY).build() : PartitionSpec.unpartitioned();
+    hiveTable = createHiveTable(db, table, HiveTableTestHelper.HIVE_TABLE_SCHEMA, spec);
+    if (isPartitioned) {
+      createPartition();
+    }
+    identifier = TableIdentifier.of(getCatalog().name(), db, table);
+  }
+
+  @After
+  public void dropTable() throws TException {
+    getCatalog().dropTable(identifier, true);
+    TEST_HMS.getHiveClient().dropDatabase(db);
+  }
+
+  @Parameterized.Parameters(name = "{0}, {1}")
+  public static Object[] parameters() {
+    return new Object[][] {{new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()), true},
+                           {new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()), false}};
+  }
+
+  @Test
+  public void upgradeHiveTable() throws Exception {
+    UpgradeHiveTableUtil.upgradeHiveTable(
+        (ArcticHiveCatalog) getCatalog(),
+        identifier,
+        new ArrayList<>(),
+        new HashMap<>());
+    ArcticTable table = getCatalog().loadTable(identifier);
+    UnkeyedHiveTable baseTable = table.isKeyedTable() ?
+        (UnkeyedHiveTable) table.asKeyedTable().baseTable() :
+        (UnkeyedHiveTable) table.asUnkeyedTable();
+    if (table.spec().isPartitioned()) {
+      List<Partition> partitions =
+          HivePartitionUtil.getHiveAllPartitions(((ArcticHiveCatalog)getCatalog()).getHMSClient(), table.id());
+      for (Partition partition : partitions) {
+        Map<String, String> partitionProperties = baseTable.partitionProperty().get(DataFiles.data(table.spec(),
+            String.join("/", partition.getValues())));
+        Assert.assertTrue(partitionProperties.containsKey(HiveTableProperties.PARTITION_PROPERTIES_KEY_HIVE_LOCATION));
+        Assert.assertTrue(partitionProperties.containsKey(HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME));
+      }
+    } else {
+      Map<String, String> partitionProperties = baseTable.partitionProperty().get(TablePropertyUtil.EMPTY_STRUCT);
+      Assert.assertTrue(partitionProperties.containsKey(HiveTableProperties.PARTITION_PROPERTIES_KEY_HIVE_LOCATION));
+      Assert.assertTrue(partitionProperties.containsKey(HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME));
+    }
+  }
+
+  private Table createHiveTable(String db, String table, Schema schema, PartitionSpec spec) throws TException,
+      IOException {
+    Table hiveTable = newHiveTable(db, table, schema, spec);
+    hiveTable.setSd(HiveTableUtil.storageDescriptor(
+        schema,
+        spec,
+        folder.newFolder(db).getAbsolutePath(),
+        FileFormat.valueOf(TableProperties.DEFAULT_FILE_FORMAT_DEFAULT.toUpperCase(Locale.ENGLISH))));
+    TEST_HMS.getHiveClient().createTable(hiveTable);
+    return TEST_HMS.getHiveClient().getTable(db, table);
+  }
+
+  private void createPartition() throws TException {
+    List<String> partitions = Lists.newArrayList();
+    for (int i = 0; i < partitionNames.length; i++) {
+      partitions.add(String.join("=", partitionNames[i], partitionValues[i]));
+    }
+    Partition newPartition =
+        HivePartitionUtil.newPartition(hiveTable, partitions,
+            hiveTable.getSd().getLocation() + "/" + String.join("/", partitions), new ArrayList<>(),
+            (int) (System.currentTimeMillis() / 1000));
+    newPartition.getValues();
+    TEST_HMS.getHiveClient().add_partition(newPartition);
+  }
+
+  private org.apache.hadoop.hive.metastore.api.Table newHiveTable(
+      String db, String table, Schema schema, PartitionSpec partitionSpec) {
+    final long currentTimeMillis = System.currentTimeMillis();
+    org.apache.hadoop.hive.metastore.api.Table newTable = new org.apache.hadoop.hive.metastore.api.Table(
+        table,
+        db,
+        System.getProperty("user.name"),
+        (int) currentTimeMillis / 1000,
+        (int) currentTimeMillis / 1000,
+        Integer.MAX_VALUE,
+        null,
+        HiveSchemaUtil.hivePartitionFields(schema, partitionSpec),
+        new HashMap<>(),
+        null,
+        null,
+        TableType.EXTERNAL_TABLE.toString());
+
+    newTable.getParameters().put("EXTERNAL", "TRUE");
+    return newTable;
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
resolve #1378

## Brief change log

Set partition properties for all partitions even if there are no files under the partition when upgrading a Hive table to an Arctic table.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
