### PR TITLE
[ARCTIC-1609] Check if is a hive table in execute in HiveCommitSyncExecutor

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/executor/HiveCommitSyncExecutor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/executor/HiveCommitSyncExecutor.java
@@ -58,12 +58,12 @@ public class HiveCommitSyncExecutor extends BaseTableExecutor {
     long startTime = System.currentTimeMillis();
     ServerTableIdentifier tableIdentifier = tableRuntime.getTableIdentifier();
     try {
-      LOG.info("{} start hive sync", tableIdentifier);
       ArcticTable arcticTable = loadTable(tableRuntime);
       if (!TableTypeUtil.isHive(arcticTable)) {
         LOG.debug("{} is not a support hive table", tableIdentifier);
         return;
       }
+      LOG.info("{} start hive sync", tableIdentifier);
       syncIcebergToHive(arcticTable);
     } catch (Exception e) {
       LOG.error("{} hive sync failed", tableIdentifier, e);

--- a/ams/server/src/main/java/com/netease/arctic/server/table/executor/HiveCommitSyncExecutor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/executor/HiveCommitSyncExecutor.java
@@ -50,7 +50,7 @@ public class HiveCommitSyncExecutor extends BaseTableExecutor {
 
   @Override
   protected boolean enabled(TableRuntime tableRuntime) {
-    return TableTypeUtil.isHive(loadTable(tableRuntime));
+    return true;
   }
 
   @Override
@@ -60,7 +60,10 @@ public class HiveCommitSyncExecutor extends BaseTableExecutor {
     try {
       LOG.info("{} start hive sync", tableIdentifier);
       ArcticTable arcticTable = loadTable(tableRuntime);
-
+      if (!TableTypeUtil.isHive(arcticTable)) {
+        LOG.debug("{} is not a support hive table", tableIdentifier);
+        return;
+      }
       syncIcebergToHive(arcticTable);
     } catch (Exception e) {
       LOG.error("{} hive sync failed", tableIdentifier, e);


### PR DESCRIPTION
## Why are the changes needed?
Fix #1609 

## Brief change log

  - *Make HiveCommitSyncExecutor always enabled.*
  - *Check if is a hive table in execute.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
