### PR TITLE
[ARCTIC-1745] Only skip partitions when the maximum size limit is exceeded

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingQueue.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingQueue.java
@@ -9,6 +9,7 @@ import com.netease.arctic.ams.api.OptimizingService;
 import com.netease.arctic.ams.api.OptimizingTask;
 import com.netease.arctic.ams.api.OptimizingTaskId;
 import com.netease.arctic.ams.api.OptimizingTaskResult;
+import com.netease.arctic.ams.api.resource.Resource;
 import com.netease.arctic.ams.api.resource.ResourceGroup;
 import com.netease.arctic.optimizing.RewriteFilesInput;
 import com.netease.arctic.server.ArcticServiceConstants;
@@ -268,7 +269,7 @@ public class OptimizingQueue extends PersistentBase implements OptimizingService
       try {
         ArcticTable table = tableManager.loadTable(tableRuntime.getTableIdentifier());
         OptimizingPlanner planner = new OptimizingPlanner(tableRuntime.refresh(table), table,
-            getAvailableCore(tableRuntime));
+            getAvailableCore());
         if (tableRuntime.isBlocked(BlockableOperation.OPTIMIZE)) {
           LOG.info("{} optimize is blocked, continue", tableRuntime.getTableIdentifier());
           continue;
@@ -288,8 +289,8 @@ public class OptimizingQueue extends PersistentBase implements OptimizingService
     }
   }
 
-  private double getAvailableCore(TableRuntime tableRuntime) {
-    return tableRuntime.getOptimizingConfig().getTargetQuota();
+  private double getAvailableCore() {
+    return authOptimizers.values().stream().map(Resource::getThreadCount).reduce(Integer::sum).orElse(0);
   }
 
   @VisibleForTesting

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingQueue.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingQueue.java
@@ -290,7 +290,9 @@ public class OptimizingQueue extends PersistentBase implements OptimizingService
   }
 
   private double getAvailableCore() {
-    return authOptimizers.values().stream().map(Resource::getThreadCount).reduce(Integer::sum).orElse(0);
+    int totalCore = authOptimizers.values().stream().mapToInt(Resource::getThreadCount).sum();
+    // the available core should be at least 1
+    return Math.max(totalCore, 1);
   }
 
   @VisibleForTesting

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 public class OptimizingPlanner extends OptimizingEvaluator {
   private static final Logger LOG = LoggerFactory.getLogger(OptimizingPlanner.class);
 
-  private static final long MAX_INPUT_FILE_SIZE_PER_THREAD = 512 * 1024 * 1024; // 500MB
+  private static final long MAX_INPUT_FILE_SIZE_PER_THREAD = 512 * 1024 * 1024; // 512MB
 
   private final TableFileScanHelper.PartitionFilter partitionFilter;
 

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
@@ -123,11 +123,11 @@ public class OptimizingPlanner extends OptimizingEvaluator {
     List<PartitionEvaluator> inputPartitions = Lists.newArrayList();
     long actualInputSize = 0;
     for (PartitionEvaluator evaluator : evaluators) {
-      if (actualInputSize + evaluator.getCost() > maxInputSize) {
-        break;
-      }
       inputPartitions.add(evaluator);
       actualInputSize += evaluator.getCost();
+      if (actualInputSize > maxInputSize) {
+        break;
+      }
     }
 
     double avgThreadCost = actualInputSize / availableCore;

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 public class OptimizingPlanner extends OptimizingEvaluator {
   private static final Logger LOG = LoggerFactory.getLogger(OptimizingPlanner.class);
 
-  private static final long MAX_INPUT_FILE_SIZE_PER_THREAD = 5L * 1024 * 1024 * 1024;
+  private static final long MAX_INPUT_FILE_SIZE_PER_THREAD = 512 * 1024 * 1024; // 500MB
 
   private final TableFileScanHelper.PartitionFilter partitionFilter;
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1745 , if the first partition's size > maxSize, it should not be skipped

## Brief change log

  - fix skip all partitions when the first partition's size > maxSize

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
