### PR TITLE
[ARCTIC-1696] Fix the different schema for delete filter and the PK projection

### DIFF
--- a/core/src/main/java/com/netease/arctic/io/reader/GenericCombinedIcebergDataReader.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/GenericCombinedIcebergDataReader.java
@@ -199,7 +199,8 @@ public class GenericCombinedIcebergDataReader implements OptimizingDataReader {
     if (!hasPosDelete && eqDeleteIds == null) {
       return requestedSchema;
     }
-
+    List<Integer> requiredEqDeleteIds = TypeUtil.select(tableSchema, eqDeleteIds).columns().
+        stream().map(Types.NestedField::fieldId).collect(Collectors.toList());
     Set<Integer> requiredIds = Sets.newLinkedHashSet();
     if (hasPosDelete) {
       requiredIds.add(MetadataColumns.FILE_PATH.fieldId());
@@ -207,7 +208,7 @@ public class GenericCombinedIcebergDataReader implements OptimizingDataReader {
     }
 
     if (eqDeleteIds != null) {
-      requiredIds.addAll(eqDeleteIds);
+      requiredIds.addAll(requiredEqDeleteIds);
       requiredIds.add(com.netease.arctic.table.MetadataColumns.TRANSACTION_ID_FILED.fieldId());
     }
 

--- a/core/src/main/java/com/netease/arctic/io/reader/GenericCombinedIcebergDataReader.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/GenericCombinedIcebergDataReader.java
@@ -199,8 +199,8 @@ public class GenericCombinedIcebergDataReader implements OptimizingDataReader {
     if (!hasPosDelete && eqDeleteIds == null) {
       return requestedSchema;
     }
-    List<Integer> requiredEqDeleteIds = TypeUtil.select(tableSchema, eqDeleteIds).columns().
-        stream().map(Types.NestedField::fieldId).collect(Collectors.toList());
+    List<Integer> requiredEqDeleteIds = TypeUtil.select(tableSchema, eqDeleteIds).columns()
+        .stream().map(Types.NestedField::fieldId).collect(Collectors.toList());
     Set<Integer> requiredIds = Sets.newLinkedHashSet();
     if (hasPosDelete) {
       requiredIds.add(MetadataColumns.FILE_PATH.fieldId());


### PR DESCRIPTION
## Why are the changes needed?
Fix #1696.

## Brief change log

  - *Using the table schema to order the equality delete ids.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
