### PR TITLE
[ARCTIC-1745] fix the calculation of `actualInputSize` when skip some partitions for optimizing

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
@@ -122,12 +122,12 @@ public class OptimizingPlanner extends OptimizingEvaluator {
     double maxInputSize = MAX_INPUT_FILE_SIZE_PER_THREAD * availableCore;
     List<PartitionEvaluator> inputPartitions = Lists.newArrayList();
     long actualInputSize = 0;
-    for (int i = 0; i < evaluators.size() && actualInputSize < maxInputSize; i++) {
-      PartitionEvaluator evaluator = evaluators.get(i);
-      inputPartitions.add(evaluator);
-      if (actualInputSize + evaluator.getCost() < maxInputSize) {
-        actualInputSize += evaluator.getCost();
+    for (PartitionEvaluator evaluator : evaluators) {
+      if (actualInputSize + evaluator.getCost() > maxInputSize) {
+        break;
       }
+      inputPartitions.add(evaluator);
+      actualInputSize += evaluator.getCost();
     }
 
     double avgThreadCost = actualInputSize / availableCore;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

resolve #1745

## Brief change log

  - fix the calculation of `actualInputSize` when skip some partitions for optimizing

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
