### PR TITLE
[ARCTIC-725] [optimizer,ams]Reporter createTime cannot be updated when failover or attempt 

### DIFF
--- a/optimizer/src/main/java/com/netease/arctic/optimizer/flink/FlinkReporter.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/flink/FlinkReporter.java
@@ -41,7 +41,7 @@ public class FlinkReporter extends AbstractStreamOperator<Void>
   private final BaseTaskReporter taskReporter;
   private final BaseToucher toucher;
   private final long heartBeatInterval;
-  private final long createTime;
+  private long createTime;
   private volatile boolean stopped = false;
   private Thread thread;
 
@@ -49,7 +49,6 @@ public class FlinkReporter extends AbstractStreamOperator<Void>
     this.taskReporter = taskReporter;
     this.toucher = toucher;
     this.heartBeatInterval = optimizerConfig.getHeartBeat();
-    this.createTime = System.currentTimeMillis();
   }
 
   public FlinkReporter(OptimizerConfig config) {
@@ -62,6 +61,7 @@ public class FlinkReporter extends AbstractStreamOperator<Void>
   @Override
   public void open() throws Exception {
     super.open();
+    createTime = System.currentTimeMillis();
     this.thread = new Thread(() -> {
       while (!stopped) {
         try {


### PR DESCRIPTION
fix #725 #1248

## Why are the changes needed?
Since createtime is initialized in the Reporter constructor instead of the open() method, Reporter createTime cannot be updated when a failover or attempt is made
```
2023-06-08 00:00:49,061 INFO [pool-4-thread-260] [com.netease.arctic.ams.server.service.impl.OptimizerService] [] - get report OptimizerStateReport(optimizerId:502369, optimizerState:
{status_identification=1685938140303, flink-job-id=43c46ea9645533421327c5a6e7dcc73d})
#after failover，createtime is not updated
2023-06-08 16:55:33,177 INFO [pool-4-thread-199] [com.netease.arctic.ams.server.service.impl.OptimizerService] [] - get report OptimizerStateReport(optimizerId:502369, optimizerState:
{status_identification=1685938140303, flink-job-id=43c46ea9645533421327c5a6e7dcc73d}
)
```

## Brief change log
- [Flink-external-optimizer] update [Reporter createtime] when open() is executed

```
  public void open() throws Exception {
    super.open();
    createTime = System.currentTimeMillis();
```

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request