### PR TITLE
[ARCTIC-1761]: Fix parquet dependency conflict.

### DIFF
--- a/hive/pom.xml
+++ b/hive/pom.xml
@@ -95,6 +95,10 @@
                     <groupId>jdk.tools</groupId>
                     <artifactId>jdk.tools</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.parquet</groupId>
+                    <artifactId>parquet-hadoop-bundle</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
 
## Why are the changes needed?

fix #1761 

## Brief change log

- Exclude hadoop-parquet-bundle in arctic-hive module.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request
 
