### PR TITLE
[ARCTIC-1736] Fix SnapshotsExpiringExecutor will expire the snapshot which table used to plan

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/executor/SnapshotsExpiringExecutor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/executor/SnapshotsExpiringExecutor.java
@@ -22,7 +22,6 @@ import com.netease.arctic.IcebergFileEntry;
 import com.netease.arctic.data.FileNameRules;
 import com.netease.arctic.hive.utils.TableTypeUtil;
 import com.netease.arctic.scan.TableEntriesScan;
-import com.netease.arctic.server.optimizing.OptimizingStatus;
 import com.netease.arctic.server.table.TableManager;
 import com.netease.arctic.server.table.TableRuntime;
 import com.netease.arctic.server.utils.HiveLocationUtil;

--- a/ams/server/src/main/java/com/netease/arctic/server/table/executor/SnapshotsExpiringExecutor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/executor/SnapshotsExpiringExecutor.java
@@ -19,7 +19,6 @@
 package com.netease.arctic.server.table.executor;
 
 import com.netease.arctic.hive.utils.TableTypeUtil;
-import com.netease.arctic.server.optimizing.OptimizingStatus;
 import com.netease.arctic.server.table.TableManager;
 import com.netease.arctic.server.table.TableRuntime;
 import com.netease.arctic.server.utils.HiveLocationUtil;
@@ -214,10 +213,10 @@ public class SnapshotsExpiringExecutor extends BaseTableExecutor {
    * @return commit time of snapshot for optimizing
    */
   public static long fetchOptimizingSnapshotTime(UnkeyedTable table, TableRuntime tableRuntime) {
-    if (tableRuntime.getOptimizingStatus() != OptimizingStatus.IDLE) {
-      long currentSnapshotId = tableRuntime.getCurrentSnapshotId();
+    if (tableRuntime.getOptimizingStatus().isProcessing()) {
+      long targetSnapshotId = tableRuntime.getOptimizingProcess().getTargetSnapshotId();
       for (Snapshot snapshot : table.snapshots()) {
-        if (snapshot.snapshotId() == currentSnapshotId) {
+        if (snapshot.snapshotId() == targetSnapshotId) {
           return snapshot.timestampMillis();
         }
       }

--- a/ams/server/src/test/java/com/netease/arctic/server/table/executor/TestSnapshotExpire.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/table/executor/TestSnapshotExpire.java
@@ -26,6 +26,7 @@ import com.netease.arctic.catalog.CatalogTestHelper;
 import com.netease.arctic.data.ChangeAction;
 import com.netease.arctic.op.UpdatePartitionProperties;
 import com.netease.arctic.server.dashboard.utils.AmsUtil;
+import com.netease.arctic.server.optimizing.OptimizingProcess;
 import com.netease.arctic.server.optimizing.OptimizingStatus;
 import com.netease.arctic.server.table.ServerTableIdentifier;
 import com.netease.arctic.server.table.TableRuntime;
@@ -329,8 +330,10 @@ public class TestSnapshotExpire extends ExecutorTestBase {
 
     // mock tableRuntime which has optimizing task not committed
     long optimizeSnapshotId = table.currentSnapshot().snapshotId();
+    OptimizingProcess optimizingProcess = Mockito.mock(OptimizingProcess.class);
+    Mockito.when(optimizingProcess.getTargetSnapshotId()).thenReturn(optimizeSnapshotId);
     Mockito.when(tableRuntime.getOptimizingStatus()).thenReturn(OptimizingStatus.COMMITTING);
-    Mockito.when(tableRuntime.getCurrentSnapshotId()).thenReturn(optimizeSnapshotId);
+    Mockito.when(tableRuntime.getOptimizingProcess()).thenReturn(optimizingProcess);
     HashSet<Snapshot> expectedSnapshots = new HashSet<>();
     expectedSnapshots.add(table.currentSnapshot());
 


### PR DESCRIPTION
## Why are the changes needed?
Fix #1736.

## Brief change log

  - *Fetch optimizing snapshot time when the table is processing.*
  - *Fetch the target snapshot id in the optimizing process instead of the current snapshot id.*
  - *Modify the UT test.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
