### PR TITLE
[ARCTIC-1708] [Bug]: When using a partition name with uppercase letters in the mixed hive format, it leads to an exceptio

### DIFF
--- a/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
+++ b/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
@@ -151,6 +151,6 @@ public class ArcticDataFiles {
         return s.name();
       }
     }).collect(Collectors.toList());
-    return GenericRecord.create(spec.schema().caseInsensitiveSelect(collect));
+    return GenericRecord.create(spec.schema().select(collect));
   }
 }

--- a/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
+++ b/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
@@ -151,6 +151,6 @@ public class ArcticDataFiles {
         return s.name();
       }
     }).collect(Collectors.toList());
-    return GenericRecord.create(spec.schema().select(collect));
+    return GenericRecord.create(spec.schema().caseInsensitiveSelect(collect));
   }
 }

--- a/hive/src/main/java/org/apache/iceberg/IcebergSchemaUtil.java
+++ b/hive/src/main/java/org/apache/iceberg/IcebergSchemaUtil.java
@@ -29,6 +29,8 @@ public class IcebergSchemaUtil {
    */
   public static PartitionSpec copyPartitionSpec(PartitionSpec partitionSpec, Schema copySchema) {
     PartitionSpec.Builder builder = PartitionSpec.builderFor(copySchema);
+    // For all tables in the mixed hive format it is necessary to also lowercase the partition name value in the iceberg
+    // table, otherwise some case-matching exceptions will be thrown.
     partitionSpec.fields().forEach(partitionField -> {
       builder.add(partitionField.sourceId(), partitionField.name().toLowerCase(), partitionField.transform());
     });

--- a/hive/src/main/java/org/apache/iceberg/IcebergSchemaUtil.java
+++ b/hive/src/main/java/org/apache/iceberg/IcebergSchemaUtil.java
@@ -30,7 +30,7 @@ public class IcebergSchemaUtil {
   public static PartitionSpec copyPartitionSpec(PartitionSpec partitionSpec, Schema copySchema) {
     PartitionSpec.Builder builder = PartitionSpec.builderFor(copySchema);
     partitionSpec.fields().forEach(partitionField -> {
-      builder.add(partitionField.sourceId(), partitionField.name(), partitionField.transform());
+      builder.add(partitionField.sourceId(), partitionField.name().toLowerCase(), partitionField.transform());
     });
     return builder.build();
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1708

## Brief change log

1.  Use caseInsensitiveSelect when generating GenericRecord
2.  Lowercase partition names when creating mixed hive tables

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
