### PR TITLE
[ARCTIC-1600][Core]Fix Self-Optimizing error when partition value is null in Mixed-format

### DIFF
--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/flow/view/KeyedTableDataView.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/flow/view/KeyedTableDataView.java
@@ -248,7 +248,11 @@ public class KeyedTableDataView extends AbstractTableDataView {
       Object o1 = r1.get(i);
       Object o2 = r2.get(i);
       boolean equals;
-      if (o1 instanceof OffsetDateTime) {
+      if (o1 == null && o2 == null) {
+        return true;
+      } else if (o1 == null || o2 == null) {
+        return false;
+      } else if (o1 instanceof OffsetDateTime) {
         equals = ((OffsetDateTime) o1).isEqual((OffsetDateTime) o2);
       } else {
         equals = o1.equals(o2);

--- a/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
+++ b/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
@@ -114,6 +114,10 @@ public class ArcticDataFiles {
               field.name().equals(parts[0]),
           "Invalid partition: %s", partitions[i]);
 
+      if ("null".equals(parts[1])) {
+        parts[1] = null;
+      }
+
       data.set(i, ArcticDataFiles.fromPartitionString(field, spec.partitionType().fieldType(parts[0]), parts[1]));
     }
 

--- a/core/src/test/java/com/netease/arctic/utils/TestArcticDataFiles.java
+++ b/core/src/test/java/com/netease/arctic/utils/TestArcticDataFiles.java
@@ -128,4 +128,16 @@ public class TestArcticDataFiles {
     p2.set(partitionData);
     Assert.assertEquals(p1, p2);
   }
+
+  @Test
+  public void testNullPartition() {
+    Schema schema = new Schema(
+        Types.NestedField.required(1, "name", Types.StringType.get())
+    );
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("name").build();
+    PartitionKey partitionKey = new PartitionKey(spec, schema);
+    String partitionPath = "name=null";
+    StructLike partitionData = ArcticDataFiles.data(spec, partitionPath);
+    Assert.assertNull(partitionData.get(0, Types.StringType.get().typeId().javaClass()));
+  }
 }


### PR DESCRIPTION
## Why are the changes needed?
fix: #1600 

## Brief change log
Modify the handling of the string "null" in the com.netease.arctic.utils.ArcticDataFiles#data method.

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
