### PR TITLE
[ARCTIC-1673]: Add maven profile to set flink version for flink optimizer 

### DIFF
--- a/ams/optimizer/pom.xml
+++ b/ams/optimizer/pom.xml
@@ -273,7 +273,7 @@
 
     <profiles>
         <profile>
-            <id>flink1.14</id>
+            <id>optimizer.flink1.14</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -282,7 +282,7 @@
             </properties>
         </profile>
         <profile>
-            <id>flink1.15</id>
+            <id>optimizer.flink1.15</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -297,7 +297,7 @@
             </properties>
         </profile>
         <profile>
-            <id>flink1.16</id>
+            <id>optimizer.flink1.16</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>

--- a/ams/optimizer/pom.xml
+++ b/ams/optimizer/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <fastjson.version>1.2.58</fastjson.version>
         <avro.version>1.10.1</avro.version>
-        <optimizer-flink.version>1.12.7</optimizer-flink.version>
+        <optimizer-flink.version>1.14.6</optimizer-flink.version>
     </properties>
 
     <dependencies>
@@ -262,4 +262,16 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>flink1.16</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <optimizer-flink.version>1.16.2</optimizer-flink.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/ams/optimizer/pom.xml
+++ b/ams/optimizer/pom.xml
@@ -63,7 +63,7 @@
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
+            <artifactId>flink-table-runtime_${scala.binary.version}</artifactId>
             <version>${optimizer-flink.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -76,7 +76,7 @@
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
             <version>${optimizer-flink.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -102,7 +102,7 @@
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-runtime_${scala.binary.version}</artifactId>
+            <artifactId>flink-runtime</artifactId>
             <version>${optimizer-flink.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -141,7 +141,7 @@
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-metrics-influxdb_${scala.binary.version}</artifactId>
+            <artifactId>flink-metrics-influxdb</artifactId>
             <version>${optimizer-flink.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/ams/optimizer/pom.xml
+++ b/ams/optimizer/pom.xml
@@ -48,18 +48,7 @@
             <artifactId>arctic-hive</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
-            <version>${optimizer-flink.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>slf4j-api</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
 
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -265,6 +254,29 @@
 
     <profiles>
         <profile>
+            <id>flink1.14</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <optimizer-flink.version>1.14.6</optimizer-flink.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+                    <version>${optimizer-flink.version}</version>
+                    <scope>provided</scope>
+                    <exclusions>
+                        <exclusion>
+                            <artifactId>slf4j-api</artifactId>
+                            <groupId>org.slf4j</groupId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>flink1.16</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -272,6 +284,20 @@
             <properties>
                 <optimizer-flink.version>1.16.2</optimizer-flink.version>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-table-api-java-bridge</artifactId>
+                    <version>${optimizer-flink.version}</version>
+                    <scope>provided</scope>
+                    <exclusions>
+                        <exclusion>
+                            <artifactId>slf4j-api</artifactId>
+                            <groupId>org.slf4j</groupId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/ams/optimizer/pom.xml
+++ b/ams/optimizer/pom.xml
@@ -55,6 +55,7 @@
             <artifactId>arctic-hive</artifactId>
         </dependency>
 
+        <!-- flink dependencies begin -->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>${flink.table-api-java-bridge.id}</artifactId>
@@ -67,6 +68,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>${flink.table-runtime.id}</artifactId>
@@ -79,6 +81,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>${flink.streaming-java.id}</artifactId>
@@ -91,6 +94,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>${flink.clients.id}</artifactId>
@@ -103,6 +107,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
@@ -115,6 +120,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-runtime</artifactId>
@@ -127,8 +133,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-
 
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -173,6 +177,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- flink dependencies end -->
 
         <dependency>
             <groupId>args4j</groupId>
@@ -225,7 +230,6 @@
             <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/ams/optimizer/pom.xml
+++ b/ams/optimizer/pom.xml
@@ -278,6 +278,21 @@
             </properties>
         </profile>
         <profile>
+            <id>flink1.15</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <optimizer-flink.version>1.15.4</optimizer-flink.version>
+                <flink.table-api-java-bridge.id>flink-table-api-java-bridge</flink.table-api-java-bridge.id>
+                <flink.table-runtime.id>flink-table-runtime</flink.table-runtime.id>
+                <flink.streaming-java.id>flink-streaming-java</flink.streaming-java.id>
+                <flink.clients.id>flink-clients</flink.clients.id>
+                <flink.runtime-web.id>flink-runtime-web</flink.runtime-web.id>
+                <flink.connector-kafka.id>flink-connector-kafka</flink.connector-kafka.id>
+            </properties>
+        </profile>
+        <profile>
             <id>flink1.16</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -291,7 +306,6 @@
                 <flink.runtime-web.id>flink-runtime-web</flink.runtime-web.id>
                 <flink.connector-kafka.id>flink-connector-kafka</flink.connector-kafka.id>
             </properties>
-
         </profile>
     </profiles>
 </project>

--- a/ams/optimizer/pom.xml
+++ b/ams/optimizer/pom.xml
@@ -35,6 +35,13 @@
         <fastjson.version>1.2.58</fastjson.version>
         <avro.version>1.10.1</avro.version>
         <optimizer-flink.version>1.14.6</optimizer-flink.version>
+        <flink.table-api-java-bridge.id>flink-table-api-java-bridge_${scala.binary.version}
+        </flink.table-api-java-bridge.id>
+        <flink.table-runtime.id>flink-table-runtime_${scala.binary.version}</flink.table-runtime.id>
+        <flink.streaming-java.id>flink-streaming-java_${scala.binary.version}</flink.streaming-java.id>
+        <flink.clients.id>flink-clients_${scala.binary.version}</flink.clients.id>
+        <flink.runtime-web.id>flink-runtime-web_${scala.binary.version}</flink.runtime-web.id>
+        <flink.connector-kafka.id>flink-connector-kafka_${scala.binary.version}</flink.connector-kafka.id>
     </properties>
 
     <dependencies>
@@ -48,11 +55,9 @@
             <artifactId>arctic-hive</artifactId>
         </dependency>
 
-
-
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-runtime_${scala.binary.version}</artifactId>
+            <artifactId>${flink.table-api-java-bridge.id}</artifactId>
             <version>${optimizer-flink.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -62,7 +67,42 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>${flink.table-runtime.id}</artifactId>
+            <version>${optimizer-flink.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>${flink.streaming-java.id}</artifactId>
+            <version>${optimizer-flink.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>${flink.clients.id}</artifactId>
+            <version>${optimizer-flink.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
@@ -75,20 +115,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-            <version>${optimizer-flink.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>slf4j-api</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-runtime</artifactId>
@@ -102,22 +128,11 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_${scala.binary.version}</artifactId>
-            <version>${optimizer-flink.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>slf4j-api</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-runtime-web_${scala.binary.version}</artifactId>
+            <artifactId>${flink.runtime-web.id}</artifactId>
             <version>${optimizer-flink.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -144,7 +159,7 @@
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kafka_${scala.binary.version}</artifactId>
+            <artifactId>${flink.connector-kafka.id}</artifactId>
             <version>${optimizer-flink.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -261,20 +276,6 @@
             <properties>
                 <optimizer-flink.version>1.14.6</optimizer-flink.version>
             </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.flink</groupId>
-                    <artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
-                    <version>${optimizer-flink.version}</version>
-                    <scope>provided</scope>
-                    <exclusions>
-                        <exclusion>
-                            <artifactId>slf4j-api</artifactId>
-                            <groupId>org.slf4j</groupId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
         </profile>
         <profile>
             <id>flink1.16</id>
@@ -283,21 +284,14 @@
             </activation>
             <properties>
                 <optimizer-flink.version>1.16.2</optimizer-flink.version>
+                <flink.table-api-java-bridge.id>flink-table-api-java-bridge</flink.table-api-java-bridge.id>
+                <flink.table-runtime.id>flink-table-runtime</flink.table-runtime.id>
+                <flink.streaming-java.id>flink-streaming-java</flink.streaming-java.id>
+                <flink.clients.id>flink-clients</flink.clients.id>
+                <flink.runtime-web.id>flink-runtime-web</flink.runtime-web.id>
+                <flink.connector-kafka.id>flink-connector-kafka</flink.connector-kafka.id>
             </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.flink</groupId>
-                    <artifactId>flink-table-api-java-bridge</artifactId>
-                    <version>${optimizer-flink.version}</version>
-                    <scope>provided</scope>
-                    <exclusions>
-                        <exclusion>
-                            <artifactId>slf4j-api</artifactId>
-                            <groupId>org.slf4j</groupId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-            </dependencies>
+
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Why are the changes needed?

fix #1673 to adapter more flink version for flink optimizer. close #1272 

## Brief change log

- Add a profile flink1.16 to flink optimizer.
- Change default dependend version to flink1.14.6

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request
 
