### PR TITLE
[ARCTIC-1630][Flink] Kafka producer encounters NPE when calling the close function

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducer.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducer.java
@@ -144,7 +144,9 @@ public class HiddenKafkaProducer<T> implements LogMsgFactory.Producer<T> {
   @Override
   public void close() throws Exception {
     try {
-      producer.close(Duration.ofSeconds(0));
+      if (producer != null) {
+        producer.close(Duration.ofSeconds(0));
+      }
       transactionalProducer.close(Duration.ofSeconds(0));
     } catch (Exception e) {
       asyncException = ExceptionUtils.firstOrSuppressed(e, asyncException);

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducer.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducer.java
@@ -145,7 +145,9 @@ public class HiddenKafkaProducer<T> implements LogMsgFactory.Producer<T> {
   @Override
   public void close() throws Exception {
     try {
-      producer.close(Duration.ofSeconds(0));
+      if (producer != null) {
+        producer.close(Duration.ofSeconds(0));
+      }
       transactionalProducer.close(Duration.ofSeconds(0));
     } catch (Exception e) {
       asyncException = ExceptionUtils.firstOrSuppressed(e, asyncException);

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducer.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/hidden/kafka/HiddenKafkaProducer.java
@@ -145,7 +145,9 @@ public class HiddenKafkaProducer<T> implements LogMsgFactory.Producer<T> {
   @Override
   public void close() throws Exception {
     try {
-      producer.close(Duration.ofSeconds(0));
+      if (producer != null) {
+        producer.close(Duration.ofSeconds(0));
+      }
       transactionalProducer.close(Duration.ofSeconds(0));
     } catch (Exception e) {
       asyncException = ExceptionUtils.firstOrSuppressed(e, asyncException);


### PR DESCRIPTION
## Why are the changes needed?
fix #1630 

## Brief change log

  - *Add non-null judgment for kafka producer.*
  - *The flink 1.12 ,1.14 and 1.15 versions are affected.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
