### PR TITLE
[ARCTIC-1694] AMS logs need to be compressed and rolled up

### DIFF
--- a/dist/src/main/arctic-bin/conf/log4j2.xml
+++ b/dist/src/main/arctic-bin/conf/log4j2.xml
@@ -27,7 +27,7 @@
         <!--Logs with a grade of debug-->
         <RollingFile name="debugFileAppender"
                      fileName="${LOG_HOME}/ams-debug.log"
-                     filePattern="${LOG_HOME}/history/ams-debug-%i.log">
+                     filePattern="${LOG_HOME}/history/ams-debug-%i.log.gz">
             <!--Set log format-->
             <PatternLayout>
                 <pattern>%d %p [%t] [%logger{39}] [%X{RequestId}] - %m%n</pattern>
@@ -46,7 +46,7 @@
         <!--Logs with a grade of info-->
         <RollingFile name="infoFileAppender"
                      fileName="${LOG_HOME}/ams-info.log"
-                     filePattern="${LOG_HOME}/history/ams-info-%d{yyyy-MM-dd}-%i.log">
+                     filePattern="${LOG_HOME}/history/ams-info-%d{yyyy-MM-dd}-%i.log.gz">
             <!--Set log format-->
             <PatternLayout>
                 <pattern>%d %p [%t] [%logger{39}] [%X{RequestId}] - %m%n</pattern>
@@ -54,13 +54,16 @@
             <Policies>
                 <!--Set the time for rolling updates of log files, depending on the file naming filePattern setting-->
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+                <!--Set the log base file size to trigger rolling log file updates if the size is exceeded-->
+                <SizeBasedTriggeringPolicy size="2048MB"/>
             </Policies>
             <!--Set the maximum number of files in the log, the default is 7 if not set, it will be overwritten when
              it exceeds the size; depends on %i in filePattern-->
             <DefaultRolloverStrategy max="7">
                 <Delete basePath="${LOG_HOME}/history" maxDepth="1">
-                    <IfFileName glob="*.log"/>
+                    <IfFileName glob="*.log.gz"/>
                     <IfLastModified age="7d"/>
+                    <IfAccumulatedFileSize exceeds="20 GB" />
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingFile>
@@ -68,7 +71,7 @@
         <!--Logs with a grade of error-->
         <RollingFile name="errorFileAppender"
                      fileName="${LOG_HOME}/ams-error.log"
-                     filePattern="${LOG_HOME}/history/ams-error-%i.log">
+                     filePattern="${LOG_HOME}/history/ams-error-%i.log.gz">
             <!--Set log format-->
             <PatternLayout>
                 <pattern>%d %p [%t] [%logger{39}] [%X{RequestId}] - %m%n</pattern>
@@ -87,7 +90,7 @@
         <!--Logs for iceberg metrics report -->
         <RollingFile name="icebergRestMetricReporter"
                      fileName="${LOG_HOME}/iceberg-metrics.log"
-                     filePattern="${LOG_HOME}/metrics/iceberg-metrics-%i.log">
+                     filePattern="${LOG_HOME}/metrics/iceberg-metrics-%i.log.gz">
             <PatternLayout>
                 <pattern>%m%n</pattern>
             </PatternLayout>

--- a/dist/src/main/arctic-bin/conf/log4j2.xml
+++ b/dist/src/main/arctic-bin/conf/log4j2.xml
@@ -63,7 +63,7 @@
                 <Delete basePath="${LOG_HOME}/history" maxDepth="1">
                     <IfFileName glob="*.log.gz"/>
                     <IfLastModified age="7d"/>
-                    <IfAccumulatedFileSize exceeds="20 GB" />
+                    <IfAccumulatedFileSize exceeds="20GB" />
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingFile>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

resolve #1694 

## Brief change log

1.Added compression to all logs
2.For info logs, it will make him start rolling up at a smaller size

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
