### PR TITLE
[ARCTIC-1626] Fix the touch time of Optimizer when restarting AMS

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/DefaultOptimizingService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/DefaultOptimizingService.java
@@ -93,7 +93,6 @@ public class DefaultOptimizingService extends DefaultResourceManager
   public void loadOptimizingQueues(List<TableRuntimeMeta> tableRuntimeMetaList) {
     List<ResourceGroup> optimizerGroups = getAs(ResourceMapper.class, ResourceMapper::selectResourceGroups);
     List<OptimizerInstance> optimizers = getAs(OptimizerMapper.class, OptimizerMapper::selectAll);
-    optimizers.forEach(optimizer -> optimizer.setTouchTime(System.currentTimeMillis()));
     Map<String, List<OptimizerInstance>> optimizersByGroup =
         optimizers.stream().collect(Collectors.groupingBy(OptimizerInstance::getGroupName));
     Map<String, List<TableRuntimeMeta>> groupToTableRuntimes = tableRuntimeMetaList.stream()
@@ -243,7 +242,9 @@ public class DefaultOptimizingService extends DefaultResourceManager
       optimizerMonitorTimer = new Timer("OptimizerMonitor", true);
       optimizerMonitorTimer.schedule(
           new SuspendingDetector(),
-          ArcticServiceConstants.OPTIMIZER_CHECK_INTERVAL,
+          optimizerTouchTimeout,
+          ArcticServiceConstants.OPTIMIZER_CHECK_INTERVAL);
+      LOG.info("init SuspendingDetector for Optimizer with delay {} ms, interval {} ms", optimizerTouchTimeout,
           ArcticServiceConstants.OPTIMIZER_CHECK_INTERVAL);
       LOG.info("OptimizerManagementService initializing has completed");
     }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1626 

## Brief change log

  - not set touch time of optimizer to current time
  - `SuspendingDetector`'s delay should be optimizer touch timeout

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not documented)
