### PR TITLE
[ARCTIC-1656][AMS] Make plan return when offered a task and do not evaluate when the table is optimizing

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingQueue.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingQueue.java
@@ -285,6 +285,7 @@ public class OptimizingQueue extends PersistentBase implements OptimizingService
           LOG.info("{} after plan get {} tasks", tableRuntime.getTableIdentifier(),
               optimizingProcess.getTaskMap().size());
           optimizingProcess.taskMap.values().forEach(taskQueue::offer);
+          break;
         } else {
           tableRuntime.cleanPendingInput();
         }

--- a/ams/server/src/main/java/com/netease/arctic/server/table/executor/TableRuntimeRefreshExecutor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/executor/TableRuntimeRefreshExecutor.java
@@ -72,7 +72,7 @@ public class TableRuntimeRefreshExecutor extends BaseTableExecutor {
       tableRuntime.refresh(table);
       if (snapshotBeforeRefresh != tableRuntime.getCurrentSnapshotId() ||
           changeSnapshotBeforeRefresh != tableRuntime.getCurrentChangeSnapshotId()) {
-        if (tableRuntime.isOptimizingEnabled()) {
+        if (tableRuntime.isOptimizingEnabled() && !tableRuntime.getOptimizingStatus().isProcessing()) {
           tryEvaluatingPendingInput(tableRuntime, table);
         }
       }


### PR DESCRIPTION

## Why are the changes needed?
Fix #1656 and some related questions.

## Brief change log

  - *Make plan task breaks when offered tasks to the task queue.*
  - *Make the evaluator not evaluate when the table is processing in optimizing.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
