### PR TITLE
[ARCTIC-1700] For unpartitioned Mixed Format KeydTable, using bin-packing to split tasks for Full Optimizing on root node

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/FileTree.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/model/FileTree.java
@@ -221,6 +221,10 @@ public class FileTree {
     return baseFiles.isEmpty() && insertFiles.isEmpty() && deleteFiles.isEmpty() && posDeleteFiles.isEmpty();
   }
   
+  public boolean onlyContainsBaseFiles() {
+    return baseFiles.size() > 0 && insertFiles.isEmpty() && deleteFiles.isEmpty() && posDeleteFiles.isEmpty();
+  }
+  
   public boolean isLeaf() {
     return left == null && right == null;
   }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveFullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveFullOptimizePlan.java
@@ -19,19 +19,16 @@
 package com.netease.arctic.ams.server.optimize;
 
 import com.google.common.base.Preconditions;
-import com.netease.arctic.ams.server.model.FileTree;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.data.DataTreeNode;
 import com.netease.arctic.data.file.FileNameGenerator;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
-import com.netease.arctic.table.TableProperties;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,40 +60,39 @@ public class SupportHiveFullOptimizePlan extends FullOptimizePlan {
 
   @Override
   protected boolean partitionNeedPlan(String partitionToPath) {
+    // check should split root node
+    if (needSplitRootNode(partitionToPath)) {
+      return true;
+    }
 
     List<DeleteFile> posDeleteFiles = getPosDeleteFilesFromFileTree(partitionToPath);
     List<DataFile> baseFiles = getBaseFilesFromFileTree(partitionToPath);
     Map<DataTreeNode, Long> nodeSmallFileCount = new HashMap<>();
     boolean nodeHaveTwoSmallFiles = false;
     boolean notInHiveFile = false;
-    boolean needSplitRootNode = needSplitRootNode(partitionToPath);
-    if (!needSplitRootNode) {
-      for (DataFile baseFile : baseFiles) {
-        boolean inHive = baseFile.path().toString().contains(((SupportHive) arcticTable).hiveLocation());
-        if (!inHive) {
-          notInHiveFile = true;
-          LOG.info("table {} has in not hive location files", arcticTable.id());
+    for (DataFile baseFile : baseFiles) {
+      boolean inHive = baseFile.path().toString().contains(((SupportHive) arcticTable).hiveLocation());
+      if (!inHive) {
+        notInHiveFile = true;
+        LOG.info("table {} has in not hive location files", arcticTable.id());
+        break;
+      } else if (baseFile.fileSizeInBytes() <= getSmallFileSize(arcticTable.properties())) {
+        DataTreeNode node = FileNameGenerator.parseFileNodeFromFileName(baseFile.path().toString());
+        if (nodeSmallFileCount.get(node) != null) {
+          nodeHaveTwoSmallFiles = true;
+          LOG.info("table {} has greater than 2 small files in (mask:{}, node :{}) in hive location",
+              arcticTable.id(), node.mask(), node.index());
           break;
-        } else if (baseFile.fileSizeInBytes() <= getSmallFileSize(arcticTable.properties())) {
-          DataTreeNode node = FileNameGenerator.parseFileNodeFromFileName(baseFile.path().toString());
-          if (nodeSmallFileCount.get(node) != null) {
-            nodeHaveTwoSmallFiles = true;
-            LOG.info("table {} has greater than 2 small files in (mask:{}, node :{}) in hive location",
-                arcticTable.id(), node.mask(), node.index());
-            break;
-          } else {
-            nodeSmallFileCount.put(node, 1L);
-          }
+        } else {
+          nodeSmallFileCount.put(node, 1L);
         }
       }
     }
     // check whether partition need plan by files info.
-    // if partition need split root node to target node
     // if partition has no pos-delete file, and there are files in not hive location or
     // small file count greater than 2 in hive location, partition need plan
     // if partition has pos-delete, partition need plan
-    boolean partitionNeedPlan =
-        needSplitRootNode || CollectionUtils.isNotEmpty(posDeleteFiles) || nodeHaveTwoSmallFiles || notInHiveFile;
+    boolean partitionNeedPlan = CollectionUtils.isNotEmpty(posDeleteFiles) || nodeHaveTwoSmallFiles || notInHiveFile;
 
     // check position delete file total size
     if (checkPosDeleteTotalSize(partitionToPath) && partitionNeedPlan) {
@@ -113,32 +109,8 @@ public class SupportHiveFullOptimizePlan extends FullOptimizePlan {
     return false;
   }
 
-  /**
-   * If all files in root node, but target base hash bucket  1, we should split the root node.
-   *
-   * @param partitionToPath - partition
-   * @return true if need split
-   */
-  private boolean needSplitRootNode(String partitionToPath) {
-    if (arcticTable.spec().isPartitioned()) {
-      // To limit the scope of this feature and avoid optimizing a large number of historical partitions, 
-      // it only applies to unpartitioned tables.
-      return false;
-    }
-    int baseBucket = PropertyUtil.propertyAsInt(arcticTable.properties(), TableProperties.BASE_FILE_INDEX_HASH_BUCKET,
-        TableProperties.BASE_FILE_INDEX_HASH_BUCKET_DEFAULT);
-    if (baseBucket <= 1) {
-      return false;
-    }
-    FileTree fileTree = partitionFileTree.get(partitionToPath);
-    if (fileTree == null) {
-      return false;
-    }
-    return !fileTree.isRootEmpty() && fileTree.isLeaf();
-  }
-
   @Override
-  protected boolean nodeTaskNeedBuild(List<DeleteFile> posDeleteFiles, List<DataFile> baseFiles) {
+  protected boolean nodeTaskNeedBuild(String partition, List<DeleteFile> posDeleteFiles, List<DataFile> baseFiles) {
     return true;
   }
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveFullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/SupportHiveFullOptimizePlan.java
@@ -19,16 +19,19 @@
 package com.netease.arctic.ams.server.optimize;
 
 import com.google.common.base.Preconditions;
+import com.netease.arctic.ams.server.model.FileTree;
 import com.netease.arctic.ams.server.model.TableOptimizeRuntime;
 import com.netease.arctic.data.DataTreeNode;
 import com.netease.arctic.data.file.FileNameGenerator;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.TableProperties;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,30 +69,34 @@ public class SupportHiveFullOptimizePlan extends FullOptimizePlan {
     Map<DataTreeNode, Long> nodeSmallFileCount = new HashMap<>();
     boolean nodeHaveTwoSmallFiles = false;
     boolean notInHiveFile = false;
-    for (DataFile baseFile : baseFiles) {
-      boolean inHive = baseFile.path().toString().contains(((SupportHive) arcticTable).hiveLocation());
-      if (!inHive) {
-        notInHiveFile = true;
-        LOG.info("table {} has in not hive location files", arcticTable.id());
-        break;
-      } else if (baseFile.fileSizeInBytes() <= getSmallFileSize(arcticTable.properties())) {
-        DataTreeNode node = FileNameGenerator.parseFileNodeFromFileName(baseFile.path().toString());
-        if (nodeSmallFileCount.get(node) != null) {
-          nodeHaveTwoSmallFiles = true;
-          LOG.info("table {} has greater than 2 small files in (mask:{}, node :{}) in hive location",
-              arcticTable.id(), node.mask(), node.index());
+    boolean needSplitRootNode = needSplitRootNode(partitionToPath);
+    if (!needSplitRootNode) {
+      for (DataFile baseFile : baseFiles) {
+        boolean inHive = baseFile.path().toString().contains(((SupportHive) arcticTable).hiveLocation());
+        if (!inHive) {
+          notInHiveFile = true;
+          LOG.info("table {} has in not hive location files", arcticTable.id());
           break;
-        } else {
-          nodeSmallFileCount.put(node, 1L);
+        } else if (baseFile.fileSizeInBytes() <= getSmallFileSize(arcticTable.properties())) {
+          DataTreeNode node = FileNameGenerator.parseFileNodeFromFileName(baseFile.path().toString());
+          if (nodeSmallFileCount.get(node) != null) {
+            nodeHaveTwoSmallFiles = true;
+            LOG.info("table {} has greater than 2 small files in (mask:{}, node :{}) in hive location",
+                arcticTable.id(), node.mask(), node.index());
+            break;
+          } else {
+            nodeSmallFileCount.put(node, 1L);
+          }
         }
       }
     }
     // check whether partition need plan by files info.
+    // if partition need split root node to target node
     // if partition has no pos-delete file, and there are files in not hive location or
     // small file count greater than 2 in hive location, partition need plan
     // if partition has pos-delete, partition need plan
     boolean partitionNeedPlan =
-        CollectionUtils.isNotEmpty(posDeleteFiles) || nodeHaveTwoSmallFiles || notInHiveFile;
+        needSplitRootNode || CollectionUtils.isNotEmpty(posDeleteFiles) || nodeHaveTwoSmallFiles || notInHiveFile;
 
     // check position delete file total size
     if (checkPosDeleteTotalSize(partitionToPath) && partitionNeedPlan) {
@@ -104,6 +111,30 @@ public class SupportHiveFullOptimizePlan extends FullOptimizePlan {
     LOG.debug("{} ==== don't need {} optimize plan, skip partition {}, partitionNeedPlan is {}",
         tableId(), getOptimizeType(), partitionToPath, partitionNeedPlan);
     return false;
+  }
+
+  /**
+   * If all files in root node, but target base hash bucket  1, we should split the root node.
+   *
+   * @param partitionToPath - partition
+   * @return true if need split
+   */
+  private boolean needSplitRootNode(String partitionToPath) {
+    if (arcticTable.spec().isPartitioned()) {
+      // To limit the scope of this feature and avoid optimizing a large number of historical partitions, 
+      // it only applies to unpartitioned tables.
+      return false;
+    }
+    int baseBucket = PropertyUtil.propertyAsInt(arcticTable.properties(), TableProperties.BASE_FILE_INDEX_HASH_BUCKET,
+        TableProperties.BASE_FILE_INDEX_HASH_BUCKET_DEFAULT);
+    if (baseBucket <= 1) {
+      return false;
+    }
+    FileTree fileTree = partitionFileTree.get(partitionToPath);
+    if (fileTree == null) {
+      return false;
+    }
+    return !fileTree.isRootEmpty() && fileTree.isLeaf();
   }
 
   @Override

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
@@ -280,6 +280,35 @@ public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
   }
 
   @Test
+  public void testNoPartitionKeyedTableSplitRootNode() throws IOException {
+    testNoPartitionTable.updateProperties()
+        .set(TableProperties.BASE_FILE_INDEX_HASH_BUCKET, "1")
+        .commit();
+    Pair<Snapshot, List<DataFile>> insertBaseResult = insertTableBaseDataFiles(testNoPartitionTable);
+    List<DataFile> baseDataFiles = insertBaseResult.second();
+    long fileSize = baseDataFiles.get(0).fileSizeInBytes();
+    // set task_size to be 2.5 * file_size, task_size = base_bucket * target_size = 2.5 * file_size
+    // base_bucket = 4, so target_size = file_size * 2.5 / 4 = file_size * 5 / 8
+    testNoPartitionTable.updateProperties()
+        .set(TableProperties.BASE_FILE_INDEX_HASH_BUCKET, "4")
+        .set(TableProperties.SELF_OPTIMIZING_TARGET_SIZE, fileSize * 5 / 8 + "")
+        .commit();
+
+    List<FileScanTask> baseFiles = planBaseFiles(testNoPartitionTable);
+    FullOptimizePlan fullOptimizePlan = new FullOptimizePlan(testNoPartitionTable,
+        new TableOptimizeRuntime(testNoPartitionTable.id()), baseFiles,
+        1, System.currentTimeMillis(), TableOptimizeRuntime.INVALID_SNAPSHOT_ID);
+    List<BasicOptimizeTask> tasks = fullOptimizePlan.plan().getOptimizeTasks();
+
+    Assert.assertEquals(OptimizeType.FullMajor, tasks.get(0).getTaskId().getType());
+    Assert.assertEquals(5, tasks.size());
+    Assert.assertEquals(2, tasks.get(0).getBaseFiles().size());
+    Assert.assertEquals(0, tasks.get(0).getPosDeleteFiles().size());
+    Assert.assertEquals(0, tasks.get(0).getInsertFileCnt());
+    Assert.assertEquals(0, tasks.get(0).getDeleteFileCnt());
+  }
+
+  @Test
   public void testPartitionWeight() {
     List<AbstractOptimizePlan.PartitionWeightWrapper> partitionWeights = new ArrayList<>();
     partitionWeights.add(new AbstractOptimizePlan.PartitionWeightWrapper("p1",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1700 

## Brief change log

  - using bin-packing to split tasks if only base files exit and all files in node(0,0)
  - add unit test case

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
