### PR TITLE
[ARCTIC-1679] Clean pending input when begin optimizing process

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/TableRuntime.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/TableRuntime.java
@@ -150,6 +150,7 @@ public class TableRuntime extends StatedPersistentBase {
       this.processId = optimizingProcess.getProcessId();
       this.currentStatusStartTime = System.currentTimeMillis();
       this.optimizingStatus = optimizingProcess.getOptimizingType().getStatus();
+      this.pendingInput = null;
       persistUpdatingRuntime();
       tableHandler.handleTableChanged(this, originalStatus);
     });
@@ -232,11 +233,7 @@ public class TableRuntime extends StatedPersistentBase {
           lastFullOptimizingTime = optimizingProcess.getPlanTime();
         }
       }
-      if (pendingInput != null) {
-        optimizingStatus = OptimizingStatus.PENDING;
-      } else {
-        optimizingStatus = OptimizingStatus.IDLE;
-      }
+      optimizingStatus = OptimizingStatus.IDLE;
       optimizingProcess = null;
       persistUpdatingRuntime();
       tableHandler.handleTableChanged(this, originalStatus);


### PR DESCRIPTION

## Why are the changes needed?

Fix #1679.

## Brief change log

  - *Clean the pendingInput when begin optimizing*
  - *When completing the optimizing process, set the optimizing status to Idle.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
