### PR TITLE
[ARCTIC-1628][Feature][AMS]: Remove the Independent DeleteFiles for the Iceberg Format Table

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
@@ -18,16 +18,23 @@
 
 package com.netease.arctic.ams.server.utils;
 
+import com.netease.arctic.IcebergFileEntry;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
+import com.netease.arctic.scan.TableEntriesScan;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.ManifestEntryFields;
 import com.netease.arctic.utils.TableFileUtils;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
@@ -36,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -75,6 +83,37 @@ public class UnKeyedTableUtil {
     }
 
     return validFilesPath;
+  }
+
+  public static Set<DeleteFile> getIndependentFiles(UnkeyedTable internalTable) {
+    Set<String> deleteFilesPath = new HashSet<>();
+    TableScan tableScan = internalTable.newScan();
+    try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {
+      for (FileScanTask fileScanTask : fileScanTasks) {
+        for (DeleteFile delete : fileScanTask.deletes()) {
+          deleteFilesPath.add(delete.path().toString());
+        }
+      }
+    } catch (IOException e) {
+      LOG.error("table scna plan files error", e);
+      return Collections.emptySet();
+    }
+
+    Set<DeleteFile> independentFiles = new HashSet<>();
+    TableEntriesScan entriesScan = TableEntriesScan.builder(internalTable)
+        .useSnapshot(internalTable.currentSnapshot().snapshotId())
+        .includeFileContent(FileContent.EQUALITY_DELETES, FileContent.POSITION_DELETES)
+        .build();
+
+    for (IcebergFileEntry entry : entriesScan.entries()) {
+      ContentFile<?> file = entry.getFile();
+      String path = file.path().toString();
+      if (!deleteFilesPath.contains(path)) {
+        independentFiles.add((DeleteFile) file);
+      }
+    }
+
+    return independentFiles;
   }
 
   private static String metadataTableName(String tableName, MetadataTableType type) {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/utils/UnKeyedTableUtil.java
@@ -86,6 +86,9 @@ public class UnKeyedTableUtil {
   }
 
   public static Set<DeleteFile> getIndependentFiles(UnkeyedTable internalTable) {
+    if (internalTable.currentSnapshot() == null) {
+      return Collections.emptySet();
+    }
     Set<String> deleteFilesPath = new HashSet<>();
     TableScan tableScan = internalTable.newScan();
     try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -175,6 +175,9 @@ public class TableProperties {
   public static final String BASE_SNAPSHOT_KEEP_MINUTES = "snapshot.base.keep.minutes";
   public static final String BASE_SNAPSHOT_KEEP_MINUTES_DEFAULT = "720"; // 12 Hours
 
+  public static final String ENABLE_INDEPENDENT_CLEAN = "clean-independent-delete-files.enabled";
+  public static final boolean ENABLE_INDEPENDENT_CLEAN_DEFAULT = true;
+
   public static final String ENABLE_ORPHAN_CLEAN = "clean-orphan-file.enabled";
   public static final boolean ENABLE_ORPHAN_CLEAN_DEFAULT = false;
   @Deprecated

--- a/site/docs/ch/configurations.md
+++ b/site/docs/ch/configurations.md
@@ -37,6 +37,7 @@ Self-optimizing 配置对 Iceberg format, Mixed streaming format 都会生效。
 | snapshot.base.keep.minutes                  | 720（12小时） | BaseStore 历史快照的保留时间                |
 | clean-orphan-file.enabled                   | false     | 是否开启孤儿文件自动清理                       |
 | clean-orphan-file.min-existing-time-minutes | 2880（2天）  | 存在时间超过 min-existing-time-minutes 未被引用的孤儿文件会被自动清理 |
+| clean-independent-delete-files.enabled      | true      | 是否开启游离文件删除                |
 
 ## Mixed streaming format
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is to increase the feature to 0.4.x，for details, please refer to https://github.com/NetEase/arctic/issues/1628.

## Brief change log

Regularly delete iceberg independent deleteFiles by configuring 'clean-independent-delete-files.enabled'.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes)
  - If yes, how is the feature documented? (docs)
